### PR TITLE
Return inner stream from `ForEach` when done.

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -42,7 +42,7 @@ pub use self::filter::Filter;
 pub use self::filter_map::FilterMap;
 pub use self::flatten::Flatten;
 pub use self::fold::Fold;
-pub use self::for_each::ForEach;
+pub use self::for_each::{Drained, ForEach};
 pub use self::fuse::Fuse;
 pub use self::future::StreamFuture;
 pub use self::map::Map;


### PR DESCRIPTION
This allows resources to be reclaimed from the stream, similar to how `StreamFuture` returns its inner stream when the end is reached.

After this change, `cargo test` continues to pass for `tokio-core`, but there are some new "unused result which must be used" warnings.
