### PR TITLE
Forget about the iterator type after constructing a `JoinAll`.

### DIFF
--- a/src/future/join_all.rs
+++ b/src/future/join_all.rs
@@ -17,11 +17,10 @@ enum ElemState<T> where T: Future {
 ///
 /// This future is created with the `join_all` method.
 #[must_use = "futures do nothing unless polled"]
-pub struct JoinAll<I>
-    where I: IntoIterator,
-          I::Item: IntoFuture,
+pub struct JoinAll<Item>
+    where Item: IntoFuture,
 {
-    elems: Vec<ElemState<<I::Item as IntoFuture>::Future>>,
+    elems: Vec<ElemState<<Item as IntoFuture>::Future>>,
 }
 
 /// Creates a future which represents a collection of the results of the futures
@@ -60,7 +59,7 @@ pub struct JoinAll<I>
 ///     x
 /// });
 /// ```
-pub fn join_all<I>(i: I) -> JoinAll<I>
+pub fn join_all<I>(i: I) -> JoinAll<I::Item>
     where I: IntoIterator,
           I::Item: IntoFuture,
 {
@@ -70,12 +69,11 @@ pub fn join_all<I>(i: I) -> JoinAll<I>
     JoinAll { elems: elems }
 }
 
-impl<I> Future for JoinAll<I>
-    where I: IntoIterator,
-          I::Item: IntoFuture,
+impl<Item> Future for JoinAll<Item>
+    where Item: IntoFuture,
 {
-    type Item = Vec<<I::Item as IntoFuture>::Item>;
-    type Error = <I::Item as IntoFuture>::Error;
+    type Item = Vec<<Item as IntoFuture>::Item>;
+    type Error = <Item as IntoFuture>::Error;
 
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -252,6 +252,18 @@ fn collect_collects() {
 }
 
 #[test]
+fn join_all_iter_lifetime() {
+    // In futures-rs version 0.1, this function would fail to typecheck due to an overly
+    // conservative type parameterization of `JoinAll`.
+    fn sizes<'a>(bufs: Vec<&'a [u8]>) -> Box<Future<Item=Vec<usize>, Error=()> + 'static> {
+        let iter = bufs.into_iter().map(|b| future::ok::<usize, ()>(b.len()));
+        Box::new(join_all(iter))
+    }
+
+    assert_done(|| sizes(vec![&[1,2,3], &[], &[0]]), Ok(vec![3, 0, 1]));
+}
+
+#[test]
 fn select2() {
     fn d<T, U, E>(r: Result<(T, U), (E, U)>) -> Result<T, E> {
         match r {


### PR DESCRIPTION
Fixes #285.