### PR TITLE
Make `after_start` and `before_stop` take an index

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -82,8 +82,8 @@ pub struct CpuPool {
 pub struct Builder {
     pool_size: usize,
     name_prefix: Option<String>,
-    after_start: Option<Arc<Fn() + Send + Sync>>,
-    before_stop: Option<Arc<Fn() + Send + Sync>>,
+    after_start: Option<Arc<Fn(usize) + Send + Sync>>,
+    before_stop: Option<Arc<Fn(usize) + Send + Sync>>,
 }
 
 struct MySender<F, T> {
@@ -102,8 +102,8 @@ struct Inner {
     queue: MsQueue<Message>,
     cnt: AtomicUsize,
     size: usize,
-    after_start: Option<Arc<Fn() + Send + Sync>>,
-    before_stop: Option<Arc<Fn() + Send + Sync>>,
+    after_start: Option<Arc<Fn(usize) + Send + Sync>>,
+    before_stop: Option<Arc<Fn(usize) + Send + Sync>>,
 }
 
 /// The type of future returned from the `CpuPool::spawn` function, which
@@ -204,15 +204,15 @@ impl CpuPool {
     }
 }
 
-fn work(inner: &Inner) {
-    inner.after_start.as_ref().map(|fun| fun());
+fn work(inner: &Inner, number: usize) {
+    inner.after_start.as_ref().map(|fun| fun(number));
     loop {
         match inner.queue.pop() {
             Message::Run(r) => r.run(),
             Message::Close => break,
         }
     }
-    inner.before_stop.as_ref().map(|fun| fun());
+    inner.before_stop.as_ref().map(|fun| fun(number));
 }
 
 impl Clone for CpuPool {
@@ -306,7 +306,7 @@ impl Builder {
     ///
     /// This is initially intended for bookkeeping and monitoring uses
     pub fn after_start<F>(&mut self, f: F) -> &mut Self
-        where F: Fn() + Send + Sync + 'static
+        where F: Fn(usize) + Send + Sync + 'static
     {
         self.after_start = Some(Arc::new(f));
         self
@@ -316,7 +316,7 @@ impl Builder {
     ///
     /// This is initially intended for bookkeeping and monitoring uses
     pub fn before_stop<F>(&mut self, f: F) -> &mut Self
-        where F: Fn() + Send + Sync + 'static
+        where F: Fn(usize) + Send + Sync + 'static
     {
         self.before_stop = Some(Arc::new(f));
         self
@@ -341,7 +341,7 @@ impl Builder {
             if let Some(ref name_prefix) = self.name_prefix {
                 thread_builder = thread_builder.name(format!("{}{}", name_prefix, counter));
             }
-            thread_builder.spawn(move || work(&inner)).unwrap();
+            thread_builder.spawn(move || work(&inner, counter)).unwrap();
         }
 
         return pool

--- a/futures-cpupool/tests/smoke.rs
+++ b/futures-cpupool/tests/smoke.rs
@@ -66,15 +66,16 @@ fn threads_go_away() {
 
 #[test]
 fn lifecycle_test() {
-    static NUM_STARTS: AtomicUsize = ATOMIC_USIZE_INIT;
-    static NUM_STOPS: AtomicUsize = ATOMIC_USIZE_INIT;
+    static SUM_STARTS: AtomicUsize = ATOMIC_USIZE_INIT;
+    static SUM_STOPS: AtomicUsize = ATOMIC_USIZE_INIT;
+    const EXPECTED_SUM: usize = 3+2+1+0; // 4 threads indexed 3,2,1,0.
 
-    fn after_start() {
-        NUM_STARTS.fetch_add(1, Ordering::SeqCst);
+    fn after_start(number: usize) {
+        SUM_STARTS.fetch_add(number, Ordering::SeqCst);
     }
 
-    fn before_stop() {
-        NUM_STOPS.fetch_add(1, Ordering::SeqCst);
+    fn before_stop(number: usize) {
+        SUM_STOPS.fetch_add(number, Ordering::SeqCst);
     }
 
     let pool = Builder::new()
@@ -88,8 +89,8 @@ fn lifecycle_test() {
     drop(pool);
 
     for _ in 0..100 {
-        if NUM_STOPS.load(Ordering::SeqCst) == 4 {
-            assert_eq!(NUM_STARTS.load(Ordering::SeqCst), 4);
+        if SUM_STOPS.load(Ordering::SeqCst) == EXPECTED_SUM {
+            assert_eq!(SUM_STARTS.load(Ordering::SeqCst), EXPECTED_SUM);
             return;
         }
         thread::sleep(Duration::from_millis(10));


### PR DESCRIPTION
Since these functions are primarily intended for bookkeeping and
monitoring it seems like they should have some knowledge of which thread
they are.

Means you can do something like:

```rust
let pool = PoolBuilder::new()
        .pool_size(4)
        .after_start(|num| println!("THREAD {} START", num))
        .before_stop(|num| println!("THREAD {} STOP", num))
        .create();
```

This is a **breaking change**.