### PR TITLE
Combinators for wrapping futures in Either.

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -834,6 +834,60 @@ pub trait Future {
     {
         Shared::new(self)
     }
+
+    /// Wrap this future in an `Either` future, making it the left-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `right` method to write `if`
+    /// statements that evaluate to different futures in different branches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::future::*;
+    ///
+    /// let x = 6;
+    /// let future = if x < 10 {
+    ///     ok::<_, bool>(x).left()
+    /// } else {
+    ///     empty().right()
+    /// };
+    ///
+    /// assert_eq!(x, future.wait().unwrap());
+    /// ```
+    fn left<B>(self) -> Either<Self, B>
+        where B: Future<Item = Self::Item, Error = Self::Error>,
+              Self: Sized
+    {
+        Either::A(self)
+    }
+
+    /// Wrap this future in an `Either` future, making it the right-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `left` method to write `if`
+    /// statements that evaluate to different futures in different branches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::future::*;
+    ///
+    /// let x = 6;
+    /// let future = if x < 10 {
+    ///     ok::<_, bool>(x).left()
+    /// } else {
+    ///     empty().right()
+    /// };
+    ///
+    /// assert_eq!(x, future.wait().unwrap());
+    /// ```
+    fn right<A>(self) -> Either<A, Self>
+        where A: Future<Item = Self::Item, Error = Self::Error>,
+              Self: Sized,
+    {
+        Either::B(self)
+    }
 }
 
 impl<'a, F: ?Sized + Future> Future for &'a mut F {


### PR DESCRIPTION
If you are returning different futures in different branches of a
conditional expression, you need to wrap them in a construct which
unifies their types.

Currently, the easiest way to do this is to called the `.boxed()`
method on both of them, but a lower overhead solution is to wrap them
in an `Either`. This commit enables that by defining a `left` and
`right` method on `Future` which wrap the future in different variants
of the `Either`.