### PR TITLE
Remove implicit error type conversion from Stream::fold

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -636,8 +636,7 @@ pub trait Stream {
     /// ```
     fn fold<F, T, Fut>(self, init: T, f: F) -> Fold<Self, F, Fut, T>
         where F: FnMut(T, Self::Item) -> Fut,
-              Fut: IntoFuture<Item = T>,
-              Self::Error: From<Fut::Error>,
+              Fut: IntoFuture<Item = T, Error = Self::Error>,
               Self: Sized
     {
         fold::new(self, f, init)

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -56,8 +56,8 @@ fn from_err() {
 
 #[test]
 fn fold() {
-    assert_done(|| list().fold(0, |a, b| ok::<i32, u32>(a + b)), Ok(6));
-    assert_done(|| err_list().fold(0, |a, b| ok::<i32, u32>(a + b)), Err(3));
+    assert_done(|| list().fold(0, |a, b| ok(a + b)), Ok(6));
+    assert_done(|| err_list().fold(0, |a, b| ok(a + b)), Err(3));
 }
 
 #[test]


### PR DESCRIPTION
In my experience it does more harm than good: you need to specify
error type explicitly too often. See e. g. patched test case: it
fails before this commit.

```
stream.fold(0, |a, b| ok(a + b))
```

Without explicit error type parameter of `ok`, compilation fails with:

```
error[E0283]: type annotations required: cannot resolve `u32: std::convert::From<_>`
  --> tests/stream.rs:59:27
   |
59 |     assert_done(|| list().fold(0, |a, b| ok(a + b)), Ok(6));
   |                           ^^^^
```