### PR TITLE
SendAll::poll() should not close underlying Sink

### DIFF
--- a/src/sink/send_all.rs
+++ b/src/sink/send_all.rs
@@ -75,7 +75,7 @@ impl<T, U> Future for SendAll<T, U>
             match try!(self.stream_mut().poll()) {
                 Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
                 Async::Ready(None) => {
-                    try_ready!(self.sink_mut().close());
+                    try_ready!(self.sink_mut().poll_complete());
                     return Ok(Async::Ready(self.take_result()))
                 }
                 Async::NotReady => {


### PR DESCRIPTION
Hello. May be I am missing something, but it seems that `sink.send_all(stream)`
should not close itself on completion.