### PR TITLE
Add Void type and expect_no_error method

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -115,7 +115,8 @@ if_std! {
     }
 }
 
-use {Poll, stream};
+use {Async, Never, Poll, stream};
+use never::InfallibleResultExt;
 
 /// Trait for types which are a placeholder of a value that may become
 /// available at some later point in time.
@@ -271,6 +272,16 @@ pub trait Future {
     /// error.
     fn poll(&mut self) -> Poll<Self::Item, Self::Error>;
 
+    /// Poll a future that can not fail.
+    ///
+    /// Works similar to `poll`, except that it returns an `Async` value directly
+    /// rather than `Poll`.
+    fn poll_infallible(&mut self) -> Async<Self::Item>
+        where Self: Future<Error=Never> + Sized
+    {
+        self.poll().infallible()
+    }
+
     /// Block the current thread until this future is resolved.
     ///
     /// This method will consume ownership of this future, driving it to
@@ -297,6 +308,17 @@ pub trait Future {
         where Self: Sized
     {
         ::executor::spawn(self).wait_future()
+    }
+
+    /// Wait on a future that can not fail.
+    ///
+    /// Works similar to `wait`, except that it returns the item directly rather
+    /// than a `Result`.
+    #[cfg(feature = "use_std")]
+    fn wait_infallible(self) -> Self::Item
+        where Self: Future<Error=Never> + Sized
+    {
+        self.wait().infallible()
     }
 
     /// Convenience function for turning this future into a trait object which
@@ -410,8 +432,6 @@ pub trait Future {
     {
         assert_future::<Self::Item, E, _>(map_err::new(self, f))
     }
-
-
 
     /// Map this future's error to any error implementing `From` for
     /// this future's `Error`, returning a new future.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,8 @@ pub mod sync;
 #[cfg(feature = "use_std")]
 pub mod unsync;
 
+mod never;
+pub use never::Never;
 
 if_std! {
     #[doc(hidden)]

--- a/src/never.rs
+++ b/src/never.rs
@@ -1,0 +1,62 @@
+use core::fmt;
+#[cfg(feature = "std")]
+use std::error::Error;
+
+/// A value that can never happen!
+///
+/// For context:
+///
+/// - The boolean type `bool` has two values: `true` and `false`
+/// - The unit type `()` has one value: `()`
+/// - The empty type `Never` has no values!
+///
+/// You may see it in the wild in `Future<Error = Never>`,
+/// which means that this future will never fail.
+#[derive(Copy, Clone, Debug)]
+pub enum Never {}
+
+impl Never {
+    /// Convert into any other type.
+    ///
+    /// Since it is impossible for `Never` to exist,
+    /// we can exploit this to convert it into any type.
+    ///
+    /// This is also called the [Principle of Explosion]
+    /// (https://en.wikipedia.org/wiki/Principle_of_explosion).
+    #[inline(always)]
+    pub fn never<T>(self) -> T {
+        match self {}
+    }
+}
+
+impl fmt::Display for Never {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        self.never()
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for Never {
+    fn description(&self) -> &str {
+        self.never()
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        self.never()
+    }
+}
+
+pub trait InfallibleResultExt {
+    type Item;
+
+    fn infallible(self) -> Self::Item;
+}
+
+impl<T> InfallibleResultExt for Result<T, Never> {
+    type Item = T;
+
+    #[inline]
+    fn infallible(self) -> Self::Item {
+        self.unwrap_or_else(|x| x.never())
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! [online]: https://tokio.rs/docs/getting-started/streams-and-sinks/
 
-use {IntoFuture, Poll};
+use {IntoFuture, Never, Poll};
 
 mod iter;
 #[allow(deprecated)]
@@ -58,6 +58,8 @@ mod then;
 mod unfold;
 mod zip;
 mod forward;
+#[cfg(feature = "use_std")]
+mod wait_infallible;
 pub use self::and_then::AndThen;
 pub use self::chain::Chain;
 pub use self::concat::{Concat, Concat2};
@@ -88,6 +90,8 @@ pub use self::then::Then;
 pub use self::unfold::{Unfold, unfold};
 pub use self::zip::Zip;
 pub use self::forward::Forward;
+#[cfg(feature = "use_std")]
+pub use self::wait_infallible::WaitInfallible;
 use sink::{Sink};
 
 if_std! {
@@ -239,6 +243,17 @@ pub trait Stream {
         where Self: Sized
     {
         wait::new(self)
+    }
+
+    /// Wait on a stream that can not fail.
+    ///
+    /// Works similar to `wait`, except that it yields the items directly rather
+    /// than a `Result`.
+    #[cfg(feature = "use_std")]
+    fn wait_infallible(self) -> WaitInfallible<Self>
+        where Self: Stream<Error=Never> + Sized
+    {
+        wait_infallible::new(self)
     }
 
     /// Convenience function for turning this stream into a trait object.

--- a/src/stream/wait_infallible.rs
+++ b/src/stream/wait_infallible.rs
@@ -1,0 +1,30 @@
+use {Stream, Never};
+use stream::Wait;
+use never::InfallibleResultExt;
+
+/// A stream combinator which converts an asynchronous infallible stream to a
+/// **blocking iterator**.
+///
+/// Created by the `Stream::wait_infallible` method, this function transforms an
+/// infallible stream into a standard iterator. This is implemented by blocking the
+/// current thread while items on the underlying stream aren't ready yet.
+#[derive(Debug)]
+#[must_use = "iterators do nothing unless advanced"]
+pub struct WaitInfallible<S> {
+    inner: Wait<S>
+}
+
+pub fn new<S>(stream: S) -> WaitInfallible<S> where S: Stream<Error=Never> {
+    WaitInfallible {
+        inner: stream.wait()
+    }
+}
+
+impl<S> Iterator for WaitInfallible<S> where S: Stream<Error=Never> {
+    type Item = S::Item;
+
+    fn next(&mut self) -> Option<S::Item> {
+        self.inner.next()
+            .map(|r| r.infallible())
+    }
+}


### PR DESCRIPTION
As discussed in #476.

Went with the name `Void` for now, but as far as I can see we have the following choices:

- Haskell: [`Void`](https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-Void.html) (could be confusing for people coming from C-like languages?)
- Elm: [`Never`](http://package.elm-lang.org/packages/elm-lang/core/5.1.1/Basics#Never) (works nicely for the error case IMO, smth can  "never" fail)
- Scala: [`Nothing`](http://www.scala-lang.org/api/2.9.1/scala/Nothing.html) (subtype of every other type, referring to the bottom of the OO type hierarchy)
- Type Theory: [`Bottom`](https://en.wikipedia.org/wiki/Bottom_type)

I also added a combinator method `expect_no_error` that can be used to convert existing cases of `Future<Error=()>` into `Future<Error=Void>`. It might also make sense to add a function going the other way, e.g. `Future<Error=Void>` into `Future<Error=()>` in order to conform with existing APIs expecting `Error=()`. I'm also happy to remove this from the PR for now and open a separate one once we landed the `Void` type.

Let me know what you think!