### PR TITLE
Alternative bi-lock implementation

### DIFF
--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -132,7 +132,6 @@ impl<T> Inner<T> {
         assert!(caller_state != 2, "Lock already held");
 
         // Fast path
-        *self.tasks[caller_state].get() = None;
         caller_state = self.free_state.swap(caller_state, AcqRel);
 
         if caller_state != 2 {

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -239,9 +239,8 @@ impl<T> Future for BiLockAcquire<T> {
             }
             Async::NotReady => return Ok(Async::NotReady),
         }
-        let bi_lock = self.inner.take().expect("cannot poll after Ready");
         Ok(Async::Ready(BiLockAcquired {
-            inner: Some(bi_lock)
+            inner: self.inner.take()
         }))
     }
 }
@@ -281,7 +280,7 @@ impl<T> DerefMut for BiLockAcquired<T> {
 
 impl<T> Drop for BiLockAcquired<T> {
     fn drop(&mut self) {
-        if let Some(mut bi_lock) = self.inner.take() {
+        if let Some(ref mut bi_lock) = self.inner {
             bi_lock.unlock();
         }
     }

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -146,7 +146,7 @@ impl<T> Inner<T> {
 
             // Make sure the state wraps around at a multiple of 6, and leave plenty of
             // room at the end.
-            const UPPER_LIMIT: usize = !0usize - 64;
+            const UPPER_LIMIT: usize = !0usize - 63;
             if state >= UPPER_LIMIT {
                 self.state.fetch_sub(UPPER_LIMIT, Relaxed);
             }

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::boxed::Box;
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt;
@@ -7,7 +6,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::AcqRel;
 
 use {Async, Future, Poll};
 use task::{self, Task};
@@ -33,12 +32,14 @@ use task::{self, Task};
 #[derive(Debug)]
 pub struct BiLock<T> {
     inner: Arc<Inner<T>>,
+    state: usize
 }
 
 #[derive(Debug)]
 struct Inner<T> {
-    state: AtomicUsize,
-    inner: Option<UnsafeCell<T>>,
+    free_state: AtomicUsize,
+    tasks: [UnsafeCell<Option<Task>>; 2],
+    value: Option<UnsafeCell<T>>,
 }
 
 unsafe impl<T: Send> Send for Inner<T> {}
@@ -52,11 +53,12 @@ impl<T> BiLock<T> {
     /// tasks to be managed there.
     pub fn new(t: T) -> (BiLock<T>, BiLock<T>) {
         let inner = Arc::new(Inner {
-            state: AtomicUsize::new(0),
-            inner: Some(UnsafeCell::new(t)),
+            free_state: AtomicUsize::new(2),
+            tasks: [Default::default(), Default::default()],
+            value: Some(UnsafeCell::new(t)),
         });
 
-        (BiLock { inner: inner.clone() }, BiLock { inner: inner })
+        (BiLock { inner: inner.clone(), state: 0 }, BiLock { inner: inner, state: 1 })
     }
 
     /// Attempt to acquire this lock, returning `NotReady` if it can't be
@@ -68,54 +70,19 @@ impl<T> BiLock<T> {
     /// the locked value (and can be used to access the protected data). The
     /// lock is unlocked when the returned `BiLockGuard` is dropped.
     ///
-    /// If the lock is already held then this function will return
-    /// `Async::NotReady`. In this case the current task will also be scheduled
-    /// to receive a notification when the lock would otherwise become
-    /// available.
-    ///
     /// # Panics
     ///
     /// This function will panic if called outside the context of a future's
-    /// task.
-    pub fn poll_lock(&self) -> Async<BiLockGuard<T>> {
-        loop {
-            match self.inner.state.swap(1, SeqCst) {
-                // Woohoo, we grabbed the lock!
-                0 => return Async::Ready(BiLockGuard { inner: self }),
+    /// task, or if the lock is already held.
+    pub fn poll_lock(&mut self) -> Async<BiLockGuard<T>> {
+        unsafe {
+            self.state = self.inner.poll_lock(self.state);
+        }
 
-                // Oops, someone else has locked the lock
-                1 => {}
-
-                // A task was previously blocked on this lock, likely our task,
-                // so we need to update that task.
-                n => unsafe {
-                    drop(Box::from_raw(n as *mut Task));
-                }
-            }
-
-            let me = Box::new(task::current());
-            let me = Box::into_raw(me) as usize;
-
-            match self.inner.state.compare_exchange(1, me, SeqCst, SeqCst) {
-                // The lock is still locked, but we've now parked ourselves, so
-                // just report that we're scheduled to receive a notification.
-                Ok(_) => return Async::NotReady,
-
-                // Oops, looks like the lock was unlocked after our swap above
-                // and before the compare_exchange. Deallocate what we just
-                // allocated and go through the loop again.
-                Err(0) => unsafe {
-                    drop(Box::from_raw(me as *mut Task));
-                },
-
-                // The top of this loop set the previous state to 1, so if we
-                // failed the CAS above then it's because the previous value was
-                // *not* zero or one. This indicates that a task was blocked,
-                // but we're trying to acquire the lock and there's only one
-                // other reference of the lock, so it should be impossible for
-                // that task to ever block itself.
-                Err(n) => panic!("invalid state: {}", n),
-            }
+        if self.state == 2 {
+            Async::Ready(BiLockGuard { inner: self })
+        } else {
+            Async::NotReady
         }
     }
 
@@ -149,33 +116,48 @@ impl<T> BiLock<T> {
         }
     }
 
-    fn unlock(&self) {
-        match self.inner.state.swap(0, SeqCst) {
-            // we've locked the lock, shouldn't be possible for us to see an
-            // unlocked lock.
-            0 => panic!("invalid unlocked state"),
-
-            // Ok, no one else tried to get the lock, we're done.
-            1 => {}
-
-            // Another task has parked themselves on this lock, let's wake them
-            // up as its now their turn.
-            n => unsafe {
-                Box::from_raw(n as *mut Task).notify();
-            }
+    fn unlock(&mut self) {
+        unsafe {
+            self.state = self.inner.unlock(self.state);
         }
     }
 }
 
 impl<T> Inner<T> {
     unsafe fn into_inner(mut self) -> T {
-        mem::replace(&mut self.inner, None).unwrap().into_inner()
+        self.value.take().unwrap().into_inner()
+    }
+
+    unsafe fn poll_lock(&self, caller_state: usize) -> usize {
+        assert!(caller_state != 2, "Lock already held");
+
+        // Save current task
+        *self.tasks[caller_state].get() = Some(task::current());
+        self.free_state.swap(caller_state, AcqRel)
+    }
+
+    unsafe fn unlock(&self, mut caller_state: usize) -> usize {
+        assert!(caller_state == 2, "Lock not held");
+
+        // Swap our state with the free state
+        caller_state = self.free_state.swap(caller_state, AcqRel);
+
+        // Wake up the other task
+        if let Some(task) = (*self.tasks[caller_state].get()).take() {
+            task.notify();
+        }
+
+        caller_state
+    }
+
+    unsafe fn get_value(&self) -> &mut T {
+        &mut *self.value.as_ref().unwrap().get()
     }
 }
 
 impl<T> Drop for Inner<T> {
     fn drop(&mut self) {
-        assert_eq!(self.state.load(SeqCst), 0);
+        assert_eq!(*self.free_state.get_mut(), 2);
     }
 }
 
@@ -210,19 +192,19 @@ impl<T: Any> Error for ReuniteError<T> {
 /// unlocked.
 #[derive(Debug)]
 pub struct BiLockGuard<'a, T: 'a> {
-    inner: &'a BiLock<T>,
+    inner: &'a mut BiLock<T>,
 }
 
 impl<'a, T> Deref for BiLockGuard<'a, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        unsafe { &*self.inner.inner.inner.as_ref().unwrap().get() }
+        unsafe { self.inner.inner.get_value() }
     }
 }
 
 impl<'a, T> DerefMut for BiLockGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.inner.inner.inner.as_ref().unwrap().get() }
+        unsafe { self.inner.inner.get_value() }
     }
 }
 
@@ -244,13 +226,16 @@ impl<T> Future for BiLockAcquire<T> {
     type Error = ();
 
     fn poll(&mut self) -> Poll<BiLockAcquired<T>, ()> {
-        match self.inner.as_ref().expect("cannot poll after Ready").poll_lock() {
+        match self.inner.as_mut().expect("cannot poll after Ready").poll_lock() {
             Async::Ready(r) => {
                 mem::forget(r);
             }
             Async::NotReady => return Ok(Async::NotReady),
         }
-        Ok(Async::Ready(BiLockAcquired { inner: self.inner.take() }))
+        let bi_lock = self.inner.take().expect("cannot poll after Ready");
+        Ok(Async::Ready(BiLockAcquired {
+            inner: Some(bi_lock.inner.clone())
+        }))
     }
 }
 
@@ -262,16 +247,17 @@ impl<T> Future for BiLockAcquire<T> {
 /// `unlock` method.
 #[derive(Debug)]
 pub struct BiLockAcquired<T> {
-    inner: Option<BiLock<T>>,
+    inner: Option<Arc<Inner<T>>>,
 }
 
 impl<T> BiLockAcquired<T> {
     /// Recovers the original `BiLock<T>`, unlocking this lock.
     pub fn unlock(mut self) -> BiLock<T> {
-        let bi_lock = self.inner.take().unwrap();
-
+        let mut bi_lock = BiLock {
+            inner: self.inner.take().unwrap(),
+            state: 2
+        };
         bi_lock.unlock();
-
         bi_lock
     }
 }
@@ -279,20 +265,20 @@ impl<T> BiLockAcquired<T> {
 impl<T> Deref for BiLockAcquired<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        unsafe { &*self.inner.as_ref().unwrap().inner.inner.as_ref().unwrap().get() }
+        unsafe { self.inner.as_ref().unwrap().get_value() }
     }
 }
 
 impl<T> DerefMut for BiLockAcquired<T> {
     fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.inner.as_mut().unwrap().inner.inner.as_ref().unwrap().get() }
+        unsafe { self.inner.as_ref().unwrap().get_value() }
     }
 }
 
 impl<T> Drop for BiLockAcquired<T> {
     fn drop(&mut self) {
-        if let Some(ref bi_lock) = self.inner {
-            bi_lock.unlock();
+        if let Some(inner) = self.inner.take() {
+            unsafe { inner.unlock(2); }
         }
     }
 }

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -32,13 +32,118 @@ use task::{self, Task};
 #[derive(Debug)]
 pub struct BiLock<T> {
     inner: Arc<Inner<T>>,
+    // The `index` is set to `true` for one side of the `BiLock` and `false` for
+    // the other side.
     index: bool
 }
 
+/// IMPLEMENTATION DETAILS
+/// ======================
+/// 
+/// Token system
+/// ------------
+/// It is necessary to protect the unsynchronised parts of the data structure
+/// (tasks, value) from concurrent access by both sides of the BiLock.
+/// To achieve this, there are three "tokens" numbered 0, 1, 2. At any given
+/// time, each side of the BiLock owns one of these tokens, and the remaining
+/// token is free. To access an element in the task array or the value, the
+/// corresponding token must be owned:
+///  ___________________
+/// | TOKEN |   FIELD   |
+/// |_______|___________|
+/// |     0 |  tasks[0] |
+/// |     1 |  tasks[1] |
+/// |     2 |   value   |
+/// |_______|___________|
+/// 
+/// If one side of the BiLock owns the token "2", then it has taken the lock.
+/// If the token "2" is free, then neither side has taken the lock.
+/// 
+/// State encoding
+/// --------------
+/// The ownership of the tokens is encoded entirely withing the state field,
+/// which allows it to be updated atomically.
+/// 
+/// The "LEFT" and "RIGHT" columns indicate which token is owned by each side
+/// of the BiLock, and the "FREE" column shows the remaining token:
+///  _________________________________
+/// | state % 6 | LEFT | FREE | RIGHT |
+/// |___________|______|______|_______|
+/// |         0 |    0 |    1 |     2 |
+/// |         1 |    1 |    0 |     2 |
+/// |         2 |    2 |    0 |     1 |
+/// |         3 |    0 |    2 |     1 |
+/// |         4 |    1 |    2 |     0 |
+/// |         5 |    2 |    1 |     0 |
+/// |___________|______|______|_______|
+/// 
+/// Each side of the BiLock can perform a single atomic operation: it can swap
+/// its token with the free token.
+/// 
+/// For the LEFT side, by examining the table above, we can see that this
+/// corresponds to the operation "XOR 1":
+///     0 <=> 1
+///     2 <=> 3
+///     4 <=> 5
+/// 
+/// For the RIGHT side, by the same process we can see that this corresponds
+/// to the operation "ADD 3 (mod 6)":
+///     0 <=> 3
+///     1 <=> 4
+///     2 <=> 5
+/// 
+/// This yields a simple implementation of the swap operation for each side
+/// of the BiLock: `state.fetch_xor(1, AcqRel)`, `state.fetch_add(3, AcqRel)`.
+/// 
+/// The "lock" operation
+/// --------------------
+/// To implement the "lock" operation, we must own token "0" or "1", or else we
+/// would already have the lock. This gives us access to an entry in the
+/// "tasks" array. We store the current task handle here in case we fail
+/// to take the lock and need to be woken up.
+/// 
+/// Once we have stored the task handle, we perform the atomic swap, and
+/// we check what token we got back. If we got back "2" then we succeeded
+/// in taking the lock. Otherwise, we return NotReady, suspending the task.
+/// If this occurs, the "FREE" token now contains our task handle.
+/// 
+/// The "unlock" operation
+/// ----------------------
+/// To implement the "unlock" operation, we must own token "2". We perform
+/// the atomic swap operation, which results in the "FREE" token being "2"
+/// (ie. the lock is not held by anyone). In exchange, we get back either
+/// the "0" or "1" tokens.
+/// 
+/// At this point we must wake up the other side of the BiLock if it's
+/// currently waiting on the lock. Conveniently, the token we just got
+/// back gives us access to any task handle that was stored if the other
+/// side suspended itself.
+/// 
+/// Optimisations
+/// -------------
+/// Obtaining the current task handle can be expensive, so the "lock"
+/// implementation has a fast path which tries to take the lock without
+/// storing a task handle. If this fails it simply tries to take the lock
+/// again, this time storing a task handle. In the event that it fails that
+/// second time, it returns NotReady.
+/// 
+/// Wrapping behaviour
+/// ------------------
+/// Since modular arithmatic is not a supported atomic operation, normal
+/// addition is used in the "ADD 3 (mod 6)" operation. This results in the
+/// `state` growing indefinitely. As a result, it must be protected from
+/// wrapping around as it would naturally at a power of 2 determined by
+/// the machine word size. After performing a lock, the side of the BiLock
+/// which performs this addition checks if state is getting close to this
+/// limit, and if so subtracts a large multiple of 6 to bring it back down
+/// again.
 #[derive(Debug)]
 struct Inner<T> {
+    // (state % 6) identifies a state in a state machine
     state: AtomicUsize,
+    // Up to two tasks may be trying to park themselves concurrently
     tasks: [UnsafeCell<Option<Task>>; 2],
+    // The protected value
     value: Option<UnsafeCell<T>>,
 }
 
@@ -125,51 +230,66 @@ impl<T> Inner<T> {
     }
 
     unsafe fn poll_lock(&self, caller_index: bool) -> bool {
-        let mut state;
+        let mut prev_state;
         if caller_index {
-            // This needs precisely Acquire/Release semantics
-            state = self.state.fetch_add(3, AcqRel);
+            // Swap our token with the "FREE" token
+            prev_state = self.state.fetch_add(3, AcqRel);
 
-            // Slow path if lock failed
-            match state % 6 {
+            // See what happened
+            match prev_state % 6 {
+                // Slow paths if lock failed
                 2 => {
-                    *self.tasks.get_unchecked(0).get() = Some(task::current());
-                    state = self.state.fetch_add(3, AcqRel);
+                    // Store our task handle
+                    *self.tasks[0].get() = Some(task::current());
+                    // Try again
+                    prev_state = self.state.fetch_add(3, AcqRel);
                 },
                 5 => {
-                    *self.tasks.get_unchecked(1).get() = Some(task::current());
-                    state = self.state.fetch_add(3, AcqRel);
+                    // Store our task handle
+                    *self.tasks[1].get() = Some(task::current());
+                    // Try again
+                    prev_state = self.state.fetch_add(3, AcqRel);
                 },
+                // If we had the lock originally, we should never have been called!
                 0 | 1 => panic!("Lock already held"),
+                // We obtained the lock!
                 _ => {}
             }
 
             // Make sure the state wraps around at a multiple of 6, and leave plenty of
             // room at the end.
             const UPPER_LIMIT: usize = !0usize - 63;
-            if state >= UPPER_LIMIT {
+            if prev_state >= UPPER_LIMIT {
                 self.state.fetch_sub(UPPER_LIMIT, Relaxed);
             }
         } else {
-            // This needs precisely Acquire/Release semantics
-            state = self.state.fetch_xor(1, AcqRel);
+            // Swap our token with the "FREE" token
+            prev_state = self.state.fetch_xor(1, AcqRel);
 
-            // Slow path if lock failed
-            match state % 6 {
+            // See what happened
+            match prev_state % 6 {
+                // Slow paths if lock failed
                 0 => {
-                    *self.tasks.get_unchecked(1).get() = Some(task::current());
-                    state = self.state.fetch_xor(1, AcqRel);
+                    // Store our task handle
+                    *self.tasks[1].get() = Some(task::current());
+                    // Try again
+                    prev_state = self.state.fetch_xor(1, AcqRel);
                 },
                 1 => {
-                    *self.tasks.get_unchecked(0).get() = Some(task::current());
-                    state = self.state.fetch_xor(1, AcqRel);
+                    // Store our task handle
+                    *self.tasks[0].get() = Some(task::current());
+                    // Try again
+                    prev_state = self.state.fetch_xor(1, AcqRel);
                 },
+                // If we had the lock originally, we should never have been called!
                 2 | 5 => panic!("Lock already held"),
+                // We obtained the lock!
                 _ => {}
             }
         }
 
-        match state % 6 {
+        // Return true if we obtained the lock
+        match prev_state % 6 {
             3 | 4 => true,
             _ => false
         }
@@ -177,25 +297,25 @@ impl<T> Inner<T> {
 
     unsafe fn unlock(&self, caller_index: bool) {
         if caller_index {
-            // This needs precisely Acquire/Release semantics
-            let state = self.state.fetch_add(3, AcqRel);
+            // Swap our token with the "FREE" token
+            let prev_state = self.state.fetch_add(3, AcqRel);
 
             // Wake up a waiting task if necessary
-            match state % 6 {
-                0 => (*self.tasks.get_unchecked(1).get()).take().map(|t| t.notify()),
-                1 => (*self.tasks.get_unchecked(0).get()).take().map(|t| t.notify()),
+            (*match prev_state % 6 {
+                0 => self.tasks[1].get(),
+                1 => self.tasks[0].get(),
                 _ => panic!("Lock not held")
-            };
+            }).take().map(|t| t.notify());
         } else {
-            // This needs precisely Acquire/Release semantics
-            let state = self.state.fetch_xor(1, AcqRel);
+            // Swap our token with the "FREE" token
+            let prev_state = self.state.fetch_xor(1, AcqRel);
 
             // Wake up a waiting task if necessary
-            match state % 6 {
-                2 => (*self.tasks.get_unchecked(0).get()).take().map(|t| t.notify()),
-                5 => (*self.tasks.get_unchecked(1).get()).take().map(|t| t.notify()),
+            (*match prev_state % 6 {
+                2 => self.tasks[0].get(),
+                5 => self.tasks[1].get(),
                 _ => panic!("Lock not held")
-            };
+            }).take().map(|t| t.notify());
         }
     }
 

--- a/src/sync/bilock.rs
+++ b/src/sync/bilock.rs
@@ -61,7 +61,7 @@ pub struct BiLock<T> {
 /// 
 /// State encoding
 /// --------------
-/// The ownership of the tokens is encoded entirely withing the state field,
+/// The ownership of the tokens is encoded entirely within the state field,
 /// which allows it to be updated atomically.
 /// 
 /// The "LEFT" and "RIGHT" columns indicate which token is owned by each side

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -14,7 +14,7 @@ use support::*;
 #[test]
 fn smoke() {
     let future = future::lazy(|| {
-        let (a, b) = BiLock::new(1);
+        let (mut a, mut b) = BiLock::new(1);
 
         {
             let mut lock = match a.poll_lock() {
@@ -25,7 +25,6 @@ fn smoke() {
             *lock = 2;
 
             assert!(b.poll_lock().is_not_ready());
-            assert!(a.poll_lock().is_not_ready());
         }
 
         assert!(b.poll_lock().is_ready());
@@ -52,34 +51,38 @@ fn smoke() {
 
 #[test]
 fn concurrent() {
-    const N: usize = 10000;
-    let (a, b) = BiLock::new(0);
+    let _ = future::lazy(|| {
+        const N: usize = 10000;
+        let (a, b) = BiLock::new(0);
 
-    let a = Increment {
-        a: Some(a),
-        remaining: N,
-    };
-    let b = stream::iter_ok::<_, ()>((0..N)).fold(b, |b, _n| {
-        b.lock().map(|mut b| {
-            *b += 1;
-            b.unlock()
-        })
-    });
+        let a = Increment {
+            a: Some(a),
+            remaining: N,
+        };
+        let b = stream::iter_ok::<_, ()>((0..N)).fold(b, |b, _n| {
+            b.lock().map(|mut b| {
+                *b += 1;
+                b.unlock()
+            })
+        });
 
-    let t1 = thread::spawn(move || a.wait());
-    let b = b.wait().expect("b error");
-    let a = t1.join().unwrap().expect("a error");
+        let t1 = thread::spawn(move || a.wait());
+        let mut b = b.wait().expect("b error");
+        let mut a = t1.join().unwrap().expect("a error");
 
-    match a.poll_lock() {
-        Async::Ready(l) => assert_eq!(*l, 2 * N),
-        Async::NotReady => panic!("poll not ready"),
-    }
-    match b.poll_lock() {
-        Async::Ready(l) => assert_eq!(*l, 2 * N),
-        Async::NotReady => panic!("poll not ready"),
-    }
+        match a.poll_lock() {
+            Async::Ready(l) => assert_eq!(*l, 2 * N),
+            Async::NotReady => panic!("poll not ready"),
+        }
+        match b.poll_lock() {
+            Async::Ready(l) => assert_eq!(*l, 2 * N),
+            Async::NotReady => panic!("poll not ready"),
+        }
 
-    assert_eq!(a.reunite(b).expect("bilock/concurrent: reunite error"), 2 * N);
+        assert_eq!(a.reunite(b).expect("bilock/concurrent: reunite error"), 2 * N);
+
+        Ok::<(), ()>(())
+    }).wait();
 
     struct Increment {
         remaining: usize,
@@ -96,7 +99,7 @@ fn concurrent() {
                     return Ok(self.a.take().unwrap().into())
                 }
 
-                let a = self.a.as_ref().unwrap();
+                let a = self.a.as_mut().unwrap();
                 let mut a = match a.poll_lock() {
                     Async::Ready(l) => l,
                     Async::NotReady => return Ok(Async::NotReady),


### PR DESCRIPTION
This PR replaces the implementation of `BiLock` with one which does not perform allocation, ~and is slightly simpler~.

This introduces a backwards-incompatible change to the API as it requires a mutable reference when locking/unlocking a `BiLock`.

In general, lock-free data structures require space proportional to the number of concurrent accessors, so taking mutable references to `self` should be preferred as it allows more efficient implementations.

Implementation details:
- The `BiLock` is initialised with three "tokens", numbered 0, 1, 2.
- At all times, each side of the `BiLock` owns one token, and the remaining token is "free".
- Only one thread-safe operation is supported by a `BiLock`: atomically swapping its own token with the "free" token.
- Owning a token gives you exclusive access to part of the data structure: tokens 0, 1 gives access to the corresponding indices in the "tasks" array, while token 2 gives access to the value protected by the lock.

`poll_lock` operation:
- The current token must be 0 of 1, or else we'd already have the lock
- The current task can be stored in the `tasks` array at the element we have access to
- Atomically swap our token with the free token
- If our token is now "2", we own the lock
- Otherwise, the free token now corresponds to our own task

`unlock` operation:
- The current token must be 2
- Atomically swap our token with the free token
- We get back either the 0 or 1 token, which gives us access to an element in the tasks array
- Wake up the task we obtained from the token

Tests:
I had to wrap the "concurrent" tests in a lazy future, because they called `poll_lock` outside a task, which used to work despite the documentation saying that the method should panic when called off-task.