### PR TITLE
Re-export futures::stream::ReuniteError

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -115,7 +115,7 @@ if_std! {
     pub use self::chunks::Chunks;
     pub use self::collect::Collect;
     pub use self::wait::Wait;
-    pub use self::split::{SplitStream, SplitSink};
+    pub use self::split::{SplitStream, SplitSink, ReuniteError};
     pub use self::futures_unordered::FuturesUnordered;
     pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
 


### PR DESCRIPTION
Should close #719 

Note: not checked at all, just edited the code in browser.