### PR TITLE
streams: implement select_all based on futures_unordered (#461)

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -106,6 +106,7 @@ if_std! {
     mod collect;
     mod wait;
     mod channel;
+    mod select_all;
     mod split;
     pub mod futures_unordered;
     mod futures_ordered;
@@ -115,6 +116,7 @@ if_std! {
     pub use self::chunks::Chunks;
     pub use self::collect::Collect;
     pub use self::wait::Wait;
+    pub use self::select_all::SelectAll;
     pub use self::split::{SplitStream, SplitSink, ReuniteError};
     pub use self::futures_unordered::FuturesUnordered;
     pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
@@ -1139,6 +1141,29 @@ pub fn futures_unordered<I>(futures: I) -> FuturesUnordered<<I::Item as IntoFutu
 
     for future in futures {
         set.push(future.into_future());
+    }
+
+    return set
+}
+
+/// Convert a list of streams into a `Stream` of results from the streams.
+/// 
+/// This essentially takes a list of streams (e.g. a vector, an iterator, etc.)
+/// and bundles them together into a single stream.
+/// The stream will yield items as they become available on the underlying
+/// streams internally, in the order they become available.
+/// 
+/// Note that the returned set can also be used to dynamically push more
+/// futures into the set as they become available.
+#[cfg(feature = "use_std")]
+pub fn select_all<I>(streams: I) -> SelectAll<I::Item> 
+    where I: IntoIterator,
+          I::Item: Stream
+{
+    let mut set = SelectAll::new();
+
+    for stream in streams {
+        set.push(stream);
     }
 
     return set

--- a/src/stream/select_all.rs
+++ b/src/stream/select_all.rs
@@ -1,0 +1,77 @@
+//! An unbounded set of streams
+use std::fmt::{self, Debug};
+
+use {Async, Poll, Stream};
+use stream::future::StreamFuture;
+use stream::futures_unordered::FuturesUnordered;
+
+/// An unbounded set of streams
+/// 
+/// This "combinator" provides the ability to maintain a set of streams
+/// and drive them all to completion.
+/// 
+/// Streams are pushed into this set and their realized values are 
+/// yielded as they become ready. Streams will only be polled when they
+/// generate notifications. This allows to coordinate a large number of streams.
+/// 
+/// Note that you can create a ready-made `SelectAll` via the
+/// `select_all` function in the `stream` module, or you can start with an
+/// empty set with the `SelectAll::new` constructor.
+#[must_use = "streams do nothing unless polled"]
+pub struct SelectAll<S> {
+    inner: FuturesUnordered<StreamFuture<S>>,
+}
+
+impl<T: Debug> Debug for SelectAll<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "SelectAll {{ ... }}")
+    }
+}
+
+impl<S: Stream> SelectAll<S> {
+    /// Constructs a new, empty `SelectAll`
+    ///
+    /// The returned `SelectAll` does not contain any streams and, in this
+    /// state, `SelectAll::poll` will return `Ok(Async::Ready(None))`.
+    pub fn new() -> SelectAll<S> {
+        SelectAll { inner: FuturesUnordered::new() }
+    }
+
+    /// Returns the number of streams contained in the set.
+    ///
+    /// This represents the total number of in-flight streams.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Returns `true` if the set contains no streams
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Push a stream into the set.
+    ///
+    /// This function submits the given stream to the set for managing. This
+    /// function will not call `poll` on the submitted stream. The caller must
+    /// ensure that `SelectAll::poll` is called in order to receive task
+    /// notifications.
+    pub fn push(&mut self, stream: S) {
+        self.inner.push(stream.into_future());
+    }
+}
+
+impl<S: Stream> Stream for SelectAll<S> {
+    type Item = S::Item;
+    type Error = S::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.inner.poll().map_err(|(err, _)| err)? {
+            Async::NotReady => Ok(Async::NotReady),
+            Async::Ready(Some((Some(item), remaining))) => {
+                self.push(remaining);
+                Ok(Async::Ready(Some(item)))
+            }
+            Async::Ready(_) => Ok(Async::Ready(None)),
+        }
+    }
+}

--- a/tests/stream_select_all.rs
+++ b/tests/stream_select_all.rs
@@ -1,0 +1,41 @@
+extern crate futures;
+
+use std::mem;
+
+use futures::sync::mpsc;
+use futures::stream::select_all;
+
+mod support;
+
+#[test]
+fn works_1() {
+    let (a_tx, a_rx) = mpsc::unbounded::<u32>();
+    let (b_tx, b_rx) = mpsc::unbounded::<u32>();
+    let (c_tx, c_rx) = mpsc::unbounded::<u32>();
+
+    let streams = vec![a_rx, b_rx, c_rx];
+
+    let stream = select_all(streams);
+    let mut spawn = futures::executor::spawn(stream);
+
+    b_tx.unbounded_send(99).unwrap();
+    a_tx.unbounded_send(33).unwrap();
+    assert_eq!(Some(Ok(33)), spawn.wait_stream());
+    assert_eq!(Some(Ok(99)), spawn.wait_stream());
+
+    // make sure we really return in the order items become ready
+    // so now try it the other way around as before
+    assert!(!spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_ready());
+    b_tx.unbounded_send(99).unwrap();
+    a_tx.unbounded_send(33).unwrap();
+    assert_eq!(Some(Ok(99)), spawn.wait_stream());
+    assert_eq!(Some(Ok(33)), spawn.wait_stream());
+
+    c_tx.unbounded_send(42).unwrap();
+    assert_eq!(Some(Ok(42)), spawn.wait_stream());
+    a_tx.unbounded_send(43).unwrap();
+    assert_eq!(Some(Ok(43)), spawn.wait_stream());
+
+    mem::drop((a_tx, b_tx, c_tx));
+    assert_eq!(None, spawn.wait_stream());
+}


### PR DESCRIPTION
Since this is a very basic functionality, I decided to attempt to upstream this.
A common usecase would be some case of event stream from multiple sources.
Currently you would have trouble just merging those streams and using them as one.

This internally utilities futures_unordered to combine multiple
streams into one pollable stream, that yields the items in the order
they become available.
This does not expose any internals regarding futures_unordered,
so the internal implementation can be swapped out without breaking
backwards compatibility.

I first considered basing FuturesUnordered on SelectAll (and moving the implementation
to SelectAll) to save these implicit future conversions using `IntoFuture`.
This seemed not very beneficial, since the future is "popped" every time anyways,
for safety reasons (see Bomb), so I decided to stay with the more conservative implementation
for now.