### PR TITLE
add into_inner and similar methods to StreamFuture

### DIFF
--- a/src/stream/future.rs
+++ b/src/stream/future.rs
@@ -14,6 +14,46 @@ pub fn new<S: Stream>(s: S) -> StreamFuture<S> {
     StreamFuture { stream: Some(s) }
 }
 
+impl<S> StreamFuture<S> {
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    ///
+    /// This method returns an `Option` to account for the fact that `StreamFuture`'s
+    /// implementation of `Future::poll` consumes the underlying stream during polling 
+    /// in order to return it to the caller of `Future::poll` if the stream yieleded
+    /// an element.
+    pub fn get_ref(&self) -> Option<&S> {
+        self.stream.as_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    ///
+    /// This method returns an `Option` to account for the fact that `StreamFuture`'s
+    /// implementation of `Future::poll` consumes the underlying stream during polling 
+    /// in order to return it to the caller of `Future::poll` if the stream yieleded
+    /// an element.
+    pub fn get_mut(&mut self) -> Option<&mut S> {
+        self.stream.as_mut()
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    ///
+    /// This method returns an `Option` to account for the fact that `StreamFuture`'s
+    /// implementation of `Future::poll` consumes the underlying stream during polling 
+    /// in order to return it to the caller of `Future::poll` if the stream yieleded
+    /// an element.
+    pub fn into_inner(self) -> Option<S> {
+        self.stream
+    }
+}
+
 impl<S: Stream> Future for StreamFuture<S> {
     type Item = (Option<S::Item>, S);
     type Error = (S::Error, S);


### PR DESCRIPTION
When selecting on a StreamFuture and other futures, it is useful to be able to recover the underlying Stream if one of the other futures resolves first.

See https://github.com/rust-lang-nursery/futures-rs/issues/633#issuecomment-360932386 for more information.