### PR TITLE
Change Stream::filter predicate to return a Future

### DIFF
--- a/src/stream/skip_while.rs
+++ b/src/stream/skip_while.rs
@@ -94,7 +94,6 @@ impl<S, P, R> Stream for SkipWhile<S, P, R>
                 self.pending = Some(((self.pred)(&item).into_future(), item));
             }
 
-            assert!(self.pending.is_some());
             match self.pending.as_mut().unwrap().0.poll() {
                 Ok(Async::Ready(true)) => self.pending = None,
                 Ok(Async::Ready(false)) => {

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -88,7 +88,7 @@ fn fold() {
 
 #[test]
 fn filter() {
-    assert_done(|| list().filter(|a| *a % 2 == 0).collect(), Ok(vec![2]));
+    assert_done(|| list().filter(|a| ok(*a % 2 == 0)).collect(), Ok(vec![2]));
 }
 
 #[test]


### PR DESCRIPTION
This makes Stream::filter and Stream::skip_while
consistent by making both predicates return a
Future<Item=bool> rather than a plain bool.

@alexcrichton 

Closes #311