### PR TITLE
Generalize "unfold" combinator.

### DIFF
--- a/tests/unfold.rs
+++ b/tests/unfold.rs
@@ -3,6 +3,7 @@ extern crate futures;
 mod support;
 
 use futures::stream;
+use futures::future::{ok, Either};
 
 use support::*;
 
@@ -10,10 +11,10 @@ use support::*;
 fn unfold1() {
     let mut stream = stream::unfold(0, |state| {
         if state <= 2 {
-            let res: Result<_,()> = Ok((state * 2, state + 1));
-            Some(delay_future(res))
+            let res = ok::<_, ()>(Some((state * 2, state + 1)));
+            Either::A(delay_future(res))
         } else {
-            None
+            Either::B(ok(None))
         }
     });
     // Creates the future with the closure
@@ -37,9 +38,9 @@ fn unfold1() {
 fn unfold_err1() {
     let mut stream = stream::unfold(0, |state| {
         if state <= 2 {
-            Some(Ok((state * 2, state + 1)))
+            Ok(Some((state * 2, state + 1)))
         } else {
-            Some(Err(-1))
+            Err(-1)
         }
     });
     sassert_next(&mut stream, 0);

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -116,7 +116,7 @@ fn mpsc_send_unpark() {
 #[test]
 fn spawn_sends_items() {
     let core = Core::new();
-    let stream = unfold(0, |i| Some(Ok::<_,u8>((i, i + 1))));
+    let stream = unfold(0, |i| Ok::<_,u8>(Some((i, i + 1))));
     let rx = mpsc::spawn(stream, &core, 1);
     assert_eq!(core.run(rx.take(4).collect()).unwrap(),
                [0, 1, 2, 3]);


### PR DESCRIPTION
unfold functions now must return a Future of an Option
rather than an Option of a future. This allows users
to hold off deciding whether or not a value should
be returned.

@alexcrichton 