### PR TITLE
Use `enter` in `CpuPool`

### DIFF
--- a/futures-cpupool/Cargo.toml
+++ b/futures-cpupool/Cargo.toml
@@ -14,8 +14,6 @@ computation on the threads themselves.
 [dependencies]
 num_cpus = "1.0"
 futures = { path = "../futures", version = "0.2", default-features = false }
-
-[dev-dependencies]
 futures-executor = { path = "../futures-executor", version = "0.2", default-features = false }
 
 [features]

--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -54,6 +54,7 @@ macro_rules! if_std {
 
 if_std! {
     extern crate futures;
+    extern crate futures_executor;
     extern crate num_cpus;
 
     mod unpark_mutex;

--- a/futures-cpupool/src/pool.rs
+++ b/futures-cpupool/src/pool.rs
@@ -11,6 +11,7 @@ use futures::channel::oneshot::{channel, Sender, Receiver};
 use futures::future::lazy;
 use futures::prelude::*;
 use futures::task::{self, Notify, Spawn};
+use futures_executor::enter;
 use num_cpus;
 
 use unpark_mutex::UnparkMutex;
@@ -218,6 +219,7 @@ impl Inner {
     }
 
     fn work(&self, after_start: Option<Arc<Fn() + Send + Sync>>, before_stop: Option<Arc<Fn() + Send + Sync>>) {
+        let _scope = enter().unwrap();
         after_start.map(|fun| fun());
         loop {
             let msg = self.rx.lock().unwrap().recv().unwrap();


### PR DESCRIPTION
Prevents usage of `current_thread::run` on the worker threads by accident!