### PR TITLE
Rename `Sink::poll_complete` to `flush`

### DIFF
--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -103,7 +103,7 @@ impl Stream for TestSender {
             Err(_) => panic!(),
             Ok(Ok(())) => {
                 self.last += 1;
-                assert_eq!(Ok(Async::Ready(())), self.tx.poll_complete());
+                assert_eq!(Ok(Async::Ready(())), self.tx.flush());
                 Ok(Async::Ready(Some(self.last)))
             }
             Ok(Err(_)) => {

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -34,7 +34,7 @@ fn send_recv_no_buffer() {
 
     // Run on a task context
     let f = lazy(move || {
-        assert!(tx.poll_complete().unwrap().is_ready());
+        assert!(tx.flush().unwrap().is_ready());
         assert!(tx.poll_ready().unwrap().is_ready());
 
         // Send first message

--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -16,7 +16,7 @@ impl<T> Sink for Sender<T> {
         self.start_send(msg).map(res_to_async_sink)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+    fn flush(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
 
@@ -33,7 +33,7 @@ impl<T> Sink for UnboundedSender<T> {
         self.start_send(msg).map(res_to_async_sink)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+    fn flush(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
 
@@ -51,7 +51,7 @@ impl<'a, T> Sink for &'a UnboundedSender<T> {
         Ok(AsyncSink::Ready)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
+    fn flush(&mut self) -> Poll<(), SendError<T>> {
         Ok(Async::Ready(()))
     }
 

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -48,7 +48,7 @@ impl<S: Sink> Buffer<S> {
                 self.buf.push_front(item);
 
                 // ensure that we attempt to complete any pushes we've started
-                self.sink.poll_complete()?;
+                self.sink.flush()?;
 
                 return Ok(Async::Pending);
             }
@@ -85,14 +85,14 @@ impl<S: Sink> Sink for Buffer<S> {
         Ok(AsyncSink::Ready)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+    fn flush(&mut self) -> Poll<(), Self::SinkError> {
         if self.cap == 0 {
-            return self.sink.poll_complete();
+            return self.sink.flush();
         }
 
         try_ready!(self.try_empty_buffer());
         debug_assert!(self.buf.is_empty());
-        self.sink.poll_complete()
+        self.sink.flush()
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -1,0 +1,52 @@
+use futures_core::{Poll, Async, Future};
+use futures_sink::Sink;
+
+/// Future for the `close` combinator, which polls the sink until all data has
+/// been closeed.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct Close<S> {
+    sink: Option<S>,
+}
+
+/// A future that completes when the sink has finished closing.
+///
+/// The sink itself is returned after closeing is complete.
+pub fn close<S: Sink>(sink: S) -> Close<S> {
+    Close { sink: Some(sink) }
+}
+
+impl<S: Sink> Close<S> {
+    /// Get a shared reference to the inner sink.
+    /// Returns `None` if the sink has already been closeed.
+    pub fn get_ref(&self) -> Option<&S> {
+        self.sink.as_ref()
+    }
+
+    /// Get a mutable reference to the inner sink.
+    /// Returns `None` if the sink has already been closeed.
+    pub fn get_mut(&mut self) -> Option<&mut S> {
+        self.sink.as_mut()
+    }
+
+    /// Consume the `Close` and return the inner sink.
+    /// Returns `None` if the sink has already been closeed.
+    pub fn into_inner(self) -> Option<S> {
+        self.sink
+    }
+}
+
+impl<S: Sink> Future for Close<S> {
+    type Item = S;
+    type Error = S::SinkError;
+
+    fn poll(&mut self) -> Poll<S, S::SinkError> {
+        let mut sink = self.sink.take().expect("Attempted to poll Close after it completed");
+        if sink.close()?.is_ready() {
+            Ok(Async::Ready(sink))
+        } else {
+            self.sink = Some(sink);
+            Ok(Async::Pending)
+        }
+    }
+}

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -67,9 +67,9 @@ impl<A, B> Sink for Fanout<A, B>
         }
     }
 
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        let left_async = self.left.poll_complete()?;
-        let right_async = self.right.poll_complete()?;
+    fn flush(&mut self) -> Poll<(), Self::SinkError> {
+        let left_async = self.left.flush()?;
+        let right_async = self.right.flush()?;
         // Only if both downstream sinks are ready, signal readiness.
         if left_async.is_ready() && right_async.is_ready() {
             Ok(Async::Ready(()))
@@ -112,9 +112,9 @@ impl<S: Sink> Downstream<S> {
         Ok(())
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
         self.keep_flushing()?;
-        let async = self.sink.poll_complete()?;
+        let async = self.sink.flush()?;
         // Only if all values have been sent _and_ the underlying
         // sink is completely flushed, signal readiness.
         if self.state.is_ready() && async.is_ready() {

--- a/futures-util/src/sink/from_err.rs
+++ b/futures-util/src/sink/from_err.rs
@@ -53,8 +53,8 @@ impl<S, E> Sink for SinkFromErr<S, E>
         self.sink.start_send(item).map_err(|e| e.into())
     }
 
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        self.sink.poll_complete().map_err(|e| e.into())
+    fn flush(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.flush().map_err(|e| e.into())
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -44,8 +44,8 @@ impl<S, F, E> Sink for SinkMapErr<S, F>
         self.sink.start_send(item).map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
     }
 
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        self.sink.poll_complete().map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
+    fn flush(&mut self) -> Poll<(), Self::SinkError> {
+        self.sink.flush().map_err(|e| self.f.take().expect("cannot use MapErr after an error")(e))
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -51,7 +51,7 @@ impl<S: Sink> Future for Send<S> {
 
         // we're done sending the item, but want to block on flushing the
         // sink
-        try_ready!(self.sink_mut().poll_complete());
+        try_ready!(self.sink_mut().flush());
 
         // now everything's emptied, so return the sink for further use
         Ok(Async::Ready(self.take_sink()))

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -76,11 +76,11 @@ impl<T, U> Future for SendAll<T, U>
             match self.stream_mut().poll()? {
                 Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
                 Async::Ready(None) => {
-                    try_ready!(self.sink_mut().poll_complete());
+                    try_ready!(self.sink_mut().flush());
                     return Ok(Async::Ready(self.take_result()))
                 }
                 Async::Pending => {
-                    try_ready!(self.sink_mut().poll_complete());
+                    try_ready!(self.sink_mut().flush());
                     return Ok(Async::Pending)
                 }
             }

--- a/futures-util/src/sink/wait.rs
+++ b/futures-util/src/sink/wait.rs
@@ -40,7 +40,7 @@ impl<S: Sink> Wait<S> {
     /// Flushes any buffered data in this sink, blocking the current thread
     /// until it's entirely flushed.
     ///
-    /// This function will call the underlying sink's `poll_complete` method
+    /// This function will call the underlying sink's `flush` method
     /// until it returns that it's ready to proceed. If the method returns
     /// `Pending` the current thread will be blocked until it's otherwise
     /// ready to proceed.

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -137,11 +137,11 @@ impl<S, U, F, Fut> Sink for With<S, U, F, Fut>
         Ok(AsyncSink::Ready)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), Fut::Error> {
+    fn flush(&mut self) -> Poll<(), Fut::Error> {
         // poll ourselves first, to push data downward
         let me_ready = self.poll()?;
-        // always propagate `poll_complete` downward to attempt to make progress
-        try_ready!(self.sink.poll_complete());
+        // always propagate `flush` downward to attempt to make progress
+        try_ready!(self.sink.flush());
         Ok(me_ready)
     }
 

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -109,11 +109,11 @@ where
         self.try_empty_stream()?;
         Ok(AsyncSink::Ready)
     }
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+    fn flush(&mut self) -> Poll<(), Self::SinkError> {
         if self.try_empty_stream()?.is_not_ready() {
             return Ok(Async::Pending);
         }
-        self.sink.poll_complete()
+        self.sink.flush()
     }
     fn close(&mut self) -> Poll<(), Self::SinkError> {
         if self.try_empty_stream()?.is_not_ready() {

--- a/futures-util/src/stream/and_then.rs
+++ b/futures-util/src/stream/and_then.rs
@@ -65,8 +65,8 @@ impl<S, F, U: IntoFuture> Sink for AndThen<S, F, U>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -122,8 +122,8 @@ impl<S> Sink for BufferUnordered<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -88,8 +88,8 @@ impl<S> Sink for Buffered<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -44,8 +44,8 @@ impl<S> Sink for Chunks<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/filter.rs
+++ b/futures-util/src/stream/filter.rs
@@ -72,8 +72,8 @@ impl<S, P, R> Sink for Filter<S, P, R>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -71,8 +71,8 @@ impl<S, F, R> Sink for FilterMap<S, F, R>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -60,8 +60,8 @@ impl<S> Sink for Flatten<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -98,11 +98,11 @@ impl<T, U> Future for Forward<T, U>
             {
                 Async::Ready(Some(item)) => try_ready!(self.try_start_send(item)),
                 Async::Ready(None) => {
-                    try_ready!(self.sink_mut().take().expect("Attempted to poll Forward after completion").poll_complete());
+                    try_ready!(self.sink_mut().take().expect("Attempted to poll Forward after completion").flush());
                     return Ok(Async::Ready(self.take_result()))
                 }
                 Async::Pending => {
-                    try_ready!(self.sink_mut().take().expect("Attempted to poll Forward after completion").poll_complete());
+                    try_ready!(self.sink_mut().take().expect("Attempted to poll Forward after completion").flush());
                     return Ok(Async::Pending)
                 }
             }

--- a/futures-util/src/stream/from_err.rs
+++ b/futures-util/src/stream/from_err.rs
@@ -70,8 +70,8 @@ impl<S: Stream + Sink, E> Sink for FromErr<S, E> {
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), Self::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -24,8 +24,8 @@ impl<S> Sink for Fuse<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -57,8 +57,8 @@ impl<S, F> Sink for Inspect<S, F>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/inspect_err.rs
+++ b/futures-util/src/stream/inspect_err.rs
@@ -57,8 +57,8 @@ impl<S, F> Sink for InspectErr<S, F>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -58,8 +58,8 @@ impl<S, F> Sink for Map<S, F>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/map_err.rs
+++ b/futures-util/src/stream/map_err.rs
@@ -58,8 +58,8 @@ impl<S, F> Sink for MapErr<S, F>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/or_else.rs
+++ b/futures-util/src/stream/or_else.rs
@@ -38,8 +38,8 @@ impl<S, F, U> Sink for OrElse<S, F, U>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -34,8 +34,8 @@ impl<S> Sink for Peekable<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -56,8 +56,8 @@ impl<S> Sink for Skip<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -63,8 +63,8 @@ impl<S, P, R> Sink for SkipWhile<S, P, R>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -60,9 +60,9 @@ impl<S: Sink> Sink for SplitSink<S> {
         }
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
         match self.0.poll_lock() {
-            Async::Ready(mut inner) => inner.poll_complete(),
+            Async::Ready(mut inner) => inner.flush(),
             Async::Pending => Ok(Async::Pending),
         }
     }

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -56,8 +56,8 @@ impl<S> Sink for Take<S>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -63,8 +63,8 @@ impl<S, P, R> Sink for TakeWhile<S, P, R>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -38,8 +38,8 @@ impl<S, F, U> Sink for Then<S, F, U>
         self.stream.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.poll_complete()
+    fn flush(&mut self) -> Poll<(), S::SinkError> {
+        self.stream.flush()
     }
 
     fn close(&mut self) -> Poll<(), S::SinkError> {

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -200,7 +200,7 @@ impl<T> Sink for ManualFlush<T> {
         Ok(AsyncSink::Ready)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), ()> {
+    fn flush(&mut self) -> Poll<(), ()> {
         if self.data.is_empty() {
             Ok(Async::Ready(()))
         } else {
@@ -310,7 +310,7 @@ impl<T> Sink for ManualAllow<T> {
         }
     }
 
-    fn poll_complete(&mut self) -> Poll<(), ()> {
+    fn flush(&mut self) -> Poll<(), ()> {
         Ok(Async::Ready(()))
     }
 
@@ -408,7 +408,7 @@ fn map_err() {
         let (tx, _rx) = mpsc::channel(1);
         let mut tx = tx.sink_map_err(|_| ());
         assert_eq!(tx.start_send(()), Ok(AsyncSink::Ready));
-        assert_eq!(tx.poll_complete(), Ok(Async::Ready(())));
+        assert_eq!(tx.flush(), Ok(Async::Ready(())));
     }
 
     let tx = mpsc::channel(0).0;
@@ -430,7 +430,7 @@ fn from_err() {
         let (tx, _rx) = mpsc::channel(1);
         let mut tx: SinkFromErr<mpsc::Sender<()>, FromErrTest> = tx.sink_from_err();
         assert_eq!(tx.start_send(()), Ok(AsyncSink::Ready));
-        assert_eq!(tx.poll_complete(), Ok(Async::Ready(())));
+        assert_eq!(tx.flush(), Ok(Async::Ready(())));
     }
 
     let tx = mpsc::channel(0).0;

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -24,8 +24,8 @@ impl<T, U: Sink> Sink for Join<T, U> {
         self.1.start_send(item)
     }
 
-    fn poll_complete(&mut self) -> Poll<(), U::SinkError> {
-        self.1.poll_complete()
+    fn flush(&mut self) -> Poll<(), U::SinkError> {
+        self.1.flush()
     }
 
     fn close(&mut self) -> Poll<(), U::SinkError> {


### PR DESCRIPTION
Along with a few other changes:

* Move the `Sink::flush` combinator to a free `flush` function
* Add a free `close` combinator

Closes #379