### PR TITLE
First draft of stable futures. [DO NOT MERGE]

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -9,6 +9,7 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[macro_use]
 extern crate futures_core;
 
 macro_rules! if_std {

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::error::Error;
 use std::fmt;
 
-use futures_core::{Future, Poll, Async};
+use futures_core::{Future, FutureMove, Poll, Async};
 use futures_core::task::{self, Task};
 
 use lock::Lock;
@@ -411,8 +411,11 @@ impl<T> Receiver<T> {
 impl<T> Future for Receiver<T> {
     type Item = T;
     type Error = Canceled;
+    poll_safe!();
+}
 
-    fn poll(&mut self) -> Poll<T, Canceled> {
+impl<T> FutureMove for Receiver<T> {
+    fn poll_move(&mut self) -> Poll<T, Canceled> {
         self.inner.recv()
     }
 }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -10,6 +10,10 @@ description = """
 The core traits and types in for the `futures` library.
 """
 
+[dependencies.anchor-experiment]
+git = "https://github.com/withoutboats/anchor_experiment"
+default-features = false
+
 [features]
 default = ["std"]
-std = []
+std = ["anchor-experiment/std"]

--- a/futures-core/src/future/option.rs
+++ b/futures-core/src/future/option.rs
@@ -1,6 +1,6 @@
 //! Definition of the `Option` (optional step) combinator
 
-use {Future, IntoFuture, Poll, Async};
+use {Future, FutureMove, IntoFuture, Poll, Async};
 
 use core::option;
 
@@ -27,10 +27,19 @@ impl<F, T, E> Future for Option<F> where F: Future<Item=T, Error=E> {
     type Item = option::Option<T>;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<option::Option<T>, E> {
+    unsafe fn poll_unsafe(&mut self) -> Poll<option::Option<T>, E> {
         match self.inner {
             None => Ok(Async::Ready(None)),
-            Some(ref mut x) => x.poll().map(|x| x.map(Some)),
+            Some(ref mut x) => x.poll_unsafe().map(|x| x.map(Some)),
+        }
+    }
+}
+
+impl<F, T, E> FutureMove for Option<F> where F: FutureMove<Item=T, Error=E> {
+    fn poll_move(&mut self) -> Poll<option::Option<T>, E> {
+        match self.inner {
+            None => Ok(Async::Ready(None)),
+            Some(ref mut x) => x.poll_move().map(|x| x.map(Some)),
         }
     }
 }

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,12 +1,14 @@
 //! Core traits and types for asynchronous operations in Rust.
 
 #![no_std]
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+//#![deny(missing_docs, missing_debug_implementations, warnings)]
 #![doc(html_root_url = "https://docs.rs/futures-core/0.2")]
 
 #[macro_use]
 #[cfg(feature = "std")]
 extern crate std;
+
+extern crate anchor_experiment;
 
 macro_rules! if_std {
     ($($i:item)*) => ($(
@@ -20,7 +22,7 @@ mod poll;
 pub use poll::{Async, Poll};
 
 pub mod future;
-pub use future::{Future, IntoFuture};
+pub use future::{Future, FutureMove, IntoFuture};
 
 pub mod stream;
 pub use stream::Stream;

--- a/futures-core/src/never.rs
+++ b/futures-core/src/never.rs
@@ -1,6 +1,6 @@
 //! Definition and trait implementations for the `Never` type.
 
-use {Future, Stream, Poll};
+use {Future, FutureMove, Stream, Poll};
 
 /// A type that can never exist.
 /// This is used to indicate values which can never be created, such as the
@@ -21,7 +21,13 @@ impl Future for Never {
     type Item = Never;
     type Error = Never;
 
-    fn poll(&mut self) -> Poll<Never, Never> {
+    unsafe fn poll_unsafe(&mut self) -> Poll<Never, Never> {
+        match *self {}
+    }
+}
+
+impl FutureMove for Never {
+    fn poll_move(&mut self) -> Poll<Never, Never> {
         match *self {}
     }
 }

--- a/futures-core/src/task_impl/mod.rs
+++ b/futures-core/src/task_impl/mod.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use core::marker::PhantomData;
 
-use {Poll, Future, Stream};
+use {Poll, FutureMove, Stream};
 
 mod atomic_task;
 pub use self::atomic_task::AtomicTask;
@@ -204,9 +204,9 @@ impl<T: ?Sized> Spawn<T> {
                                  notify: &N,
                                  id: usize) -> Poll<T::Item, T::Error>
         where N: Clone + Into<NotifyHandle>,
-              T: Future,
+              T: FutureMove,
     {
-        self.poll_notify(notify, id, |s| s.poll())
+        self.poll_notify(notify, id, |s| s.poll_move())
     }
 
     /// Like `poll_future_notify`, except polls the underlying stream.

--- a/futures-core/src/task_impl/std/mod.rs
+++ b/futures-core/src/task_impl/std/mod.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use std::sync::{Arc, Mutex, Condvar, Once, ONCE_INIT};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use {Future, Stream, Async};
+use {FutureMove, Stream, Async};
 use super::core;
 use super::{BorrowedTask, NotifyHandle, Spawn, Notify, UnsafeNotify};
 pub use super::core::{BorrowedUnpark, TaskUnpark};
@@ -74,7 +74,7 @@ pub fn set<'a, F, R>(task: &BorrowedTask<'a>, f: F) -> R
     }
 }
 
-impl<F: Future> Spawn<F> {
+impl<F: FutureMove> Spawn<F> {
     /// Waits for the internal future to complete, blocking this thread's
     /// execution until it does.
     ///

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -11,10 +11,11 @@ Common utilities and extension traits for the futures-rs library.
 """
 
 [features]
-std = ["futures-core/std", "futures-sink/std"]
+std = ["futures-core/std", "futures-sink/std", "anchor-experiment/std"]
 default = ["std"]
 
 [dependencies]
+anchor-experiment = { git = "https://github.com/withoutboats/anchor_experiment", default-features = false }
 futures-core = { path = "../futures-core", version = "0.2.0", default-features = false }
 futures-channel = { path = "../futures-channel", version = "0.2.0", default-features = false }
 futures-sink = { path = "../futures-sink", version = "0.2.0", default-features = false}

--- a/futures-util/src/future/chain.rs
+++ b/futures-util/src/future/chain.rs
@@ -17,7 +17,7 @@ impl<A, B, C> Chain<A, B, C>
         Chain::First(a, c)
     }
 
-    pub fn poll<F>(&mut self, f: F) -> Poll<B::Item, B::Error>
+    pub unsafe fn poll_unsafe<F>(&mut self, f: F) -> Poll<B::Item, B::Error>
         where F: FnOnce(Result<A::Item, A::Error>, C)
                         -> Result<Result<B::Item, B>, B::Error>,
     {

--- a/futures-util/src/future/empty.rs
+++ b/futures-util/src/future/empty.rs
@@ -2,7 +2,8 @@
 
 use core::marker;
 
-use futures_core::{Future, Poll, Async};
+use anchor_experiment::MovePinned;
+use futures_core::{Future, FutureMove, Poll, Async};
 
 /// A future which is never resolved.
 ///
@@ -12,6 +13,8 @@ use futures_core::{Future, Poll, Async};
 pub struct Empty<T, E> {
     _data: marker::PhantomData<(T, E)>,
 }
+
+unsafe impl<T, E> MovePinned for Empty<T, E> { }
 
 /// Creates a future which never resolves, representing a computation that never
 /// finishes.
@@ -25,7 +28,13 @@ impl<T, E> Future for Empty<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<T, E> {
+    unsafe fn poll_unsafe(&mut self) -> Poll<T, E> {
+        Ok(Async::Pending)
+    }
+}
+
+impl<T, E> FutureMove for Empty<T, E> {
+    fn poll_move(&mut self) -> Poll<T, E> {
         Ok(Async::Pending)
     }
 }

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use futures_core::{Future, IntoFuture, Poll};
+use futures_core::{Future, FutureMove, IntoFuture, Poll};
 
 use super::chain::Chain;
 
@@ -42,10 +42,21 @@ impl<A> Future for Flatten<A>
     type Item = <<A as Future>::Item as IntoFuture>::Item;
     type Error = <<A as Future>::Item as IntoFuture>::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.state.poll(|a, ()| {
+    unsafe fn poll_unsafe(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.state.poll_unsafe(|a, ()| {
             let future = a?.into_future();
             Ok(Err(future))
         })
+    }
+}
+
+impl<A> FutureMove for Flatten<A>
+    where A: FutureMove,
+          A::Item: IntoFuture,
+          <<A as Future>::Item as IntoFuture>::Future: FutureMove,
+          <<A as Future>::Item as IntoFuture>::Error: From<<A as Future>::Error>
+{
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        unsafe { self.poll_unsafe() }
     }
 }

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -56,7 +56,7 @@ impl<A> FutureMove for Flatten<A>
           <<A as Future>::Item as IntoFuture>::Future: FutureMove,
           <<A as Future>::Item as IntoFuture>::Error: From<<A as Future>::Error>
 {
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll_move(&mut self) -> Poll<Self::Item, Self::Error> {
         unsafe { self.poll_unsafe() }
     }
 }

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -1,4 +1,4 @@
-use futures_core::{Future, Poll, Async};
+use futures_core::{Future, FutureMove, Poll, Async};
 
 /// A future which "fuses" a future once it's been resolved.
 ///
@@ -23,8 +23,22 @@ impl<A: Future> Future for Fuse<A> {
     type Item = A::Item;
     type Error = A::Error;
 
-    fn poll(&mut self) -> Poll<A::Item, A::Error> {
-        let res = self.future.as_mut().map(|f| f.poll());
+    unsafe fn poll_unsafe(&mut self) -> Poll<A::Item, A::Error> {
+        let res = self.future.as_mut().map(|f| f.poll_unsafe());
+        match res.unwrap_or(Ok(Async::Pending)) {
+            res @ Ok(Async::Ready(_)) |
+            res @ Err(_) => {
+                self.future = None;
+                res
+            }
+            Ok(Async::Pending) => Ok(Async::Pending)
+        }
+    }
+}
+
+impl<A: FutureMove> FutureMove for Fuse<A> {
+    fn poll_move(&mut self) -> Poll<A::Item, A::Error> {
+        let res = self.future.as_mut().map(|f| f.poll_move());
         match res.unwrap_or(Ok(Async::Pending)) {
             res @ Ok(Async::Ready(_)) |
             res @ Err(_) => {

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -5,7 +5,7 @@
 
 use core::result;
 
-use futures_core::{Future, IntoFuture, Stream};
+use futures_core::{Future, FutureMove, IntoFuture, Stream};
 
 // Primitive futures
 mod empty;
@@ -420,7 +420,8 @@ pub trait FutureExt: Future {
     /// ```
     fn select<B>(self, other: B) -> Select<Self, B::Future>
         where B: IntoFuture<Item=Self::Item, Error=Self::Error>,
-              Self: Sized,
+              B::Future: FutureMove,
+              Self: FutureMove + Sized,
     {
         let f = select::new(self, other.into_future());
         assert_future::<(Self::Item, SelectNext<Self, B::Future>),
@@ -467,7 +468,9 @@ pub trait FutureExt: Future {
     /// # fn main() {}
     /// ```
     fn select2<B>(self, other: B) -> Select2<Self, B::Future>
-        where B: IntoFuture, Self: Sized
+        where B: IntoFuture,
+              B::Future: FutureMove,
+              Self: FutureMove + Sized,
     {
         select2::new(self, other.into_future())
     }

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -1,6 +1,7 @@
 //! Definition of the `PollFn` adapter combinator
 
-use futures_core::{Future, Poll};
+use anchor_experiment::MovePinned;
+use futures_core::{Future, FutureMove, Poll};
 
 /// A future which adapts a function returning `Poll`.
 ///
@@ -42,7 +43,15 @@ impl<T, E, F> Future for PollFn<F>
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<T, E> {
+    unsafe fn poll_unsafe(&mut self) -> Poll<T, E> {
+        (self.inner)()
+    }
+}
+
+impl<T, E, F> FutureMove for PollFn<F>
+    where F: FnMut() -> Poll<T, E> + MovePinned
+{
+    fn poll_move(&mut self) -> Poll<T, E> {
         (self.inner)()
     }
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -1,12 +1,13 @@
 //! Combinators and utilities for working with futures-rs `Futures`s, `Stream`s, and `Sink`s.
 
 #![no_std]
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+//#![deny(missing_docs, missing_debug_implementations, warnings)]
 #![doc(html_root_url = "https://docs.rs/futures/0.1")]
 
 #[macro_use]
 extern crate futures_core;
 extern crate futures_sink;
+extern crate anchor_experiment;
 
 macro_rules! if_std {
     ($($i:item)*) => ($(

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -2,7 +2,8 @@ use std::prelude::v1::*;
 
 use std::mem;
 
-use futures_core::{Future, Poll, Async, Stream};
+use anchor_experiment::MovePinned;
+use futures_core::{Future, FutureMove, Poll, Async, Stream};
 
 /// A future which collects all of the values of a stream into a vector.
 ///
@@ -35,7 +36,13 @@ impl<S> Future for Collect<S>
     type Item = Vec<S::Item>;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Vec<S::Item>, S::Error> {
+    poll_safe!();
+}
+
+impl<S> FutureMove for Collect<S>
+    where S: Stream + MovePinned,
+{
+    fn poll_move(&mut self) -> Poll<Vec<S::Item>, S::Error> {
         loop {
             match self.stream.poll() {
                 Ok(Async::Ready(Some(e))) => self.items.push(e),


### PR DESCRIPTION
This branch adds support for "pinned" futures, which can contain
internal self-references. It is currently based on the API exposed by
the anchor_experiment crate.

It significantly adjusts the definition of future, creating two traits:

```
trait Future {
    type Item;
    type Error;

    unsafe fn poll_unsafe(&mut self) -> Poll<Self::Item, Self::Error>;
}

trait FutureMove: Future {
     fn poll_move(&mut self) -> Poll<Self::Item, Self::Error>;
}
```

All existing futures are `FutureMove`, and their `poll_unsafe` methods
can delegate to `poll_move`. There are some complications for
combinators and other futures that are generic over underlying futures.

Today, the crate provides a `poll_safe!()` helper, to generate a safe
implementation of the `poll_unsafe` method if your type implements
`FutureMove`.

An even more ideal adapter would be something that looks like this:

```
impl_future_safely! {
    impl Future for MyType {
        type Item = MyItem;
        type Error = MyError;
        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
            // ....
        }
    }
}
```

Then, users would just be able to wrap `impl_future_safely!` around
their existing implementations of `Future` and have upgraded.

This is not intended to be the final API of the Future trait. In
particular, we want to replace `poll_unsafe` with a safe method. That
API would look like this:

```
trait Future {
    type Item;
    type Error;

    fn poll(self: PinMut<Self>) -> Poll<Self::Item, Self::Error>;

}
```

However, that requires `arbitrary_self_types`, which cannot be used
currently for these reasons:

1. `futures` needs to run on stable. Its not clear how to cfg out the
   method with a `PinMut` receiver and still have everything work.
2. Arbitrary self types are not object safe yet, even on nightly. Its
   essential that the `Future` trait be object safe

These implementations exist to make it safe to call a self-referential
future:

- `impl<'a, F: ?Sized + Future> FutureMove for PinMut<'a, F>`
- `impl<F: ?Sized + Future> FutureMove for Anchor<Box<F>>`

This commit is not finished. In particular, the `futures-util` crate has
not been adapted to compile against this new version of `futures-core`.