### PR TITLE
 Add Context argument to lazy.

### DIFF
--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -158,7 +158,7 @@ impl<T> Inner<T> {
         }
     }
 
-    fn poll_cancel(&self) -> Poll<(), ()> {
+    fn poll_cancel(&self, _ctx: &mut task::Context) -> Poll<(), ()> {
         // Fast path up first, just read the flag and see if our other half is
         // gone. This flag is set both in our destructor and the oneshot
         // destructor, but our destructor hasn't run yet so if it's set then the
@@ -238,7 +238,7 @@ impl<T> Inner<T> {
         }
     }
 
-    fn recv(&self) -> Poll<T, Canceled> {
+    fn recv(&self, _ctx: &mut task::Context) -> Poll<T, Canceled> {
         let mut done = false;
 
         // Check to see if some data has arrived. If it hasn't then we need to
@@ -351,8 +351,8 @@ impl<T> Sender<T> {
     ///
     /// If you're calling this function from a context that does not have a
     /// task, then you can use the `is_canceled` API instead.
-    pub fn poll_cancel(&mut self) -> Poll<(), ()> {
-        self.inner.poll_cancel()
+    pub fn poll_cancel(&mut self, ctx: &mut task::Context) -> Poll<(), ()> {
+        self.inner.poll_cancel(ctx)
     }
 
     /// Tests to see whether this `Sender`'s corresponding `Receiver`
@@ -412,8 +412,8 @@ impl<T> Future for Receiver<T> {
     type Item = T;
     type Error = Canceled;
 
-    fn poll(&mut self) -> Poll<T, Canceled> {
-        self.inner.recv()
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<T, Canceled> {
+        self.inner.recv(ctx)
     }
 }
 

--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -7,6 +7,7 @@ use std::thread;
 
 use futures::prelude::*;
 use futures::future::result;
+use futures::task;
 use futures_executor::current_thread::run;
 use futures_channel::mpsc;
 
@@ -41,7 +42,7 @@ fn sequence() {
 fn drop_sender() {
     let (tx, mut rx) = mpsc::channel::<u32>(1);
     drop(tx);
-    match rx.poll() {
+    match rx.poll(&mut task::Context) {
         Ok(Async::Ready(None)) => {}
         _ => panic!("channel should be done"),
     }

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::prelude::*;
 use futures::future::lazy;
+use futures::task;
 use futures_channel::mpsc;
 use futures_channel::oneshot;
 use futures_executor::current_thread::run;
@@ -34,29 +35,29 @@ fn send_recv_no_buffer() {
 
     // Run on a task context
     let f = lazy(move || {
-        assert!(tx.flush().unwrap().is_ready());
-        assert!(tx.poll_ready().unwrap().is_ready());
+        assert!(tx.flush(&mut task::Context).unwrap().is_ready());
+        assert!(tx.poll_ready(&mut task::Context).unwrap().is_ready());
 
         // Send first message
-        let res = tx.start_send(1).unwrap();
+        let res = tx.start_send(&mut task::Context, 1).unwrap();
         assert!(res.is_ok());
-        assert!(tx.poll_ready().unwrap().is_not_ready());
+        assert!(tx.poll_ready(&mut task::Context).unwrap().is_not_ready());
 
         // Send second message
-        let res = tx.start_send(2).unwrap();
+        let res = tx.start_send(&mut task::Context, 2).unwrap();
         assert!(res.is_err());
 
         // Take the value
-        assert_eq!(rx.poll().unwrap(), Async::Ready(Some(1)));
-        assert!(tx.poll_ready().unwrap().is_ready());
+        assert_eq!(rx.poll(&mut task::Context).unwrap(), Async::Ready(Some(1)));
+        assert!(tx.poll_ready(&mut task::Context).unwrap().is_ready());
 
-        let res = tx.start_send(2).unwrap();
+        let res = tx.start_send(&mut task::Context, 2).unwrap();
         assert!(res.is_ok());
-        assert!(tx.poll_ready().unwrap().is_not_ready());
+        assert!(tx.poll_ready(&mut task::Context).unwrap().is_not_ready());
 
         // Take the value
-        assert_eq!(rx.poll().unwrap(), Async::Ready(Some(2)));
-        assert!(tx.poll_ready().unwrap().is_ready());
+        assert_eq!(rx.poll(&mut task::Context).unwrap(), Async::Ready(Some(2)));
+        assert!(tx.poll_ready(&mut task::Context).unwrap().is_ready());
 
         Ok::<(), ()>(())
     });
@@ -125,8 +126,8 @@ fn recv_close_gets_none() {
     let f = lazy(move || {
         rx.close();
 
-        assert_eq!(rx.poll(), Ok(Async::Ready(None)));
-        assert!(tx.poll_ready().is_err());
+        assert_eq!(rx.poll(&mut task::Context), Ok(Async::Ready(None)));
+        assert!(tx.poll_ready(&mut task::Context).is_err());
 
         drop(tx);
 
@@ -142,8 +143,8 @@ fn tx_close_gets_none() {
 
     // Run on a task context
     let f = lazy(move || {
-        assert_eq!(rx.poll(), Ok(Async::Ready(None)));
-        assert_eq!(rx.poll(), Ok(Async::Ready(None)));
+        assert_eq!(rx.poll(&mut task::Context), Ok(Async::Ready(None)));
+        assert_eq!(rx.poll(&mut task::Context), Ok(Async::Ready(None)));
 
         Ok::<(), ()>(())
     });
@@ -322,7 +323,7 @@ fn stress_receiver_multi_task_bounded_hard() {
                         // Just poll
                         let n = n.clone();
                         let f = lazy(move || {
-                            let r = match rx.poll().unwrap() {
+                            let r = match rx.poll(&mut task::Context).unwrap() {
                                 Async::Ready(Some(_)) => {
                                     n.fetch_add(1, Ordering::Relaxed);
                                     *lock = Some(rx);
@@ -443,12 +444,12 @@ fn stress_poll_ready() {
         type Item = ();
         type Error = ();
 
-        fn poll(&mut self) -> Poll<(), ()> {
+        fn poll(&mut self, ctx: &mut task::Context) -> Poll<(), ()> {
             // In a loop, check if the channel is ready. If so, push an item onto the channel
             // (asserting that it doesn't attempt to block).
             while self.count > 0 {
-                try_ready!(self.sender.poll_ready().map_err(|_| ()));
-                assert!(self.sender.start_send(self.count).unwrap().is_ok());
+                try_ready!(self.sender.poll_ready(ctx).map_err(|_| ()));
+                assert!(self.sender.start_send(ctx, self.count).unwrap().is_ok());
                 self.count -= 1;
             }
             Ok(Async::Ready(()))
@@ -523,7 +524,7 @@ fn try_send_2() {
     let th = thread::spawn(|| {
         run(|c| {
             c.block_on(lazy(|| {
-                assert!(tx.start_send("fail").unwrap().is_err());
+                assert!(tx.start_send(&mut task::Context, "fail").unwrap().is_err());
                 Ok::<_, ()>(())
             })).unwrap();
 

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -14,12 +14,12 @@ use futures_executor::current_thread::run;
 #[test]
 fn smoke_poll() {
     let (mut tx, rx) = channel::<u32>();
-    let f = lazy(|| {
-        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_not_ready());
-        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_not_ready());
+    let f = lazy(|ctx| {
+        assert!(tx.poll_cancel(ctx).unwrap().is_not_ready());
+        assert!(tx.poll_cancel(ctx).unwrap().is_not_ready());
         drop(rx);
-        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_ready());
-        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_ready());
+        assert!(tx.poll_cancel(ctx).unwrap().is_ready());
+        assert!(tx.poll_cancel(ctx).unwrap().is_ready());
         ok::<(), ()>(())
     });
 

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -7,6 +7,7 @@ use std::thread;
 
 use futures::future::{lazy, ok};
 use futures::prelude::*;
+use futures::task;
 use futures_channel::oneshot::*;
 use futures_executor::current_thread::run;
 
@@ -14,11 +15,11 @@ use futures_executor::current_thread::run;
 fn smoke_poll() {
     let (mut tx, rx) = channel::<u32>();
     let f = lazy(|| {
-        assert!(tx.poll_cancel().unwrap().is_not_ready());
-        assert!(tx.poll_cancel().unwrap().is_not_ready());
+        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_not_ready());
+        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_not_ready());
         drop(rx);
-        assert!(tx.poll_cancel().unwrap().is_ready());
-        assert!(tx.poll_cancel().unwrap().is_ready());
+        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_ready());
+        assert!(tx.poll_cancel(&mut task::Context).unwrap().is_ready());
         ok::<(), ()>(())
     });
 
@@ -44,8 +45,8 @@ impl Future for WaitForCancel {
     type Item = ();
     type Error = ();
 
-    fn poll(&mut self) -> Poll<(), ()> {
-        self.tx.poll_cancel()
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<(), ()> {
+        self.tx.poll_cancel(ctx)
     }
 }
 
@@ -78,8 +79,8 @@ fn cancel_lots() {
 fn close() {
     let (mut tx, mut rx) = channel::<u32>();
     rx.close();
-    assert!(rx.poll().is_err());
-    assert!(tx.poll_cancel().unwrap().is_ready());
+    assert!(rx.poll(&mut task::Context).is_err());
+    assert!(tx.poll_cancel(&mut task::Context).unwrap().is_ready());
 }
 
 #[test]
@@ -121,7 +122,7 @@ fn cancel_sends() {
         orx.close();
         // Not necessary to wrap in a task because the implementation of oneshot
         // never calls `task::current()` if the channel has been closed already.
-        let _ = orx.poll();
+        let _ = orx.poll(&mut task::Context);
     }
 
     drop(tx);

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -5,6 +5,7 @@
 //! `Box`, `Option`, and `Result`.
 
 use Poll;
+use task;
 
 mod option;
 #[path = "result.rs"]
@@ -163,15 +164,15 @@ pub trait Future {
     /// This future may have failed to finish the computation, in which case
     /// the `Err` variant will be returned with an appropriate payload of an
     /// error.
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error>;
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error>;
 }
 
 impl<'a, F: ?Sized + Future> Future for &'a mut F {
     type Item = F::Item;
     type Error = F::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        (**self).poll()
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+        (**self).poll(ctx)
     }
 }
 
@@ -180,8 +181,8 @@ if_std! {
         type Item = F::Item;
         type Error = F::Error;
 
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            (**self).poll()
+        fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+            (**self).poll(ctx)
         }
     }
 
@@ -190,8 +191,8 @@ if_std! {
         type Item = F::Item;
         type Error = F::Error;
 
-        fn poll(&mut self) -> Poll<F::Item, F::Error> {
-            self.0.poll()
+        fn poll(&mut self, ctx: &mut task::Context) -> Poll<F::Item, F::Error> {
+            self.0.poll(ctx)
         }
     }
 }

--- a/futures-core/src/future/option.rs
+++ b/futures-core/src/future/option.rs
@@ -1,6 +1,7 @@
 //! Definition of the `Option` (optional step) combinator
 
 use {Future, IntoFuture, Poll, Async};
+use task;
 
 use core::option;
 
@@ -27,10 +28,10 @@ impl<F, T, E> Future for Option<F> where F: Future<Item=T, Error=E> {
     type Item = option::Option<T>;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<option::Option<T>, E> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<option::Option<T>, E> {
         match self.inner {
             None => Ok(Async::Ready(None)),
-            Some(ref mut x) => x.poll().map(|x| x.map(Some)),
+            Some(ref mut x) => x.poll(ctx).map(|x| x.map(Some)),
         }
     }
 }

--- a/futures-core/src/future/result.rs
+++ b/futures-core/src/future/result.rs
@@ -1,4 +1,5 @@
 use {Future, IntoFuture, Poll, Async};
+use task;
 use core::result;
 
 /// A future representing a value that is immediately ready.
@@ -75,7 +76,7 @@ impl<T, E> Future for Result<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<T, E> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<T, E> {
         self.inner.take().expect("cannot poll Result twice").map(Async::Ready)
     }
 }

--- a/futures-core/src/never.rs
+++ b/futures-core/src/never.rs
@@ -1,6 +1,7 @@
 //! Definition and trait implementations for the `Never` type.
 
 use {Future, Stream, Poll};
+use task;
 
 /// A type that can never exist.
 /// This is used to indicate values which can never be created, such as the
@@ -21,7 +22,7 @@ impl Future for Never {
     type Item = Never;
     type Error = Never;
 
-    fn poll(&mut self) -> Poll<Never, Never> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Never, Never> {
         match *self {}
     }
 }
@@ -30,7 +31,7 @@ impl Stream for Never {
     type Item = Never;
     type Error = Never;
 
-    fn poll(&mut self) -> Poll<Option<Never>, Never> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Option<Never>, Never> {
         match *self {}
     }
 }

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -16,6 +16,7 @@
 //! [online]: https://tokio.rs/docs/getting-started/streams-and-sinks/
 
 use Poll;
+use task;
 
 /// A stream of values, not all of which may have been produced yet.
 ///
@@ -87,15 +88,15 @@ pub trait Stream {
     /// further calls to `poll` may result in a panic or other "bad behavior".
     /// If this is difficult to guard against then the `fuse` adapter can be
     /// used to ensure that `poll` always has well-defined semantics.
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error>;
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error>;
 }
 
 impl<'a, S: ?Sized + Stream> Stream for &'a mut S {
     type Item = S::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        (**self).poll()
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        (**self).poll(ctx)
     }
 }
 
@@ -104,8 +105,8 @@ if_std! {
         type Item = S::Item;
         type Error = S::Error;
 
-        fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-            (**self).poll()
+        fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+            (**self).poll(ctx)
         }
     }
 
@@ -113,8 +114,8 @@ if_std! {
         type Item = S::Item;
         type Error = S::Error;
 
-        fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
-            self.0.poll()
+        fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<S::Item>, S::Error> {
+            self.0.poll(ctx)
         }
     }
 }

--- a/futures-core/src/task.rs
+++ b/futures-core/src/task.rs
@@ -28,6 +28,7 @@
 //! it's ready to make progress through the `Task::notify` method.
 pub use task_impl::{
     // Types
+    Context,
     NotifyHandle,
     Spawn,
     Task,

--- a/futures-cpupool/src/pool.rs
+++ b/futures-cpupool/src/pool.rs
@@ -209,7 +209,7 @@ impl CpuPool {
               R::Item: Send + 'static,
               R::Error: Send + 'static,
     {
-        self.spawn(lazy(f))
+        self.spawn(lazy(|_| f()))
     }
 }
 

--- a/futures-cpupool/src/pool.rs
+++ b/futures-cpupool/src/pool.rs
@@ -267,8 +267,8 @@ impl<T: Send + 'static, E: Send + 'static> Future for CpuFuture<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<T, E> {
-        match self.inner.poll().expect("cannot poll CpuFuture twice") {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<T, E> {
+        match self.inner.poll(ctx).expect("cannot poll CpuFuture twice") {
             Async::Ready(Ok(Ok(e))) => Ok(e.into()),
             Async::Ready(Ok(Err(e))) => Err(e),
             Async::Ready(Err(e)) => panic::resume_unwind(e),
@@ -281,15 +281,15 @@ impl<F: Future> Future for MySender<F, Result<F::Item, F::Error>> {
     type Item = ();
     type Error = ();
 
-    fn poll(&mut self) -> Poll<(), ()> {
-        if let Ok(Async::Ready(_)) = self.tx.as_mut().unwrap().poll_cancel() {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<(), ()> {
+        if let Ok(Async::Ready(_)) = self.tx.as_mut().unwrap().poll_cancel(ctx) {
             if !self.keep_running_flag.load(Ordering::SeqCst) {
                 // Cancelled, bail out
                 return Ok(().into())
             }
         }
 
-        let res = match self.fut.poll() {
+        let res = match self.fut.poll(ctx) {
             Ok(Async::Ready(e)) => Ok(e),
             Ok(Async::Pending) => return Ok(Async::Pending),
             Err(e) => Err(e),

--- a/futures-executor/benches/poll.rs
+++ b/futures-executor/benches/poll.rs
@@ -33,7 +33,7 @@ fn task_init(b: &mut Bencher) {
         type Item = ();
         type Error = ();
 
-        fn poll(&mut self) -> Poll<(), ()> {
+        fn poll(&mut self, _ctx: &mut task::Context) -> Poll<(), ()> {
             if self.num == NUM {
                 Ok(Async::Ready(()))
             } else {

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -22,7 +22,7 @@ fn thread_yield_single_thread_one_wait(b: &mut Bencher) {
         type Item = ();
         type Error = ();
 
-        fn poll(&mut self) -> Poll<(), ()> {
+        fn poll(&mut self, _ctx: &mut task::Context) -> Poll<(), ()> {
             if self.rem == 0 {
                 Ok(Async::Ready(()))
             } else {
@@ -51,7 +51,7 @@ fn thread_yield_single_thread_many_wait(b: &mut Bencher) {
         type Item = ();
         type Error = ();
 
-        fn poll(&mut self) -> Poll<(), ()> {
+        fn poll(&mut self, _ctx: &mut task::Context) -> Poll<(), ()> {
             if self.rem == 0 {
                 Ok(Async::Ready(()))
             } else {
@@ -88,7 +88,7 @@ fn thread_yield_multi_thread(b: &mut Bencher) {
         type Item = ();
         type Error = ();
 
-        fn poll(&mut self) -> Poll<(), ()> {
+        fn poll(&mut self, _ctx: &mut task::Context) -> Poll<(), ()> {
             if self.rem == 0 {
                 Ok(Async::Ready(()))
             } else {

--- a/futures-executor/src/task_runner.rs
+++ b/futures-executor/src/task_runner.rs
@@ -297,7 +297,7 @@ impl Future for SpawnedFuture {
     type Item = bool;
     type Error = bool;
 
-    fn poll(&mut self) -> Poll<bool, bool> {
-        self.inner.with_task_data(|f| f.poll())
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<bool, bool> {
+        self.inner.with_task_data(|f| f.poll(ctx))
     }
 }

--- a/futures-executor/tests/current_thread.rs
+++ b/futures-executor/tests/current_thread.rs
@@ -83,7 +83,7 @@ impl Future for Never {
     type Item = ();
     type Error = ();
 
-    fn poll(&mut self) -> Poll<(), ()> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<(), ()> {
         Ok(Async::Pending)
     }
 }
@@ -135,7 +135,7 @@ fn tasks_are_scheduled_fairly() {
         type Item = ();
         type Error = ();
 
-        fn poll(&mut self) -> Poll<(), ()> {
+        fn poll(&mut self, _ctx: &mut task::Context) -> Poll<(), ()> {
             let mut state = self.state.borrow_mut();
 
             if self.idx == 0 {

--- a/futures-executor/tests/current_thread.rs
+++ b/futures-executor/tests/current_thread.rs
@@ -20,7 +20,7 @@ fn spawning_from_init_future() {
     run(|_| {
         let cnt = cnt.clone();
 
-        spawn(lazy(move || {
+        spawn(lazy(move |_| {
             cnt.set(1 + cnt.get());
             Ok(())
         }));
@@ -55,7 +55,7 @@ fn block_waits_for_non_daemon() {
 #[test]
 #[should_panic]
 fn spawning_out_of_executor_context() {
-    spawn(lazy(|| Ok(())));
+    spawn(lazy(|_| Ok(())));
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn spawn_many() {
     run(|_| {
         for _ in 0..ITER {
             let cnt = cnt.clone();
-            spawn(lazy(move || {
+            spawn(lazy(move |_| {
                 cnt.set(1 + cnt.get());
                 Ok::<(), ()>(())
             }));
@@ -114,7 +114,7 @@ fn nesting_run() {
 #[should_panic]
 fn run_in_future() {
     run(|_| {
-        spawn(lazy(|| {
+        spawn(lazy(|_| {
             run(|_| {
             });
             Ok::<(), ()>(())

--- a/futures-util/benches/bilock.rs
+++ b/futures-util/benches/bilock.rs
@@ -48,8 +48,8 @@ impl Stream for LockStream {
     type Item = BiLockAcquired<u32>;
     type Error = ();
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        self.lock.poll().map(|a| match a {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        self.lock.poll(ctx).map(|a| match a {
             Async::Ready(a) => Async::Ready(Some(a)),
             Async::Pending => Async::Pending,
         })

--- a/futures-util/benches/futures_unordered.rs
+++ b/futures-util/benches/futures_unordered.rs
@@ -8,6 +8,7 @@ extern crate test;
 use futures::prelude::*;
 use futures::future;
 use futures::stream::FuturesUnordered;
+use futures::task;
 use futures_channel::oneshot;
 use futures_executor::current_thread::run;
 
@@ -39,7 +40,7 @@ fn oneshots(b: &mut Bencher) {
         run(|c| {
             let f = future::lazy(move || {
                 loop {
-                    if let Ok(Async::Ready(None)) = rxs.poll() {
+                    if let Ok(Async::Ready(None)) = rxs.poll(&mut task::Context) {
                         return Ok::<(), ()>(());
                     }
                 }

--- a/futures-util/src/future/and_then.rs
+++ b/futures-util/src/future/and_then.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, IntoFuture, Poll};
+use futures_core::task;
 
 use super::chain::Chain;
 
@@ -29,8 +30,8 @@ impl<A, B, F> Future for AndThen<A, B, F>
     type Item = B::Item;
     type Error = B::Error;
 
-    fn poll(&mut self) -> Poll<B::Item, B::Error> {
-        self.state.poll(|result, f| {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<B::Item, B::Error> {
+        self.state.poll(ctx, |result, f| {
             result.map(|e| {
                 Err(f(e).into_future())
             })

--- a/futures-util/src/future/chain.rs
+++ b/futures-util/src/future/chain.rs
@@ -1,7 +1,9 @@
 use core::mem;
 
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
+#[must_use = "futures do nothing unless polled"]
 #[derive(Debug)]
 pub enum Chain<A, B, C> where A: Future {
     First(A, C),
@@ -17,19 +19,19 @@ impl<A, B, C> Chain<A, B, C>
         Chain::First(a, c)
     }
 
-    pub fn poll<F>(&mut self, f: F) -> Poll<B::Item, B::Error>
+    pub fn poll<F>(&mut self, ctx: &mut task::Context, f: F) -> Poll<B::Item, B::Error>
         where F: FnOnce(Result<A::Item, A::Error>, C)
                         -> Result<Result<B::Item, B>, B::Error>,
     {
         let a_result = match *self {
             Chain::First(ref mut a, _) => {
-                match a.poll() {
+                match a.poll(ctx) {
                     Ok(Async::Pending) => return Ok(Async::Pending),
                     Ok(Async::Ready(t)) => Ok(t),
                     Err(e) => Err(e),
                 }
             }
-            Chain::Second(ref mut b) => return b.poll(),
+            Chain::Second(ref mut b) => return b.poll(ctx),
             Chain::Done => panic!("cannot poll a chained future twice"),
         };
         let data = match mem::replace(self, Chain::Done) {
@@ -39,7 +41,7 @@ impl<A, B, C> Chain<A, B, C>
         match f(a_result, data)? {
             Ok(e) => Ok(Async::Ready(e)),
             Err(mut b) => {
-                let ret = b.poll();
+                let ret = b.poll(ctx);
                 *self = Chain::Second(b);
                 ret
             }

--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, Poll};
+use futures_core::task;
 
 /// Combines two different futures yielding the same item and error
 /// types into a single type.
@@ -30,10 +31,10 @@ impl<A, B> Future for Either<A, B>
     type Item = A::Item;
     type Error = A::Error;
 
-    fn poll(&mut self) -> Poll<A::Item, A::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<A::Item, A::Error> {
         match *self {
-            Either::A(ref mut a) => a.poll(),
-            Either::B(ref mut b) => b.poll(),
+            Either::A(ref mut a) => a.poll(ctx),
+            Either::B(ref mut b) => b.poll(ctx),
         }
     }
 }

--- a/futures-util/src/future/empty.rs
+++ b/futures-util/src/future/empty.rs
@@ -3,6 +3,7 @@
 use core::marker;
 
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
 /// A future which is never resolved.
 ///
@@ -25,7 +26,7 @@ impl<T, E> Future for Empty<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<T, E> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<T, E> {
         Ok(Async::Pending)
     }
 }

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use futures_core::{Future, IntoFuture, Poll};
+use futures_core::task;
 
 use super::chain::Chain;
 
@@ -42,8 +43,8 @@ impl<A> Future for Flatten<A>
     type Item = <<A as Future>::Item as IntoFuture>::Item;
     type Error = <<A as Future>::Item as IntoFuture>::Error;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.state.poll(|a, ()| {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+        self.state.poll(ctx, |a, ()| {
             let future = a?.into_future();
             Ok(Err(future))
         })

--- a/futures-util/src/future/flatten_stream.rs
+++ b/futures-util/src/future/flatten_stream.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use futures_core::{Async, Future, Poll, Stream};
+use futures_core::task;
 
 /// Future for the `flatten_stream` combinator, flattening a
 /// future-of-a-stream to get just the result of the final stream as a stream.
@@ -56,11 +57,11 @@ impl<F> Stream for FlattenStream<F>
     type Item = <F::Item as Stream>::Item;
     type Error = <F::Item as Stream>::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         loop {
             let (next_state, ret_opt) = match self.state {
                 State::Future(ref mut f) => {
-                    match f.poll() {
+                    match f.poll(ctx) {
                         Ok(Async::Pending) => {
                             // State is not changed, early return.
                             return Ok(Async::Pending)
@@ -79,7 +80,7 @@ impl<F> Stream for FlattenStream<F>
                 State::Stream(ref mut s) => {
                     // Just forward call to the stream,
                     // do not track its state.
-                    return s.poll();
+                    return s.poll(ctx);
                 }
                 State::Eof => {
                     (State::Done, Some(Ok(Async::Ready(None))))

--- a/futures-util/src/future/from_err.rs
+++ b/futures-util/src/future/from_err.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
 /// Future for the `from_err` combinator, changing the error type of a future.
 ///
@@ -25,8 +26,8 @@ impl<A:Future, E:From<A::Error>> Future for FromErr<A, E> {
     type Item = A::Item;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<A::Item, E> {
-        let e = match self.future.poll() {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<A::Item, E> {
+        let e = match self.future.poll(ctx) {
             Ok(Async::Pending) => return Ok(Async::Pending),
             other => other,
         };

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
 /// A future which "fuses" a future once it's been resolved.
 ///
@@ -23,8 +24,8 @@ impl<A: Future> Future for Fuse<A> {
     type Item = A::Item;
     type Error = A::Error;
 
-    fn poll(&mut self) -> Poll<A::Item, A::Error> {
-        let res = self.future.as_mut().map(|f| f.poll());
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<A::Item, A::Error> {
+        let res = self.future.as_mut().map(|f| f.poll(ctx));
         match res.unwrap_or(Ok(Async::Pending)) {
             res @ Ok(Async::Ready(_)) |
             res @ Err(_) => {

--- a/futures-util/src/future/inspect.rs
+++ b/futures-util/src/future/inspect.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
 /// Do something with the item of a future, passing it on.
 ///
@@ -27,8 +28,8 @@ impl<A, F> Future for Inspect<A, F>
     type Item = A::Item;
     type Error = A::Error;
 
-    fn poll(&mut self) -> Poll<A::Item, A::Error> {
-        match self.future.poll() {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<A::Item, A::Error> {
+        match self.future.poll(ctx) {
             Ok(Async::Pending) => Ok(Async::Pending),
             Ok(Async::Ready(e)) => {
                 (self.f.take().expect("cannot poll Inspect twice"))(&e);

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -38,16 +38,16 @@ enum _Lazy<F, R> {
 /// use futures::future;
 ///
 /// # fn main() {
-/// let a = future::lazy(|| future::ok::<u32, u32>(1));
+/// let a = future::lazy(|_| future::ok::<u32, u32>(1));
 ///
-/// let b = future::lazy(|| -> future::Result<u32, u32> {
+/// let b = future::lazy(|_| -> future::Result<u32, u32> {
 ///     panic!("oh no!")
 /// });
 /// drop(b); // closure is never run
 /// # }
 /// ```
 pub fn lazy<F, R>(f: F) -> Lazy<F, R>
-    where F: FnOnce() -> R,
+    where F: FnOnce(&mut task::Context) -> R,
           R: IntoFuture
 {
     Lazy {
@@ -56,17 +56,17 @@ pub fn lazy<F, R>(f: F) -> Lazy<F, R>
 }
 
 impl<F, R> Lazy<F, R>
-    where F: FnOnce() -> R,
+    where F: FnOnce(&mut task::Context) -> R,
           R: IntoFuture,
 {
-    fn get(&mut self) -> &mut R::Future {
+    fn get(&mut self, ctx: &mut task::Context) -> &mut R::Future {
         match self.inner {
             _Lazy::First(_) => {}
             _Lazy::Second(ref mut f) => return f,
             _Lazy::Moved => panic!(), // can only happen if `f()` panics
         }
         match mem::replace(&mut self.inner, _Lazy::Moved) {
-            _Lazy::First(f) => self.inner = _Lazy::Second(f().into_future()),
+            _Lazy::First(f) => self.inner = _Lazy::Second(f(ctx).into_future()),
             _ => panic!(), // we already found First
         }
         match self.inner {
@@ -77,13 +77,13 @@ impl<F, R> Lazy<F, R>
 }
 
 impl<F, R> Future for Lazy<F, R>
-    where F: FnOnce() -> R,
+    where F: FnOnce(&mut task::Context) -> R,
           R: IntoFuture,
 {
     type Item = R::Item;
     type Error = R::Error;
 
     fn poll(&mut self, ctx: &mut task::Context) -> Poll<R::Item, R::Error> {
-        self.get().poll(ctx)
+        self.get(ctx).poll(ctx)
     }
 }

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -4,6 +4,7 @@
 use core::mem;
 
 use futures_core::{Future, IntoFuture, Poll};
+use futures_core::task;
 
 /// A future which defers creation of the actual future until a callback is
 /// scheduled.
@@ -82,7 +83,7 @@ impl<F, R> Future for Lazy<F, R>
     type Item = R::Item;
     type Error = R::Error;
 
-    fn poll(&mut self) -> Poll<R::Item, R::Error> {
-        self.get().poll()
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<R::Item, R::Error> {
+        self.get().poll(ctx)
     }
 }

--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
 /// Future for the `map` combinator, changing the type of a future.
 ///
@@ -26,8 +27,8 @@ impl<U, A, F> Future for Map<A, F>
     type Item = U;
     type Error = A::Error;
 
-    fn poll(&mut self) -> Poll<U, A::Error> {
-        let e = match self.future.poll() {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<U, A::Error> {
+        let e = match self.future.poll(ctx) {
             Ok(Async::Pending) => return Ok(Async::Pending),
             Ok(Async::Ready(e)) => Ok(e),
             Err(e) => Err(e),

--- a/futures-util/src/future/map_err.rs
+++ b/futures-util/src/future/map_err.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, Poll, Async};
+use futures_core::task;
 
 /// Future for the `map_err` combinator, changing the error type of a future.
 ///
@@ -26,8 +27,8 @@ impl<U, A, F> Future for MapErr<A, F>
     type Item = A::Item;
     type Error = U;
 
-    fn poll(&mut self) -> Poll<A::Item, U> {
-        let e = match self.future.poll() {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<A::Item, U> {
+        let e = match self.future.poll(ctx) {
             Ok(Async::Pending) => return Ok(Async::Pending),
             other => other,
         };

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -802,7 +802,7 @@ pub trait FutureExt: Future {
     ///     let mut future = future::ok::<i32, u32>(2);
     ///     assert!(c.block_on(future.catch_unwind()).is_ok());
     ///
-    ///     let mut future = future::lazy(|| -> future::Result<i32, u32> {
+    ///     let mut future = future::lazy(|_| -> future::Result<i32, u32> {
     ///         panic!();
     ///         future::ok::<i32, u32>(2)
     ///     });

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -720,18 +720,19 @@ pub trait FutureExt: Future {
     /// # extern crate futures;
     /// use futures::prelude::*;
     /// use futures::future;
+    /// use futures::task;
     ///
     /// # fn main() {
     /// let mut future = future::ok::<i32, u32>(2);
-    /// assert_eq!(future.poll(), Ok(Async::Ready(2)));
+    /// assert_eq!(future.poll(&mut task::Context), Ok(Async::Ready(2)));
     ///
     /// // Normally, a call such as this would panic:
     /// //future.poll();
     ///
     /// // This, however, is guaranteed to not panic
     /// let mut future = future::ok::<i32, u32>(2).fuse();
-    /// assert_eq!(future.poll(), Ok(Async::Ready(2)));
-    /// assert_eq!(future.poll(), Ok(Async::Pending));
+    /// assert_eq!(future.poll(&mut task::Context), Ok(Async::Ready(2)));
+    /// assert_eq!(future.poll(&mut task::Context), Ok(Async::Pending));
     /// # }
     /// ```
     fn fuse(self) -> Fuse<Self>

--- a/futures-util/src/future/or_else.rs
+++ b/futures-util/src/future/or_else.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, IntoFuture, Poll};
+use futures_core::task;
 use super::chain::Chain;
 
 /// Future for the `or_else` combinator, chaining a computation onto the end of
@@ -28,8 +29,8 @@ impl<A, B, F> Future for OrElse<A, B, F>
     type Item = B::Item;
     type Error = B::Error;
 
-    fn poll(&mut self) -> Poll<B::Item, B::Error> {
-        self.state.poll(|a, f| {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<B::Item, B::Error> {
+        self.state.poll(ctx, |a, f| {
             match a {
                 Ok(item) => Ok(Ok(item)),
                 Err(e) => Ok(Err(f(e).into_future()))

--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::prelude::v1::*;
 
 use futures_core::{Future, IntoFuture, Poll, Async};
+use futures_core::task;
 
 /// Future for the `select_all` combinator, waiting for one of any of a list of
 /// futures to complete.
@@ -48,9 +49,9 @@ impl<A> Future for SelectAll<A>
     type Item = (A::Item, usize, Vec<A>);
     type Error = (A::Error, usize, Vec<A>);
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
         let item = self.inner.iter_mut().enumerate().filter_map(|(i, f)| {
-            match f.poll() {
+            match f.poll(ctx) {
                 Ok(Async::Pending) => None,
                 Ok(Async::Ready(e)) => Some((i, Ok(e))),
                 Err(e) => Some((i, Err(e))),

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -99,7 +99,7 @@ impl<F> Shared<F> where F: Future {
         }
     }
 
-    fn set_waiter(&mut self) {
+    fn set_waiter(&mut self, _ctx: &mut task::Context) {
         let mut waiters = self.inner.notifier.waiters.lock().unwrap();
         waiters.insert(self.waiter, task::current());
     }
@@ -125,8 +125,8 @@ impl<F> Future for Shared<F>
     type Item = SharedItem<F::Item>;
     type Error = SharedError<F::Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.set_waiter();
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+        self.set_waiter(ctx);
 
         match self.inner.notifier.state.compare_and_swap(IDLE, POLLING, SeqCst) {
             IDLE => {

--- a/futures-util/src/future/then.rs
+++ b/futures-util/src/future/then.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, IntoFuture, Poll};
+use futures_core::task;
 use super::chain::Chain;
 
 /// Future for the `then` combinator, chaining computations on the end of
@@ -28,8 +29,8 @@ impl<A, B, F> Future for Then<A, B, F>
     type Item = B::Item;
     type Error = B::Error;
 
-    fn poll(&mut self) -> Poll<B::Item, B::Error> {
-        self.state.poll(|a, f| {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<B::Item, B::Error> {
+        self.state.poll(ctx, |a, f| {
             Ok(Err(f(a).into_future()))
         })
     }

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -1,4 +1,5 @@
 use futures_core::{Poll, Async, Future};
+use futures_core::task;
 use futures_sink::Sink;
 
 /// Future for the `close` combinator, which polls the sink until all data has
@@ -40,9 +41,9 @@ impl<S: Sink> Future for Close<S> {
     type Item = S;
     type Error = S::SinkError;
 
-    fn poll(&mut self) -> Poll<S, S::SinkError> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<S, S::SinkError> {
         let mut sink = self.sink.take().expect("Attempted to poll Close after it completed");
-        if sink.close()?.is_ready() {
+        if sink.close(ctx)?.is_ready() {
             Ok(Async::Ready(sink))
         } else {
             self.sink = Some(sink);

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -2,6 +2,7 @@ use core::fmt::{Debug, Formatter, Result as FmtResult};
 use core::mem::replace;
 
 use futures_core::{Async, Poll};
+use futures_core::task;
 use futures_sink::{AsyncSink, Sink, StartSend};
 
 /// Sink that clones incoming items and forwards them to two sinks at the same time.
@@ -52,24 +53,25 @@ impl<A, B> Sink for Fanout<A, B>
 
     fn start_send(
         &mut self,
+        ctx: &mut task::Context,
         item: Self::SinkItem
     ) -> StartSend<Self::SinkItem, Self::SinkError> {
         // Attempt to complete processing any outstanding requests.
-        self.left.keep_flushing()?;
-        self.right.keep_flushing()?;
+        self.left.keep_flushing(ctx)?;
+        self.right.keep_flushing(ctx)?;
         // Only if both downstream sinks are ready, start sending the next item.
         if self.left.is_ready() && self.right.is_ready() {
-            self.left.state = self.left.sink.start_send(item.clone())?;
-            self.right.state = self.right.sink.start_send(item)?;
+            self.left.state = self.left.sink.start_send(ctx, item.clone())?;
+            self.right.state = self.right.sink.start_send(ctx, item)?;
             Ok(AsyncSink::Ready)
         } else {
             Ok(AsyncSink::Pending(item))
         }
     }
 
-    fn flush(&mut self) -> Poll<(), Self::SinkError> {
-        let left_async = self.left.flush()?;
-        let right_async = self.right.flush()?;
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        let left_async = self.left.flush(ctx)?;
+        let right_async = self.right.flush(ctx)?;
         // Only if both downstream sinks are ready, signal readiness.
         if left_async.is_ready() && right_async.is_ready() {
             Ok(Async::Ready(()))
@@ -78,9 +80,9 @@ impl<A, B> Sink for Fanout<A, B>
         }
     }
 
-    fn close(&mut self) -> Poll<(), Self::SinkError> {
-        let left_async = self.left.close()?;
-        let right_async = self.right.close()?;
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        let left_async = self.left.close(ctx)?;
+        let right_async = self.right.close(ctx)?;
         // Only if both downstream sinks are ready, signal readiness.
         if left_async.is_ready() && right_async.is_ready() {
             Ok(Async::Ready(()))
@@ -105,16 +107,16 @@ impl<S: Sink> Downstream<S> {
         self.state.is_ready()
     }
 
-    fn keep_flushing(&mut self) -> Result<(), S::SinkError> {
+    fn keep_flushing(&mut self, ctx: &mut task::Context) -> Result<(), S::SinkError> {
         if let AsyncSink::Pending(item) = replace(&mut self.state, AsyncSink::Ready) {
-            self.state = self.sink.start_send(item)?;
+            self.state = self.sink.start_send(ctx, item)?;
         }
         Ok(())
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.keep_flushing()?;
-        let async = self.sink.flush()?;
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.keep_flushing(ctx)?;
+        let async = self.sink.flush(ctx)?;
         // Only if all values have been sent _and_ the underlying
         // sink is completely flushed, signal readiness.
         if self.state.is_ready() && async.is_ready() {
@@ -124,11 +126,11 @@ impl<S: Sink> Downstream<S> {
         }
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.keep_flushing()?;
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.keep_flushing(ctx)?;
         // If all items have been flushed, initiate close.
         if self.state.is_ready() {
-            self.sink.close()
+            self.sink.close(ctx)
         } else {
             Ok(Async::Pending)
         }

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -1,4 +1,5 @@
 use futures_core::{Poll, Async, Future};
+use futures_core::task;
 use futures_sink::Sink;
 
 /// Future for the `flush` combinator, which polls the sink until all data
@@ -43,9 +44,9 @@ impl<S: Sink> Future for Flush<S> {
     type Item = S;
     type Error = S::SinkError;
 
-    fn poll(&mut self) -> Poll<S, S::SinkError> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<S, S::SinkError> {
         let mut sink = self.sink.take().expect("Attempted to poll Flush after it completed");
-        if sink.flush()?.is_ready() {
+        if sink.flush(ctx)?.is_ready() {
             Ok(Async::Ready(sink))
         } else {
             self.sink = Some(sink);

--- a/futures-util/src/stream/and_then.rs
+++ b/futures-util/src/stream/and_then.rs
@@ -1,4 +1,5 @@
 use futures_core::{IntoFuture, Future, Poll, Async, Stream};
+use futures_core::task;
 use futures_sink::{Sink, StartSend};
 
 /// A stream combinator which chains a computation onto values produced by a
@@ -61,16 +62,16 @@ impl<S, F, U: IntoFuture> Sink for AndThen<S, F, U>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }
 
@@ -82,16 +83,16 @@ impl<S, F, U> Stream for AndThen<S, F, U>
     type Item = U::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<U::Item>, S::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<U::Item>, S::Error> {
         if self.future.is_none() {
-            let item = match try_ready!(self.stream.poll()) {
+            let item = match try_ready!(self.stream.poll(ctx)) {
                 None => return Ok(Async::Ready(None)),
                 Some(e) => e,
             };
             self.future = Some((self.f)(item).into_future());
         }
         assert!(self.future.is_some());
-        match self.future.as_mut().unwrap().poll() {
+        match self.future.as_mut().unwrap().poll(ctx) {
             Ok(Async::Ready(e)) => {
                 self.future = None;
                 Ok(Async::Ready(Some(e)))

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use futures_core::{Async, IntoFuture, Poll, Stream};
+use futures_core::task;
 use futures_sink::{Sink, StartSend};
 
 use stream::{Fuse, FuturesUnordered};
@@ -81,11 +82,11 @@ impl<S> Stream for BufferUnordered<S>
     type Item = <S::Item as IntoFuture>::Item;
     type Error = <S as Stream>::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         // First up, try to spawn off as many futures as possible by filling up
         // our slab of futures.
         while self.queue.len() < self.max {
-            let future = match self.stream.poll()? {
+            let future = match self.stream.poll(ctx)? {
                 Async::Ready(Some(s)) => s.into_future(),
                 Async::Ready(None) |
                 Async::Pending => break,
@@ -95,7 +96,7 @@ impl<S> Stream for BufferUnordered<S>
         }
 
         // Try polling a new future
-        if let Some(val) = try_ready!(self.queue.poll()) {
+        if let Some(val) = try_ready!(self.queue.poll(ctx)) {
             return Ok(Async::Ready(Some(val)));
         }
 
@@ -118,15 +119,15 @@ impl<S> Sink for BufferUnordered<S>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }

--- a/futures-util/src/stream/catch_unwind.rs
+++ b/futures-util/src/stream/catch_unwind.rs
@@ -4,6 +4,7 @@ use std::panic::{catch_unwind, UnwindSafe};
 use std::mem;
 
 use futures_core::{Poll, Async, Stream};
+use futures_core::task;
 
 /// Stream for the `catch_unwind` combinator.
 ///
@@ -35,7 +36,7 @@ impl<S> Stream for CatchUnwind<S>
     type Item = Result<S::Item, S::Error>;
     type Error = Box<Any + Send>;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, _ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         let mut stream = match mem::replace(&mut self.state, CatchUnwindState::Eof) {
             CatchUnwindState::Done => panic!("cannot poll after eof"),
             CatchUnwindState::Eof => {
@@ -44,7 +45,8 @@ impl<S> Stream for CatchUnwind<S>
             }
             CatchUnwindState::Stream(stream) => stream,
         };
-        let res = catch_unwind(|| (stream.poll(), stream));
+        // FIXME: fix passing the actual context here.
+        let res = catch_unwind(|| (stream.poll(&mut task::Context), stream));
         match res {
             Err(e) => Err(e), // and state is already Eof
             Ok((poll, stream)) => {

--- a/futures-util/src/stream/chain.rs
+++ b/futures-util/src/stream/chain.rs
@@ -1,6 +1,7 @@
 use core::mem;
 
 use futures_core::{Stream, Async, Poll};
+use futures_core::task;
 
 /// State of chain stream.
 #[derive(Debug)]
@@ -35,14 +36,14 @@ impl<S1, S2> Stream for Chain<S1, S2>
     type Item = S1::Item;
     type Error = S1::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         loop {
             match self.state {
-                State::First(ref mut s1, ref _s2) => match s1.poll() {
+                State::First(ref mut s1, ref _s2) => match s1.poll(ctx) {
                     Ok(Async::Ready(None)) => (), // roll
                     x => return x,
                 },
-                State::Second(ref mut s2) => return s2.poll(),
+                State::Second(ref mut s2) => return s2.poll(ctx),
                 State::Temp => unreachable!(),
             }
 

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -3,6 +3,7 @@ use std::prelude::v1::*;
 use std::mem;
 
 use futures_core::{Future, Poll, Async, Stream};
+use futures_core::task;
 
 /// A future which collects all of the values of a stream into a vector.
 ///
@@ -35,9 +36,9 @@ impl<S> Future for Collect<S>
     type Item = Vec<S::Item>;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Vec<S::Item>, S::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Vec<S::Item>, S::Error> {
         loop {
-            match self.stream.poll() {
+            match self.stream.poll(ctx) {
                 Ok(Async::Ready(Some(e))) => self.items.push(e),
                 Ok(Async::Ready(None)) => return Ok(Async::Ready(self.finish())),
                 Ok(Async::Pending) => return Ok(Async::Pending),

--- a/futures-util/src/stream/empty.rs
+++ b/futures-util/src/stream/empty.rs
@@ -1,6 +1,7 @@
 use core::marker;
 
 use futures_core::{Stream, Poll, Async};
+use futures_core::task;
 
 /// A stream which contains no elements.
 ///
@@ -22,7 +23,7 @@ impl<T, E> Stream for Empty<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         Ok(Async::Ready(None))
     }
 }

--- a/futures-util/src/stream/future.rs
+++ b/futures-util/src/stream/future.rs
@@ -1,4 +1,5 @@
 use futures_core::{Future, Poll, Async, Stream};
+use futures_core::task;
 
 /// A combinator used to temporarily convert a stream into a future.
 ///
@@ -57,10 +58,10 @@ impl<S: Stream> Future for StreamFuture<S> {
     type Item = (Option<S::Item>, S);
     type Error = (S::Error, S);
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
         let item = {
             let s = self.stream.as_mut().expect("polling StreamFuture twice");
-            match s.poll() {
+            match s.poll(ctx) {
                 Ok(Async::Pending) => return Ok(Async::Pending),
                 Ok(Async::Ready(e)) => Ok(e),
                 Err(e) => Err(e),

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -266,7 +266,7 @@ impl<T> Stream for FuturesUnordered<T>
     type Item = T::Item;
     type Error = T::Error;
 
-    fn poll(&mut self) -> Poll<Option<T::Item>, T::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<T::Item>, T::Error> {
         // Ensure `parent` is correctly set.
         self.inner.parent.register();
 
@@ -359,7 +359,7 @@ impl<T> Stream for FuturesUnordered<T>
                 let res = {
                     let notify = NodeToHandle(bomb.node.as_ref().unwrap());
                     task::with_notify(&notify, 0, || {
-                        future.poll()
+                        future.poll(ctx)
                     })
                 };
 

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -1,4 +1,5 @@
 use futures_core::{Stream, Poll, Async};
+use futures_core::task;
 use futures_sink::{Sink, StartSend};
 
 /// Do something with the items of a stream, passing it on.
@@ -53,16 +54,16 @@ impl<S, F> Sink for Inspect<S, F>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }
 
@@ -73,8 +74,8 @@ impl<S, F> Stream for Inspect<S, F>
     type Item = S::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
-        match try_ready!(self.stream.poll()) {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<S::Item>, S::Error> {
+        match try_ready!(self.stream.poll(ctx)) {
             Some(e) => {
                 (self.inspect)(&e);
                 Ok(Async::Ready(Some(e)))

--- a/futures-util/src/stream/iter_ok.rs
+++ b/futures-util/src/stream/iter_ok.rs
@@ -1,6 +1,7 @@
 use core::marker;
 
 use futures_core::{Async, Poll, Stream};
+use futures_core::task;
 
 /// A stream which is just a shim over an underlying instance of `Iterator`.
 ///
@@ -47,7 +48,7 @@ impl<I, E> Stream for IterOk<I, E>
     type Item = I::Item;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<Option<I::Item>, E> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Option<I::Item>, E> {
         Ok(Async::Ready(self.iter.next()))
     }
 }

--- a/futures-util/src/stream/iter_result.rs
+++ b/futures-util/src/stream/iter_result.rs
@@ -1,4 +1,5 @@
 use futures_core::{Async, Poll, Stream};
+use futures_core::task;
 
 /// A stream which is just a shim over an underlying instance of `Iterator`.
 ///
@@ -52,7 +53,7 @@ where
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<Option<T>, E> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Option<T>, E> {
         match self.iter.next() {
             Some(Ok(e)) => Ok(Async::Ready(Some(e))),
             Some(Err(e)) => Err(e),

--- a/futures-util/src/stream/map_err.rs
+++ b/futures-util/src/stream/map_err.rs
@@ -1,4 +1,5 @@
 use futures_core::{Poll, Stream};
+use futures_core::task;
 use futures_sink::{Sink, StartSend};
 
 /// A stream combinator which will change the error type of a stream from one
@@ -54,16 +55,16 @@ impl<S, F> Sink for MapErr<S, F>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }
 
@@ -74,7 +75,7 @@ impl<S, F, U> Stream for MapErr<S, F>
     type Item = S::Item;
     type Error = U;
 
-    fn poll(&mut self) -> Poll<Option<S::Item>, U> {
-        self.stream.poll().map_err(&mut self.f)
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<S::Item>, U> {
+        self.stream.poll(ctx).map_err(&mut self.f)
     }
 }

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -1,4 +1,5 @@
 use futures_core::{Poll, Async, Stream};
+use futures_core::task;
 
 /// A stream which emits single element and then EOF.
 ///
@@ -36,7 +37,7 @@ impl<T, E> Stream for Once<T, E> {
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<Option<T>, E> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Option<T>, E> {
         match self.0.take() {
             Some(Ok(e)) => Ok(Async::Ready(Some(e))),
             Some(Err(e)) => Err(e),

--- a/futures-util/src/stream/or_else.rs
+++ b/futures-util/src/stream/or_else.rs
@@ -1,4 +1,5 @@
 use futures_core::{IntoFuture, Future, Poll, Async, Stream};
+use futures_core::task;
 use futures_sink::{Sink, StartSend};
 
 /// A stream combinator which chains a computation onto errors produced by a
@@ -34,16 +35,16 @@ impl<S, F, U> Sink for OrElse<S, F, U>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }
 
@@ -55,9 +56,9 @@ impl<S, F, U> Stream for OrElse<S, F, U>
     type Item = S::Item;
     type Error = U::Error;
 
-    fn poll(&mut self) -> Poll<Option<S::Item>, U::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<S::Item>, U::Error> {
         if self.future.is_none() {
-            let item = match self.stream.poll() {
+            let item = match self.stream.poll(ctx) {
                 Ok(Async::Ready(e)) => return Ok(Async::Ready(e)),
                 Ok(Async::Pending) => return Ok(Async::Pending),
                 Err(e) => e,
@@ -65,7 +66,7 @@ impl<S, F, U> Stream for OrElse<S, F, U>
             self.future = Some((self.f)(item).into_future());
         }
         assert!(self.future.is_some());
-        match self.future.as_mut().unwrap().poll() {
+        match self.future.as_mut().unwrap().poll(ctx) {
             Ok(Async::Ready(e)) => {
                 self.future = None;
                 Ok(Async::Ready(Some(e)))

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -1,6 +1,7 @@
 use core::marker;
 
 use futures_core::{Stream, Async, Poll};
+use futures_core::task;
 
 /// Stream that produces the same element repeatedly.
 ///
@@ -49,7 +50,7 @@ impl<T, E> Stream for Repeat<T, E>
     type Item = T;
     type Error = E;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, _: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         Ok(Async::Ready(Some(self.item.clone())))
     }
 }

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -3,6 +3,7 @@
 use std::fmt::{self, Debug};
 
 use futures_core::{Async, Poll, Stream};
+use futures_core::task;
 
 use stream::{StreamExt, StreamFuture, FuturesUnordered};
 
@@ -65,8 +66,8 @@ impl<S: Stream> Stream for SelectAll<S> {
     type Item = S::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        match self.inner.poll().map_err(|(err, _)| err)? {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.inner.poll(ctx).map_err(|(err, _)| err)? {
             Async::Pending => Ok(Async::Pending),
             Async::Ready(Some((Some(item), remaining))) => {
                 self.push(remaining);

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -1,4 +1,5 @@
 use futures_core::{Async, Poll, IntoFuture, Future, Stream};
+use futures_core::task;
 use futures_sink::{StartSend, Sink};
 
 /// A stream combinator which skips elements of a stream while a predicate
@@ -59,16 +60,16 @@ impl<S, P, R> Sink for SkipWhile<S, P, R>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }
 
@@ -80,21 +81,21 @@ impl<S, P, R> Stream for SkipWhile<S, P, R>
     type Item = S::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<S::Item>, S::Error> {
         if self.done_skipping {
-            return self.stream.poll();
+            return self.stream.poll(ctx);
         }
 
         loop {
             if self.pending.is_none() {
-                let item = match try_ready!(self.stream.poll()) {
+                let item = match try_ready!(self.stream.poll(ctx)) {
                     Some(e) => e,
                     None => return Ok(Async::Ready(None)),
                 };
                 self.pending = Some(((self.pred)(&item).into_future(), item));
             }
 
-            match self.pending.as_mut().unwrap().0.poll() {
+            match self.pending.as_mut().unwrap().0.poll(ctx) {
                 Ok(Async::Ready(true)) => self.pending = None,
                 Ok(Async::Ready(false)) => {
                     let (_, item) = self.pending.take().unwrap();

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -1,4 +1,5 @@
 use futures_core::{Async, Poll, Stream};
+use futures_core::task;
 use futures_sink::{StartSend, Sink};
 
 /// A stream combinator which returns a maximum number of elements.
@@ -52,16 +53,16 @@ impl<S> Sink for Take<S>
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn start_send(&mut self, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
-        self.stream.start_send(item)
+    fn start_send(&mut self, ctx: &mut task::Context, item: S::SinkItem) -> StartSend<S::SinkItem, S::SinkError> {
+        self.stream.start_send(ctx, item)
     }
 
-    fn flush(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.flush()
+    fn flush(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.flush(ctx)
     }
 
-    fn close(&mut self) -> Poll<(), S::SinkError> {
-        self.stream.close()
+    fn close(&mut self, ctx: &mut task::Context) -> Poll<(), S::SinkError> {
+        self.stream.close(ctx)
     }
 }
 
@@ -71,11 +72,11 @@ impl<S> Stream for Take<S>
     type Item = S::Item;
     type Error = S::Error;
 
-    fn poll(&mut self) -> Poll<Option<S::Item>, S::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<S::Item>, S::Error> {
         if self.remaining == 0 {
             Ok(Async::Ready(None))
         } else {
-            let next = try_ready!(self.stream.poll());
+            let next = try_ready!(self.stream.poll(ctx));
             match next {
                 Some(_) => self.remaining -= 1,
                 None => self.remaining = 0,

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -1,4 +1,5 @@
 use futures_core::{Async, Poll, Stream};
+use futures_core::task;
 
 use stream::{StreamExt, Fuse};
 
@@ -33,15 +34,15 @@ impl<S1, S2> Stream for Zip<S1, S2>
     type Item = (S1::Item, S2::Item);
     type Error = S1::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         if self.queued1.is_none() {
-            match self.stream1.poll()? {
+            match self.stream1.poll(ctx)? {
                 Async::Ready(Some(item1)) => self.queued1 = Some(item1),
                 Async::Ready(None) | Async::Pending => {}
             }
         }
         if self.queued2.is_none() {
-            match self.stream2.poll()? {
+            match self.stream2.poll(ctx)? {
                 Async::Ready(Some(item2)) => self.queued2 = Some(item2),
                 Async::Ready(None) | Async::Pending => {}
             }


### PR DESCRIPTION
It seems quite common to use lazy to get into a task context. Make it explicit.