### PR TITLE
Remove the `futures::task::current` function

### DIFF
--- a/futures-core/src/task.rs
+++ b/futures-core/src/task.rs
@@ -38,7 +38,6 @@ pub use task_impl::{
     UnsafeNotify,
 
     // Functions
-    current,
     init,
     spawn,
     with_notify,

--- a/futures-core/src/task_impl/mod.rs
+++ b/futures-core/src/task_impl/mod.rs
@@ -49,6 +49,13 @@ pub struct Task {
 trait AssertSend: Send {}
 impl AssertSend for Task {}
 
+impl Context {
+    /// TODO: dox
+    pub fn waker(&mut self) -> Task {
+        current()
+    }
+}
+
 /// Returns a handle to the current task to call `notify` at a later date.
 ///
 /// The returned handle implements the `Send` and `'static` bounds and may also
@@ -71,7 +78,7 @@ impl AssertSend for Task {}
 /// This function will panic if a task is not currently being executed. That
 /// is, this method can be dangerous to call outside of an implementation of
 /// `poll`.
-pub fn current() -> Task {
+fn current() -> Task {
     with(|borrowed| {
         let unpark = borrowed.unpark.to_owned();
 

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -99,9 +99,9 @@ impl<F> Shared<F> where F: Future {
         }
     }
 
-    fn set_waiter(&mut self, _cx: &mut task::Context) {
+    fn set_waiter(&mut self, cx: &mut task::Context) {
         let mut waiters = self.inner.notifier.waiters.lock().unwrap();
-        waiters.insert(self.waiter, task::current());
+        waiters.insert(self.waiter, cx.waker());
     }
 
     unsafe fn clone_result(&self) -> Result<SharedItem<F::Item>, SharedError<F::Error>> {

--- a/futures-util/src/lock.rs
+++ b/futures-util/src/lock.rs
@@ -79,7 +79,7 @@ impl<T> BiLock<T> {
     ///
     /// This function will panic if called outside the context of a future's
     /// task.
-    pub fn poll_lock(&self, _cx: &mut task::Context) -> Async<BiLockGuard<T>> {
+    pub fn poll_lock(&self, cx: &mut task::Context) -> Async<BiLockGuard<T>> {
         loop {
             match self.inner.state.swap(1, SeqCst) {
                 // Woohoo, we grabbed the lock!
@@ -95,7 +95,7 @@ impl<T> BiLock<T> {
                 }
             }
 
-            let me = Box::new(task::current());
+            let me = Box::new(cx.waker());
             let me = Box::into_raw(me) as usize;
 
             match self.inner.state.compare_exchange(1, me, SeqCst, SeqCst) {

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -283,7 +283,7 @@ impl<T> Stream for FuturesUnordered<T>
                     // At this point, it may be worth yielding the thread &
                     // spinning a few times... but for now, just yield using the
                     // task system.
-                    task::current().notify();
+                    cx.waker().notify();
                     return Ok(Async::Pending);
                 }
                 Dequeue::Data(node) => node,


### PR DESCRIPTION
This currently just makes it private and adds a new `Context::waker` function
which will call the original private version.