### PR TITLE
Remove unneccessary poll_complete when trying to empty buffered Sink

### DIFF
--- a/src/sink/buffer.rs
+++ b/src/sink/buffer.rs
@@ -49,9 +49,6 @@ impl<S: Sink> Buffer<S> {
             if let AsyncSink::NotReady(item) = self.sink.start_send(item)? {
                 self.buf.push_front(item);
 
-                // ensure that we attempt to complete any pushes we've started
-                self.sink.poll_complete()?;
-
                 return Ok(Async::NotReady);
             }
         }


### PR DESCRIPTION
This fixes #752 

Summary of the bug: buffered Sinks would sometimes get stuck - i.e. the task was never triggered to be polled again - because the call to `poll_complete` on line 53 would return `Async::Ready(())` even though the buffer still had data that needed to be written.

@alexcrichton pointed out that the call to `poll_complete` was actually unnecessary as `start_send` should (if implemented correctly) call `poll_complete` before returning, and therefore could be removed.

Removing the call did indeed fix the issue for me.  And all the futures-rs tests still pass.  So unless there are any side-effects I haven't anticipated, this should be a safe change.