### PR TITLE
futures_[un]ordered cleanup

### DIFF
--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -105,16 +105,11 @@ pub struct FuturesOrdered<T>
 /// Note that the returned queue can also be used to dynamically push more
 /// futures into the queue as they become available.
 pub fn futures_ordered<I>(futures: I) -> FuturesOrdered<<I::Item as IntoFuture>::Future>
-    where I: IntoIterator,
-          I::Item: IntoFuture
+where
+    I: IntoIterator,
+    I::Item: IntoFuture,
 {
-    let mut queue = FuturesOrdered::new();
-
-    for future in futures {
-        queue.push(future.into_future());
-    }
-
-    queue
+    futures.into_iter().map(|f| f.into_future()).collect()
 }
 
 impl<T> FuturesOrdered<T>

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -208,7 +208,7 @@ impl<F: Future> FromIterator<F> for FuturesOrdered<F> {
         where T: IntoIterator<Item = F>
     {
         let mut new = FuturesOrdered::new();
-        for future in iter.into_iter() {
+        for future in iter {
             new.push(future);
         }
         new

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -205,12 +205,10 @@ impl<T: Debug> Debug for FuturesOrdered<T>
 
 impl<F: Future> FromIterator<F> for FuturesOrdered<F> {
     fn from_iter<T>(iter: T) -> Self
-        where T: IntoIterator<Item = F>
+    where
+        T: IntoIterator<Item = F>,
     {
-        let mut new = FuturesOrdered::new();
-        for future in iter {
-            new.push(future);
-        }
-        new
+        let acc = FuturesOrdered::new();
+        iter.into_iter().fold(acc, |mut acc, item| { acc.push(item); acc })
     }
 }

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -114,7 +114,7 @@ pub fn futures_ordered<I>(futures: I) -> FuturesOrdered<<I::Item as IntoFuture>:
         queue.push(future.into_future());
     }
 
-    return queue
+    queue
 }
 
 impl<T> FuturesOrdered<T>

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -679,14 +679,9 @@ fn abort(s: &str) -> ! {
 /// Note that the returned set can also be used to dynamically push more
 /// futures into the set as they become available.
 pub fn futures_unordered<I>(futures: I) -> FuturesUnordered<<I::Item as IntoFuture>::Future>
-    where I: IntoIterator,
-        I::Item: IntoFuture
+where
+    I: IntoIterator,
+    I::Item: IntoFuture,
 {
-    let mut set = FuturesUnordered::new();
-
-    for future in futures {
-        set.push(future.into_future());
-    }
-
-    set
+    futures.into_iter().map(|f| f.into_future()).collect()
 }

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -417,13 +417,11 @@ impl<T> Drop for FuturesUnordered<T> {
 
 impl<F: Future> FromIterator<F> for FuturesUnordered<F> {
     fn from_iter<T>(iter: T) -> Self
-        where T: IntoIterator<Item = F>
+    where
+        T: IntoIterator<Item = F>,
     {
-        let mut new = FuturesUnordered::new();
-        for future in iter {
-            new.push(future);
-        }
-        new
+        let acc = FuturesUnordered::new();
+        iter.into_iter().fold(acc, |mut acc, item| { acc.push(item); acc })
     }
 }
 

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -420,7 +420,7 @@ impl<F: Future> FromIterator<F> for FuturesUnordered<F> {
         where T: IntoIterator<Item = F>
     {
         let mut new = FuturesUnordered::new();
-        for future in iter.into_iter() {
+        for future in iter {
             new.push(future);
         }
         new

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -234,7 +234,7 @@ impl<T> FuturesUnordered<T> {
 
         self.head_all = ptr;
         self.len += 1;
-        return ptr
+        ptr
     }
 
     /// Remove the node from the linked list tracking all nodes currently
@@ -256,7 +256,7 @@ impl<T> FuturesUnordered<T> {
             self.head_all = next;
         }
         self.len -= 1;
-        return node
+        node
     }
 }
 
@@ -445,7 +445,7 @@ impl<'a, F> Iterator for IterMut<'a, F> {
             let next = *(*self.node).next_all.get();
             self.node = next;
             self.len -= 1;
-            return Some(future);
+            Some(future)
         }
     }
 
@@ -644,7 +644,7 @@ impl<T> Drop for Node<T> {
 fn arc2ptr<T>(ptr: Arc<T>) -> *const T {
     let addr = &*ptr as *const T;
     mem::forget(ptr);
-    return addr
+    addr
 }
 
 unsafe fn ptr2arc<T>(ptr: *const T) -> Arc<T> {

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -92,7 +92,7 @@ if_std! {
     pub use self::collect::Collect;
     pub use self::select_all::SelectAll;
     pub use self::split::{SplitStream, SplitSink, ReuniteError};
-    pub use self::futures_unordered::FuturesUnordered;
+    pub use self::futures_unordered::{futures_unordered, FuturesUnordered};
     pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
 }
 
@@ -960,30 +960,6 @@ pub trait StreamExt: Stream {
     {
         recover::new(self, f)
     }
-}
-
-/// Converts a list of futures into a `Stream` of results from the futures.
-///
-/// This function will take an list of futures (e.g. a vector, an iterator,
-/// etc), and return a stream. The stream will yield items as they become
-/// available on the futures internally, in the order that they become
-/// available. This function is similar to `buffer_unordered` in that it may
-/// return items in a different order than in the list specified.
-///
-/// Note that the returned set can also be used to dynamically push more
-/// futures into the set as they become available.
-#[cfg(feature = "std")]
-pub fn futures_unordered<I>(futures: I) -> FuturesUnordered<<I::Item as IntoFuture>::Future>
-    where I: IntoIterator,
-        I::Item: IntoFuture
-{
-    let mut set = FuturesUnordered::new();
-
-    for future in futures {
-        set.push(future.into_future());
-    }
-
-    return set
 }
 
 /// Convert a list of streams into a `Stream` of results from the streams.


### PR DESCRIPTION
I was experimenting recently with some variations of `futures_ordered` and while doing so cleaned it and its cousin `futures_unordered` a little bit. Thought I'd share it.

Each commit addresses single change, which should be pretty straightforward.