### PR TITLE
Fix `unsync::mpsc::Sender`'s Drop impl.

### DIFF
--- a/src/unsync/mpsc.rs
+++ b/src/unsync/mpsc.rs
@@ -110,7 +110,8 @@ impl<T> Drop for Sender<T> {
             Some(shared) => shared,
             None => return,
         };
-        if Rc::weak_count(&shared) == 0 {
+        if Rc::weak_count(&shared) == 1 {
+            // `self.shared` is the only remaining weak reference, meaning that the last sender is being dropped.
             if let Some(task) = shared.borrow_mut().blocked_recv.take() {
                 // Wake up receiver as its stream has ended
                 task.notify();

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -137,6 +137,20 @@ fn mpsc_send_unpark() {
 }
 
 #[test]
+fn mspc_drop_sender_unparks() {
+    let (tx, rx) = mpsc::channel::<i32>(1);
+
+    let send_future = lazy(move || {
+        drop(tx);
+        Ok(())
+    });
+    rx.for_each(|_: i32| Ok(()))
+        .join(send_future)
+        .wait()
+        .unwrap();
+}
+
+#[test]
 fn spawn_sends_items() {
     let core = Core::new();
     let stream = unfold(0, |i| Ok::<_,u8>(Some((i, i + 1))));


### PR DESCRIPTION
This was testing `Rc::weak_count(&self.shared) == 0`, which is never the case
because `self.shared` still exists. This would cause a missed wakeup. Instead
test `weak_count == 1`.