### PR TITLE
Sink refactor take 2

### DIFF
--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -14,11 +14,11 @@ impl<T> Sink for Sender<T> {
         self.start_send(msg)
     }
 
-    fn start_close(&mut self) -> Result<(), Self::SinkError> {
-        Ok(())
+    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
     }
 
-    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+    fn poll_close(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
         Ok(Async::Ready(()))
     }
 }
@@ -35,11 +35,11 @@ impl<T> Sink for UnboundedSender<T> {
         self.start_send(msg)
     }
 
-    fn start_close(&mut self) -> Result<(), Self::SinkError> {
-        Ok(())
+    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
     }
 
-    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+    fn poll_close(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
         Ok(Async::Ready(()))
     }
 }
@@ -56,11 +56,11 @@ impl<'a, T> Sink for &'a UnboundedSender<T> {
         self.unbounded_send(msg)
     }
 
-    fn start_close(&mut self) -> Result<(), Self::SinkError> {
-        Ok(())
+    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+        Ok(Async::Ready(()))
     }
 
-    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+    fn poll_close(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
         Ok(Async::Ready(()))
     }
 }

--- a/futures-util/src/io/framed.rs
+++ b/futures-util/src/io/framed.rs
@@ -141,12 +141,12 @@ impl<T, U> Sink for Framed<T, U>
         self.inner.get_mut().start_send(item)
     }
 
-    fn start_close(&mut self) -> Result<(), Self::SinkError> {
-        self.inner.get_mut().start_close()
-    }
-
     fn poll_flush(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
         self.inner.get_mut().poll_flush(cx)
+    }
+
+    fn poll_close(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        self.inner.get_mut().poll_close(cx)
     }
 }
 

--- a/futures-util/src/io/framed_read.rs
+++ b/futures-util/src/io/framed_read.rs
@@ -186,12 +186,12 @@ impl<T, D> Sink for FramedRead<T, D>
         self.inner.inner.0.start_send(item)
     }
 
-    fn start_close(&mut self) -> Result<(), Self::SinkError> {
-        self.inner.inner.0.start_close()
-    }
-
     fn poll_flush(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
         self.inner.inner.0.poll_flush(cx)
+    }
+
+    fn poll_close(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        self.inner.inner.0.poll_close(cx)
     }
 }
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -41,13 +41,14 @@ macro_rules! delegate_sink {
             self.$field.start_send(item)
         }
 
-        fn start_close(&mut self) -> Result<(), Self::SinkError> {
-            self.$field.start_close()
-        }
-
         fn poll_flush(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
             self.$field.poll_flush(cx)
         }
+
+        fn poll_close(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+            self.$field.poll_close(cx)
+        }
+
     }
 }
 

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -53,12 +53,12 @@ impl<S, F, E> Sink for SinkMapErr<S, F>
         self.sink.start_send(item).map_err(|e| self.expect_f()(e))
     }
 
-    fn start_close(&mut self) -> Result<(), Self::SinkError> {
-        self.sink.start_close().map_err(|e| self.expect_f()(e))
-    }
-
     fn poll_flush(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
         self.sink.poll_flush(cx).map_err(|e| self.expect_f()(e))
+    }
+
+    fn poll_close(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        self.sink.poll_close(cx).map_err(|e| self.expect_f()(e))
     }
 }
 


### PR DESCRIPTION
cc https://github.com/rust-lang-nursery/futures-rs/issues/751

In this case, `poll_close` should both flush *and* close the `Sink` before returning `Async::Ready`.