### PR TITLE
Futures io Tests

### DIFF
--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -17,3 +17,7 @@ default = ["std"]
 [dependencies]
 futures-core = { path = "../futures-core", version = "0.2.0", default-features = false }
 iovec = { version = "0.1", optional = true }
+
+[dev-dependencies]
+bytes = { version = "0.4" }
+futures = { path = "../futures", version = "0.2" }

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -31,6 +31,8 @@ if_std! {
     // Re-export io::Error so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
     pub use StdIo::Error as Error;
+    pub use StdIo::ErrorKind as ErrorKind;
+    pub use StdIo::Result as Result;
 
     /// A type used to conditionally initialize buffers passed to `AsyncRead`
     /// methods.

--- a/futures-io/tests/async_read.rs
+++ b/futures-io/tests/async_read.rs
@@ -1,0 +1,130 @@
+extern crate bytes;
+extern crate futures;
+
+use futures::prelude::*;
+use futures::{executor, io};
+use bytes::{BytesMut, BufMut};
+
+const TEST_MSG: &[u8] = b"hello world";
+
+fn dummy_cx<F>(f: F) where F: FnOnce(&mut task::Context) {
+    struct Fut<F>(Option<F>);
+
+    impl<F> Future for Fut<F> where F: FnOnce(&mut task::Context) {
+        type Item = ();
+        type Error = ();
+        fn poll(&mut self, cx: &mut task::Context) -> Poll<(), ()> {
+            (self.0.take().unwrap())(cx);
+            Ok(Async::Ready(()))
+        }
+    }
+
+    executor::block_on(Fut(Some(f))).unwrap();
+}
+
+#[test]
+fn read_buf_success() {
+    struct R;
+
+    impl AsyncRead for R {
+        fn poll_read(&mut self, _: &mut task::Context, buf: &mut [u8]) -> Poll<usize, io::Error> {
+            let len = TEST_MSG.len();
+            buf[0..len].copy_from_slice(TEST_MSG);
+            Ok(Async::Ready(len))
+        }
+    }
+
+    let mut buf = BytesMut::with_capacity(65);
+
+    dummy_cx(|cx| {
+        let n = match R.read_buf(cx, &mut buf).unwrap() {
+            Async::Ready(n) => n,
+            _ => panic!(),
+        };
+
+        assert_eq!(TEST_MSG.len(), n);
+        assert_eq!(buf, TEST_MSG);
+    })
+}
+
+#[test]
+fn read_buf_no_capacity() {
+    struct R;
+
+    impl AsyncRead for R {
+        fn poll_read(&mut self, _: &mut task::Context, _: &mut [u8]) -> Poll<usize, io::Error> {
+            unimplemented!()
+        }
+    }
+
+    // Can't create BytesMut w/ zero capacity, so fill it up
+    let mut buf = BytesMut::with_capacity(64);
+    buf.put(&[0; 64][..]);
+
+    dummy_cx(|cx| {
+        let n = match R.read_buf(cx, &mut buf).unwrap() {
+            Async::Ready(n) => n,
+            _ => panic!(),
+        };
+
+        assert_eq!(0, n);
+    })
+}
+
+#[test]
+fn read_buf_no_uninitialized() {
+    struct R;
+
+    impl AsyncRead for R {
+        fn poll_read(&mut self, _: &mut task::Context, buf: &mut [u8]) -> Poll<usize, io::Error> {
+            for b in buf {
+                assert_eq!(0, *b);
+            }
+
+            Ok(Async::Ready(0))
+        }
+    }
+
+    // Can't create BytesMut w/ zero capacity, so fill it up
+    let mut buf = BytesMut::with_capacity(64);
+
+    dummy_cx(|cx| {
+        let n = match R.read_buf(cx, &mut buf).unwrap() {
+            Async::Ready(n) => n,
+            _ => panic!(),
+        };
+
+        assert_eq!(0, n);
+    })
+}
+
+#[test]
+fn read_buf_uninitialized_ok() {
+    struct R;
+
+    impl AsyncRead for R {
+        unsafe fn initializer(&self) -> io::Initializer {
+            io::Initializer::nop()
+        }
+
+        fn poll_read(&mut self, _: &mut task::Context, buf: &mut [u8]) -> Poll<usize, io::Error> {
+            assert_eq!(&buf[0..TEST_MSG.len()], TEST_MSG);
+            Ok(Async::Ready(0))
+        }
+    }
+
+    // Can't create BytesMut w/ zero capacity, so fill it up
+    let mut buf = BytesMut::with_capacity(64);
+    unsafe {
+        buf.bytes_mut()[0..TEST_MSG.len()].copy_from_slice(TEST_MSG);
+    }
+
+    dummy_cx(|cx| {
+        let n = match R.read_buf(cx, &mut buf).unwrap() {
+            Async::Ready(n) => n,
+            _ => panic!(),
+        };
+
+        assert_eq!(0, n);
+    })
+}

--- a/futures-io/tests/codecs.rs
+++ b/futures-io/tests/codecs.rs
@@ -1,0 +1,79 @@
+extern crate bytes;
+extern crate futures;
+
+use bytes::{BytesMut, Bytes, BufMut};
+use futures::io::codec::{BytesCodec, LinesCodec, Decoder, Encoder};
+
+#[test]
+fn bytes_decoder() {
+    let mut codec = BytesCodec::new();
+    let buf = &mut BytesMut::new();
+    buf.put_slice(b"abc");
+    assert_eq!("abc", codec.decode(buf).unwrap().unwrap());
+    assert_eq!(None, codec.decode(buf).unwrap());
+    assert_eq!(None, codec.decode(buf).unwrap());
+    buf.put_slice(b"a");
+    assert_eq!("a", codec.decode(buf).unwrap().unwrap());
+}
+
+#[test]
+fn bytes_encoder() {
+    let mut codec = BytesCodec::new();
+
+    // Default capacity of BytesMut
+    #[cfg(target_pointer_width = "64")]
+    const INLINE_CAP: usize = 4 * 8 - 1;
+    #[cfg(target_pointer_width = "32")]
+    const INLINE_CAP: usize = 4 * 4 - 1;
+    const INLINE_CAP_PLUS_ONE_BYTES: &[u8] = &[0; INLINE_CAP + 1];
+
+    let mut buf = BytesMut::new();
+    codec.encode(Bytes::from_static(INLINE_CAP_PLUS_ONE_BYTES), &mut buf).unwrap();
+
+    // Default capacity of Framed Read
+    const INITIAL_CAPACITY: usize = 8 * 1024;
+
+    let mut buf = BytesMut::with_capacity(INITIAL_CAPACITY);
+    codec.encode(Bytes::from_static(INLINE_CAP_PLUS_ONE_BYTES), &mut buf).unwrap();
+}
+
+#[test]
+fn lines_decoder() {
+    let mut codec = LinesCodec::new();
+    let buf = &mut BytesMut::new();
+    buf.reserve(200);
+    buf.put("line 1\nline 2\r\nline 3\n\r\n\r");
+    assert_eq!("line 1", codec.decode(buf).unwrap().unwrap());
+    assert_eq!("line 2", codec.decode(buf).unwrap().unwrap());
+    assert_eq!("line 3", codec.decode(buf).unwrap().unwrap());
+    assert_eq!("", codec.decode(buf).unwrap().unwrap());
+    assert_eq!(None, codec.decode(buf).unwrap());
+    assert_eq!(None, codec.decode_eof(buf).unwrap());
+    buf.put("k");
+    assert_eq!(None, codec.decode(buf).unwrap());
+    assert_eq!("\rk", codec.decode_eof(buf).unwrap().unwrap());
+    assert_eq!(None, codec.decode(buf).unwrap());
+    assert_eq!(None, codec.decode_eof(buf).unwrap());
+}
+
+#[test]
+fn lines_encoder() {
+    let mut codec = BytesCodec::new();
+
+    // Default capacity of BytesMut
+    #[cfg(target_pointer_width = "64")]
+    const INLINE_CAP: usize = 4 * 8 - 1;
+    #[cfg(target_pointer_width = "32")]
+    const INLINE_CAP: usize = 4 * 4 - 1;
+    const INLINE_CAP_PLUS_ONE_BYTES: &[u8] = &[b'a'; INLINE_CAP + 1];
+    const INITIAL_CAP_PLUS_ONE_BYTES: &[u8] = &[b'a'; INITIAL_CAPACITY + 1];
+
+    let mut buf = BytesMut::new();
+    codec.encode(Bytes::from_static(INLINE_CAP_PLUS_ONE_BYTES), &mut buf).unwrap();
+
+    // Default capacity of Framed Read
+    const INITIAL_CAPACITY: usize = 8 * 1024;
+
+    let mut buf = BytesMut::with_capacity(INITIAL_CAPACITY);
+    codec.encode(Bytes::from_static(INITIAL_CAP_PLUS_ONE_BYTES), &mut buf).unwrap();
+}

--- a/futures-io/tests/framed.rs
+++ b/futures-io/tests/framed.rs
@@ -1,0 +1,91 @@
+extern crate bytes;
+extern crate futures;
+
+use futures::prelude::*;
+use futures::{executor, io};
+use futures::io::codec::{Framed, FramedParts, Decoder, Encoder};
+use bytes::{BytesMut, Buf, BufMut, IntoBuf, BigEndian};
+
+const INITIAL_CAPACITY: usize = 8 * 1024;
+
+struct U32Codec;
+
+impl Decoder for U32Codec {
+    type Item = u32;
+    type Error = io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
+        if buf.len() < 4 {
+            return Ok(None);
+        }
+
+        let n = buf.split_to(4).into_buf().get_u32::<BigEndian>();
+        Ok(Some(n))
+    }
+}
+
+impl Encoder for U32Codec {
+    type Item = u32;
+    type Error = io::Error;
+
+    fn encode(&mut self, item: u32, dst: &mut BytesMut) -> io::Result<()> {
+        // Reserve space
+        dst.reserve(4);
+        dst.put_u32::<BigEndian>(item);
+        Ok(())
+    }
+}
+
+struct DontReadIntoThis;
+
+impl AsyncRead for DontReadIntoThis {
+    fn poll_read(&mut self, _: &mut task::Context, _: &mut [u8]) -> Poll<usize, io::Error> {
+        Err(io::Error::new(io::ErrorKind::Other,
+                           "Read into something you weren't supposed to."))
+    }
+}
+
+#[test]
+fn can_read_from_existing_buf() {
+    let parts = FramedParts {
+        inner: DontReadIntoThis,
+        readbuf: vec![0, 0, 0, 42].into(),
+        writebuf: BytesMut::with_capacity(0),
+    };
+    let framed = Framed::from_parts(parts, U32Codec);
+
+    let num = executor::block_on(framed
+        .into_future()
+        .map(|(first_num, _)| {
+            first_num.unwrap()
+        }))
+        .map_err(|e| e.0)
+        .unwrap();
+    assert_eq!(num, 42);
+}
+
+#[test]
+fn external_buf_grows_to_init() {
+    let parts = FramedParts {
+        inner: DontReadIntoThis,
+        readbuf: vec![0, 0, 0, 42].into(),
+        writebuf: BytesMut::with_capacity(0),
+    };
+    let framed = Framed::from_parts(parts, U32Codec);
+    let FramedParts { readbuf, .. } = framed.into_parts();
+
+    assert_eq!(readbuf.capacity(), INITIAL_CAPACITY);
+}
+
+#[test]
+fn external_buf_does_not_shrink() {
+    let parts = FramedParts {
+        inner: DontReadIntoThis,
+        readbuf: vec![0; INITIAL_CAPACITY * 2].into(),
+        writebuf: BytesMut::with_capacity(0),
+    };
+    let framed = Framed::from_parts(parts, U32Codec);
+    let FramedParts { readbuf, .. } = framed.into_parts();
+
+    assert_eq!(readbuf.capacity(), INITIAL_CAPACITY * 2);
+}

--- a/futures-io/tests/framed_read.rs
+++ b/futures-io/tests/framed_read.rs
@@ -1,0 +1,246 @@
+extern crate bytes;
+extern crate futures;
+
+use futures::prelude::*;
+use futures::{executor, io};
+use futures::io::codec::{FramedRead, Decoder};
+use futures::Async::{Ready, Pending};
+
+use bytes::{BytesMut, Buf, IntoBuf, BigEndian};
+
+use std::collections::VecDeque;
+
+macro_rules! mock {
+    ($($x:expr,)*) => {{
+        let mut v = VecDeque::new();
+        v.extend(vec![$($x),*]);
+        Mock { calls: v }
+    }};
+}
+
+fn dummy_cx<F>(f: F) where F: FnOnce(&mut task::Context) {
+    struct Fut<F>(Option<F>);
+
+    impl<F> Future for Fut<F> where F: FnOnce(&mut task::Context) {
+        type Item = ();
+        type Error = ();
+        fn poll(&mut self, cx: &mut task::Context) -> Poll<(), ()> {
+            (self.0.take().unwrap())(cx);
+            Ok(Async::Ready(()))
+        }
+    }
+
+    executor::block_on(Fut(Some(f))).unwrap();
+}
+
+struct U32Decoder;
+
+impl Decoder for U32Decoder {
+    type Item = u32;
+    type Error = io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
+        if buf.len() < 4 {
+            return Ok(None);
+        }
+
+        let n = buf.split_to(4).into_buf().get_u32::<BigEndian>();
+        Ok(Some(n))
+    }
+}
+
+#[test]
+fn read_multi_frame_in_packet() {
+    let mock = mock! {
+        Ok(Ready(b"\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec())),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(1)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(2)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(None), framed.poll_next(cx).unwrap());
+    })
+}
+
+#[test]
+fn read_multi_frame_across_packets() {
+    let mock = mock! {
+        Ok(Ready(b"\x00\x00\x00\x00".to_vec())),
+        Ok(Ready(b"\x00\x00\x00\x01".to_vec())),
+        Ok(Ready(b"\x00\x00\x00\x02".to_vec())),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(1)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(2)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(None), framed.poll_next(cx).unwrap());
+    })
+}
+
+#[test]
+fn read_not_ready() {
+    let mock = mock! {
+        Ok(Pending),
+        Ok(Ready(b"\x00\x00\x00\x00".to_vec())),
+        Ok(Ready(b"\x00\x00\x00\x01".to_vec())),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(Pending, framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(1)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(None), framed.poll_next(cx).unwrap());
+    })
+}
+
+#[test]
+fn read_partial_then_not_ready() {
+    let mock = mock! {
+        Ok(Ready(b"\x00\x00".to_vec())),
+        Ok(Pending),
+        Ok(Ready(b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec())),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(Pending, framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(1)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(2)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(None), framed.poll_next(cx).unwrap());
+    })
+}
+
+#[test]
+fn read_err() {
+    let mock = mock! {
+        Err(io::Error::new(io::ErrorKind::Other, "")),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(io::ErrorKind::Other, framed.poll_next(cx).unwrap_err().kind());
+    })
+}
+
+#[test]
+fn read_partial_then_err() {
+    let mock = mock! {
+        Ok(Ready(b"\x00\x00".to_vec())),
+        Err(io::Error::new(io::ErrorKind::Other, "")),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(io::ErrorKind::Other, framed.poll_next(cx).unwrap_err().kind());
+    })
+}
+
+#[test]
+fn read_partial_would_block_then_err() {
+    let mock = mock! {
+        Ok(Ready(b"\x00\x00".to_vec())),
+        Ok(Pending),
+        Err(io::Error::new(io::ErrorKind::Other, "")),
+    };
+
+    let mut framed = FramedRead::new(mock, U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(Pending, framed.poll_next(cx).unwrap());
+        assert_eq!(io::ErrorKind::Other, framed.poll_next(cx).unwrap_err().kind());
+    })
+}
+
+#[test]
+fn huge_size() {
+    let data = [0; 32 * 1024];
+
+    let mut framed = FramedRead::new(&data[..], BigDecoder);
+    dummy_cx(|cx| {
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(None), framed.poll_next(cx).unwrap());
+    });
+
+    struct BigDecoder;
+
+    impl Decoder for BigDecoder {
+        type Item = u32;
+        type Error = io::Error;
+
+        fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
+            if buf.len() < 32 * 1024 {
+                return Ok(None);
+            }
+            buf.split_to(32 * 1024);
+            Ok(Some(0))
+        }
+    }
+}
+
+#[test]
+fn data_remaining_is_error() {
+    let data = [0; 5];
+
+    let mut framed = FramedRead::new(&data[..], U32Decoder);
+    dummy_cx(|cx| {
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert!(framed.poll_next(cx).is_err());
+    })
+}
+
+#[test]
+fn multi_frames_on_eof() {
+    struct MyDecoder(Vec<u32>);
+
+    impl Decoder for MyDecoder {
+        type Item = u32;
+        type Error = io::Error;
+
+        fn decode(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
+            unreachable!();
+        }
+
+        fn decode_eof(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
+            if self.0.is_empty() {
+                return Ok(None);
+            }
+
+            Ok(Some(self.0.remove(0)))
+        }
+    }
+
+    let mut framed = FramedRead::new(mock!(), MyDecoder(vec![0, 1, 2, 3]));
+    dummy_cx(|cx| {
+        assert_eq!(Ready(Some(0)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(1)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(2)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(Some(3)), framed.poll_next(cx).unwrap());
+        assert_eq!(Ready(None), framed.poll_next(cx).unwrap());
+    })
+}
+
+// ===== Mock ======
+
+struct Mock {
+    calls: VecDeque<Poll<Vec<u8>, io::Error>>,
+}
+
+impl AsyncRead for Mock {
+    fn poll_read(&mut self, _: &mut task::Context, dst: &mut [u8]) -> Poll<usize, io::Error> {
+        match self.calls.pop_front() {
+            Some(Ok(Ready(data))) => {
+                debug_assert!(dst.len() >= data.len());
+                dst[..data.len()].copy_from_slice(&data[..]);
+                Ok(Ready(data.len()))
+            }
+            Some(Ok(Pending)) => Ok(Pending),
+            Some(Err(e)) => Err(e),
+            None => Ok(Ready(0)),
+        }
+    }
+}

--- a/futures-io/tests/framed_write.rs
+++ b/futures-io/tests/framed_write.rs
@@ -1,0 +1,149 @@
+extern crate bytes;
+extern crate futures;
+
+use futures::prelude::*;
+use futures::{executor, io};
+use futures::io::codec::{Encoder, FramedWrite};
+use futures::Async::{Ready, Pending};
+
+use bytes::{BytesMut, BufMut, BigEndian};
+
+use std::collections::VecDeque;
+
+macro_rules! mock {
+    ($($x:expr,)*) => {{
+        let mut v = VecDeque::new();
+        v.extend(vec![$($x),*]);
+        Mock { calls: v }
+    }};
+}
+
+fn dummy_cx<F>(f: F) where F: FnOnce(&mut task::Context) {
+    struct Fut<F>(Option<F>);
+
+    impl<F> Future for Fut<F> where F: FnOnce(&mut task::Context) {
+        type Item = ();
+        type Error = ();
+        fn poll(&mut self, cx: &mut task::Context) -> Poll<(), ()> {
+            (self.0.take().unwrap())(cx);
+            Ok(Async::Ready(()))
+        }
+    }
+
+    executor::block_on(Fut(Some(f))).unwrap();
+}
+
+struct U32Encoder;
+
+impl Encoder for U32Encoder {
+    type Item = u32;
+    type Error = io::Error;
+
+    fn encode(&mut self, item: u32, dst: &mut BytesMut) -> io::Result<()> {
+        // Reserve space
+        dst.reserve(4);
+        dst.put_u32::<BigEndian>(item);
+        Ok(())
+    }
+}
+
+#[test]
+fn write_multi_frame_in_packet() {
+    let mock = mock! {
+        Ok(Ready(b"\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec())),
+    };
+
+    let mut framed = FramedWrite::new(mock, U32Encoder);
+    framed.start_send(0).unwrap();
+    framed.start_send(1).unwrap();
+    framed.start_send(2).unwrap();
+
+    // Nothing written yet
+    assert_eq!(1, framed.get_ref().calls.len());
+
+    // Flush the writes
+    dummy_cx(|cx| {
+        assert!(framed.poll_flush(cx).unwrap().is_ready());
+    });
+
+    assert_eq!(0, framed.get_ref().calls.len());
+}
+
+#[test]
+fn write_hits_backpressure() {
+    const ITER: usize = 2 * 1024;
+
+    let mut mock = mock! {
+        // Block the `ITER`th write
+        Ok(Pending),
+        Ok(Ready(b"".to_vec())),
+    };
+
+    for i in 0..(ITER + 1) {
+        let mut b = BytesMut::with_capacity(4);
+        b.put_u32::<BigEndian>(i as u32);
+
+        // Append to the end
+        match mock.calls.back_mut().unwrap() {
+            &mut Ok(Ready(ref mut data)) => {
+                // Write in 2kb chunks
+                if data.len() < ITER {
+                    data.extend_from_slice(&b[..]);
+                    continue;
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        // Push a new new chunk
+        mock.calls.push_back(Ok(Ready(b[..].to_vec())));
+    }
+
+    let mut framed = FramedWrite::new(mock, U32Encoder);
+
+    for i in 0..ITER {
+        framed.start_send(i as u32).unwrap();
+    }
+
+    dummy_cx(|cx| {
+        // This should reject
+        assert!(!framed.poll_ready(cx).unwrap().is_ready());
+
+        // This should succeed and start flushing the buffer.
+        framed.start_send(ITER as u32).unwrap();
+
+        // Flush the rest of the buffer
+        assert!(framed.poll_flush(cx).unwrap().is_ready());
+    });
+
+    // Ensure the mock is empty
+    assert_eq!(0, framed.get_ref().calls.len());
+}
+
+// ===== Mock ======
+
+struct Mock {
+    calls: VecDeque<Poll<Vec<u8>, io::Error>>,
+}
+
+impl AsyncWrite for Mock {
+    fn poll_write(&mut self, _: &mut task::Context, src: &[u8]) -> Poll<usize, io::Error> {
+        match self.calls.pop_front().expect("unexpected write") {
+            Ok(Ready(data)) => {
+                assert!(src.len() >= data.len());
+                assert_eq!(&data[..], &src[..data.len()]);
+                Ok(Ready(data.len()))
+            }
+            Ok(Pending) => Ok(Pending),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), io::Error> {
+        Ok(Ready(()))
+    }
+
+    fn poll_close(&mut self, _: &mut task::Context) -> Poll<(), io::Error> {
+        Ok(Ready(()))
+    }
+}

--- a/futures-io/tests/length_delimited.rs
+++ b/futures-io/tests/length_delimited.rs
@@ -1,0 +1,601 @@
+extern crate futures;
+
+use futures::prelude::*;
+use futures::{executor, io};
+use futures::io::codec::length_delimited::*;
+use futures::Async::{Ready, Pending};
+
+use std::collections::VecDeque;
+
+macro_rules! mock {
+    ($($x:expr,)*) => {{
+        let mut v = VecDeque::new();
+        v.extend(vec![$($x),*]);
+        Mock { calls: v }
+    }};
+}
+
+fn dummy_cx<F>(f: F) where F: FnOnce(&mut task::Context) {
+    struct Fut<F>(Option<F>);
+
+    impl<F> Future for Fut<F> where F: FnOnce(&mut task::Context) {
+        type Item = ();
+        type Error = ();
+        fn poll(&mut self, cx: &mut task::Context) -> Poll<(), ()> {
+            (self.0.take().unwrap())(cx);
+            Ok(Async::Ready(()))
+        }
+    }
+
+    executor::block_on(Fut(Some(f))).unwrap();
+}
+
+#[test]
+fn read_empty_io_yields_nothing() {
+    let mut io = FramedRead::new(mock!());
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_frame_one_packet() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00\x00\x09abcdefghi"[..].into())),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_frame_one_packet_little_endian() {
+    let mut io = Builder::new()
+        .little_endian()
+        .new_read(mock! {
+            Ok(Ready(b"\x09\x00\x00\x00abcdefghi"[..].into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_multi_frame_one_packet() {
+    let mut data: Vec<u8> = vec![];
+    data.extend_from_slice(b"\x00\x00\x00\x09abcdefghi");
+    data.extend_from_slice(b"\x00\x00\x00\x03123");
+    data.extend_from_slice(b"\x00\x00\x00\x0bhello world");
+
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(data.into())),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"123"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"hello world"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_frame_multi_packet() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00"[..].into())),
+        Ok(Ready(b"\x00\x09abc"[..].into())),
+        Ok(Ready(b"defghi"[..].into())),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_multi_frame_multi_packet() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00"[..].into())),
+        Ok(Ready(b"\x00\x09abc"[..].into())),
+        Ok(Ready(b"defghi"[..].into())),
+        Ok(Ready(b"\x00\x00\x00\x0312"[..].into())),
+        Ok(Ready(b"3\x00\x00\x00\x0bhello world"[..].into())),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"123"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"hello world"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_frame_multi_packet_wait() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"\x00\x09abc"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"defghi"[..].into())),
+        Ok(Pending),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_multi_frame_multi_packet_wait() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"\x00\x09abc"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"defghi"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"\x00\x00\x00\x0312"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"3\x00\x00\x00\x0bhello world"[..].into())),
+        Ok(Pending),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"123"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"hello world"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_incomplete_head() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00"[..].into())),
+    });
+
+    dummy_cx(|cx| {
+        assert!(io.poll_next(cx).is_err());
+    })
+}
+
+#[test]
+fn read_incomplete_head_multi() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Pending),
+        Ok(Ready(b"\x00"[..].into())),
+        Ok(Pending),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert!(io.poll_next(cx).is_err());
+    })
+}
+
+#[test]
+fn read_incomplete_payload() {
+    let mut io = FramedRead::new(mock! {
+        Ok(Ready(b"\x00\x00\x00\x09ab"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"cd"[..].into())),
+        Ok(Pending),
+    });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        assert!(io.poll_next(cx).is_err());
+    })
+}
+
+#[test]
+fn read_max_frame_len() {
+    let mut io = Builder::new()
+        .max_frame_length(5)
+        .new_read(mock! {
+            Ok(Ready(b"\x00\x00\x00\x09abcdefghi"[..].into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap_err().kind(), io::ErrorKind::InvalidData);
+    })
+}
+
+#[test]
+fn read_update_max_frame_len_at_rest() {
+    let mut io = Builder::new()
+        .new_read(mock! {
+            Ok(Ready(b"\x00\x00\x00\x09abcdefghi"[..].into())),
+            Ok(Ready(b"\x00\x00\x00\x09abcdefghi"[..].into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        io.set_max_frame_length(5);
+        assert_eq!(io.poll_next(cx).unwrap_err().kind(), io::ErrorKind::InvalidData);
+    })
+}
+
+#[test]
+fn read_update_max_frame_len_in_flight() {
+    let mut io = Builder::new()
+        .new_read(mock! {
+            Ok(Ready(b"\x00\x00\x00\x09abcd"[..].into())),
+            Ok(Pending),
+            Ok(Ready(b"efghi"[..].into())),
+            Ok(Ready(b"\x00\x00\x00\x09abcdefghi"[..].into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Pending);
+        io.set_max_frame_length(5);
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap_err().kind(), io::ErrorKind::InvalidData);
+    })
+}
+
+#[test]
+fn read_one_byte_length_field() {
+    let mut io = Builder::new()
+        .length_field_length(1)
+        .new_read(mock! {
+            Ok(Ready(b"\x09abcdefghi"[..].into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_header_offset() {
+    let mut io = Builder::new()
+        .length_field_length(2)
+        .length_field_offset(4)
+        .new_read(mock! {
+            Ok(Ready(b"zzzz\x00\x09abcdefghi"[..].into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_multi_frame_one_packet_skip_none_adjusted() {
+    let mut data: Vec<u8> = vec![];
+    data.extend_from_slice(b"xx\x00\x09abcdefghi");
+    data.extend_from_slice(b"yy\x00\x03123");
+    data.extend_from_slice(b"zz\x00\x0bhello world");
+
+    let mut io = Builder::new()
+        .length_field_length(2)
+        .length_field_offset(2)
+        .num_skip(0)
+        .length_adjustment(4)
+        .new_read(mock! {
+            Ok(Ready(data.into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"xx\x00\x09abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"yy\x00\x03123"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"zz\x00\x0bhello world"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn read_single_multi_frame_one_packet_length_includes_head() {
+    let mut data: Vec<u8> = vec![];
+    data.extend_from_slice(b"\x00\x0babcdefghi");
+    data.extend_from_slice(b"\x00\x05123");
+    data.extend_from_slice(b"\x00\x0dhello world");
+
+    let mut io = Builder::new()
+        .length_field_length(2)
+        .length_adjustment(-2)
+        .new_read(mock! {
+            Ok(Ready(data.into())),
+        });
+
+    dummy_cx(|cx| {
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"123"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(Some(b"hello world"[..].into())));
+        assert_eq!(io.poll_next(cx).unwrap(), Ready(None));
+    })
+}
+
+#[test]
+fn write_single_frame_length_adjusted() {
+    let mut io = Builder::new()
+        .length_adjustment(-2)
+        .new_write(mock! {
+            Ok(Ready(b"\x00\x00\x00\x0b"[..].into())),
+            Ok(Ready(b"abcdefghi"[..].into())),
+            Ok(Ready(Flush)),
+        });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdefghi").unwrap();
+        assert!(io.poll_ready(cx).unwrap().is_ready());
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+#[test]
+fn write_nothing_yields_nothing() {
+    let mut io: FramedWrite<_, &'static [u8]> = FramedWrite::new(mock!());
+    dummy_cx(|cx| {
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+    })
+}
+
+#[test]
+fn write_single_frame_one_packet() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(Ready(b"\x00\x00\x00\x09"[..].into())),
+        Ok(Ready(b"abcdefghi"[..].into())),
+        Ok(Ready(Flush)),
+    });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdefghi").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+#[test]
+fn write_single_multi_frame_one_packet() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(Ready(b"\x00\x00\x00\x09"[..].into())),
+        Ok(Ready(b"abcdefghi"[..].into())),
+        Ok(Ready(b"\x00\x00\x00\x03"[..].into())),
+        Ok(Ready(b"123"[..].into())),
+        Ok(Ready(b"\x00\x00\x00\x0b"[..].into())),
+        Ok(Ready(b"hello world"[..].into())),
+        Ok(Ready(Flush)),
+    });
+    dummy_cx(|cx| {
+        assert!(io.poll_ready(cx).unwrap().is_ready());
+        io.start_send("abcdefghi").unwrap();
+        assert!(io.poll_ready(cx).unwrap().is_ready());
+        io.start_send("123").unwrap();
+        assert!(io.poll_ready(cx).unwrap().is_ready());
+        io.start_send("hello world").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+    });
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_single_multi_frame_multi_packet() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(Ready(b"\x00\x00\x00\x09"[..].into())),
+        Ok(Ready(b"abcdefghi"[..].into())),
+        Ok(Ready(Flush)),
+        Ok(Ready(b"\x00\x00\x00\x03"[..].into())),
+        Ok(Ready(b"123"[..].into())),
+        Ok(Ready(Flush)),
+        Ok(Ready(b"\x00\x00\x00\x0b"[..].into())),
+        Ok(Ready(b"hello world"[..].into())),
+        Ok(Ready(Flush)),
+    });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdefghi").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        io.start_send("123").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        io.start_send("hello world").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+#[test]
+fn write_single_frame_would_block() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(Pending),
+        Ok(Ready(b"\x00\x00"[..].into())),
+        Ok(Pending),
+        Ok(Ready(b"\x00\x09"[..].into())),
+        Ok(Ready(b"abcdefghi"[..].into())),
+        Ok(Ready(Flush)),
+    });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdefghi").unwrap();
+        assert!(!io.poll_flush(cx).unwrap().is_ready());
+        assert!(!io.poll_flush(cx).unwrap().is_ready());
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+#[test]
+fn write_single_frame_little_endian() {
+    let mut io = Builder::new()
+        .little_endian()
+        .new_write(mock! {
+            Ok(Ready(b"\x09\x00\x00\x00"[..].into())),
+            Ok(Ready(b"abcdefghi"[..].into())),
+            Ok(Ready(Flush)),
+        });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdefghi").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+
+#[test]
+fn write_single_frame_with_short_length_field() {
+    let mut io = Builder::new()
+        .length_field_length(1)
+        .new_write(mock! {
+            Ok(Ready(b"\x09"[..].into())),
+            Ok(Ready(b"abcdefghi"[..].into())),
+            Ok(Ready(Flush)),
+        });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdefghi").unwrap();
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+#[test]
+fn write_max_frame_len() {
+    let mut io = Builder::new()
+        .max_frame_length(5)
+        .new_write(mock! { });
+
+    assert_eq!(io.start_send("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_update_max_frame_len_at_rest() {
+    let mut io = Builder::new()
+        .new_write(mock! {
+            Ok(Ready(b"\x00\x00\x00\x06"[..].into())),
+            Ok(Ready(b"abcdef"[..].into())),
+            Ok(Ready(Flush)),
+        });
+
+    io.start_send("abcdef").unwrap();
+    dummy_cx(|cx| {
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+    });
+    io.set_max_frame_length(5);
+    assert_eq!(io.start_send("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_update_max_frame_len_in_flight() {
+    let mut io = Builder::new()
+        .new_write(mock! {
+            Ok(Ready(b"\x00\x00\x00\x06"[..].into())),
+            Ok(Ready(b"ab"[..].into())),
+            Ok(Pending),
+            Ok(Ready(b"cdef"[..].into())),
+            Ok(Ready(Flush)),
+        });
+
+    dummy_cx(|cx| {
+        io.start_send("abcdef").unwrap();
+        assert!(!io.poll_flush(cx).unwrap().is_ready());
+        io.set_max_frame_length(5);
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        assert_eq!(io.start_send("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
+        assert!(io.poll_flush(cx).unwrap().is_ready());
+        assert!(io.get_ref().calls.is_empty());
+    })
+}
+
+// ===== Test utils =====
+
+struct Mock {
+    calls: VecDeque<Poll<Op, io::Error>>,
+}
+
+#[derive(Debug, PartialEq)]
+enum Op {
+    Data(Vec<u8>),
+    Flush,
+}
+
+use self::Op::*;
+
+impl AsyncRead for Mock {
+    fn poll_read(&mut self, _: &mut task::Context, dst: &mut [u8]) -> Poll<usize, io::Error> {
+        match self.calls.pop_front() {
+            Some(Ok(Ready(Op::Data(data)))) => {
+                debug_assert!(dst.len() >= data.len());
+                dst[..data.len()].copy_from_slice(&data[..]);
+                Ok(Ready(data.len()))
+            }
+            Some(Ok(Ready(_))) => panic!(),
+            Some(Ok(Pending)) => Ok(Pending),
+            Some(Err(e)) => Err(e),
+            None => Ok(Ready(0)),
+        }
+    }
+}
+
+impl AsyncWrite for Mock {
+    fn poll_write(&mut self, _: &mut task::Context, src: &[u8]) -> Poll<usize, io::Error> {
+        match self.calls.pop_front() {
+            Some(Ok(Ready(Op::Data(data)))) => {
+                let len = data.len();
+                assert!(src.len() >= len, "expect={:?}; actual={:?}", data, src);
+                assert_eq!(&data[..], &src[..len]);
+                Ok(Ready(len))
+            }
+            Some(Ok(Ready(Op::Flush))) => panic!("unexpected flush"),
+            Some(Ok(Pending)) => Ok(Pending),
+            Some(Err(e)) => Err(e),
+            None => Ok(Ready(0)),
+        }
+    }
+
+    fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), io::Error> {
+        match self.calls.pop_front() {
+            Some(Ok(Ready(Op::Flush))) => {
+                Ok(Ready(()))
+            }
+            Some(Ok(Ready(Op::Data(data)))) => {
+                // Push the data back on-- it wasn't intended to be received yet
+                self.calls.push_front(Ok(Ready(Op::Data(data))));
+                Ok(Ready(()))
+            },
+            Some(Ok(Pending)) => Ok(Pending),
+            Some(Err(e)) => Err(e),
+            None => Ok(Ready(())),
+        }
+    }
+
+    fn poll_close(&mut self, _: &mut task::Context) -> Poll<(), io::Error> {
+        Ok(Ready(()))
+    }
+}
+
+impl<'a> From<&'a [u8]> for Op {
+    fn from(src: &'a [u8]) -> Op {
+        Op::Data(src.into())
+    }
+}
+
+impl From<Vec<u8>> for Op {
+    fn from(src: Vec<u8>) -> Op {
+        Op::Data(src)
+    }
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -255,6 +255,7 @@ pub mod prelude {
         Stream,
         Async,
         Poll,
+        task,
     };
 
     pub use futures_sink::Sink;


### PR DESCRIPTION
These are mostly a straight port from tokio-io-- we'll likely want to adapt them somewhat, but this change pulls them in and gets them all passing (which required adding a couple missing `AsyncWrite::flush` calls).

One interesting tidbit is the `dummy_ctx` function that I've added for several of the tests-- do we want to expose something like this for testing purposes so that users can examine the state of the world in between individual calls to `poll`?