### PR TITLE
Roll back mentions of traits in intra-rustdoc links to avoid ICE

### DIFF
--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -33,8 +33,9 @@ pub use self::result_::{result, ok, err, Result};
 ///
 /// When using a future, you generally won't call `poll` directly, but instead
 /// use combinators to build up asynchronous computations. A complete
-/// computation can then be spawned onto an [executor](::executor::Executor) as
-/// a new, independent task that will automatically be `poll`ed to completion.
+/// computation can then be spawned onto an
+/// [executor](../futures_core/executor/trait.Executor.html) as a new, independent
+/// task that will automatically be `poll`ed to completion.
 ///
 /// # Combinators
 ///
@@ -84,9 +85,9 @@ pub trait Future {
     /// actively re-`poll` pending futures that it still has an interest in.
     /// Usually this is done by building up a large computation as a single
     /// future (using combinators), then spawning that future as a *task* onto
-    /// an [executor](::executor::Executor). Executors ensure that each task is
-    /// `poll`ed every time a future internal to that task is ready to make
-    /// progress.
+    /// an [executor](../futures_core/executor/trait.Executor.html). Executors
+    /// ensure that each task is `poll`ed every time a future internal to that
+    /// task is ready to make progress.
     ///
     /// The `poll` function is not called repeatedly in a tight loop for
     /// futures, but only whenever the future itself is ready, as signaled via

--- a/futures-core/src/poll.rs
+++ b/futures-core/src/poll.rs
@@ -13,8 +13,7 @@ macro_rules! try_ready {
 
 /// A convenience wrapper for `Result<Async<T>, E>`.
 ///
-/// `Poll` is the return type of the [`poll` method](::future::Future::poll) on
-/// the [`Future` trait](::future::Future).
+/// `Poll` is the return type of the `poll` method on the `Future` trait.
 ///
 /// * `Ok(Async::Ready(t))` means the future has successfully resolved.
 /// * `Ok(Async::Pending)` means the future is not able to fully resolve yet.

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -70,7 +70,7 @@ if_std! {
         ///
         /// - Task-local data
         /// - A means of waking the task
-        /// - A means of spawning new tasks, i.e. an [executor](::executor::Executor)
+        /// - A means of spawning new tasks, i.e. an [executor]()
         pub fn new(map: &'a mut LocalMap, waker: &'a Waker, executor: &'a mut Executor) -> Context<'a> {
             Context { waker, map, executor }
         }


### PR DESCRIPTION
Work around https://github.com/rust-lang/rust/issues/48414