### PR TITLE
Revise channel docs

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -1,6 +1,10 @@
-//! Asynchronous channels
+//! Asynchronous channels.
 //!
-//! This crate provides channels which can be used to communicate between futures.
+//! This crate provides channels that can be used to communicate between
+//! asynchronous tasks.
+//!
+//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
+//! overview.
 
 #![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/futures-channel/0.2")]

--- a/futures-channel/src/lock.rs
+++ b/futures-channel/src/lock.rs
@@ -16,14 +16,14 @@ use self::core::sync::atomic::AtomicBool;
 /// This lock only supports the `try_lock` operation, however, and does not
 /// implement poisoning.
 #[derive(Debug)]
-pub struct Lock<T> {
+pub(crate) struct Lock<T> {
     locked: AtomicBool,
     data: UnsafeCell<T>,
 }
 
 /// Sentinel representing an acquired lock through which the data can be
 /// accessed.
-pub struct TryLock<'a, T: 'a> {
+pub(crate) struct TryLock<'a, T: 'a> {
     __ptr: &'a Lock<T>,
 }
 
@@ -38,7 +38,7 @@ unsafe impl<T: Send> Sync for Lock<T> {}
 
 impl<T> Lock<T> {
     /// Creates a new lock around the given value.
-    pub fn new(t: T) -> Lock<T> {
+    pub(crate) fn new(t: T) -> Lock<T> {
         Lock {
             locked: AtomicBool::new(false),
             data: UnsafeCell::new(t),
@@ -54,7 +54,7 @@ impl<T> Lock<T> {
     ///
     /// If `None` is returned then the lock is already locked, either elsewhere
     /// on this thread or on another thread.
-    pub fn try_lock(&self) -> Option<TryLock<T>> {
+    pub(crate) fn try_lock(&self) -> Option<TryLock<T>> {
         if !self.locked.swap(true, SeqCst) {
             Some(TryLock { __ptr: self })
         } else {

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -6,7 +6,7 @@
 //! [`Stream`](futures_core::Stream) and allows a task to read values out of the
 //! channel. If there is no message to read from the channel, the current task
 //! will be notified when a new value is sent. [`Sender`](Sender) implements the
-//! [`Sink`](futures_core::Sink) trait and allows a task to send messages into
+//! `Sink` trait and allows a task to send messages into
 //! the channel. If the channel is at capacity, the send will be rejected and
 //! the task will be notified when additional capacity is available. In other
 //! words, the channel provides backpressure.
@@ -18,8 +18,8 @@
 //!
 //! When all [`Sender`](Sender) handles have been dropped, it is no longer
 //! possible to send values into the channel. This is considered the termination
-//! event of the stream. As such, [`Sender::poll`](Sender::poll) will return
-//! `Ok(Ready(None))`.
+//! event of the stream. As such, [`Receiver::poll_next`](Receiver::poll_next)
+//! will return `Ok(Ready(None))`.
 //!
 //! If the [`Receiver`](Receiver) handle is dropped, then messages can no longer
 //! be read out of the channel. In this case, all further attempts to send will
@@ -131,7 +131,7 @@ pub struct Receiver<T> {
 #[derive(Debug)]
 pub struct UnboundedReceiver<T>(Receiver<T>);
 
-/// The error type for [`Sender`s](Sender) used as [`Sink`s](futures_core::Sink).
+/// The error type for [`Sender`s](Sender) used as `Sink`s.
 ///
 /// It will contain a value of type `T` if one was passed to `start_send`
 /// after the channel was closed.
@@ -323,14 +323,15 @@ impl SenderTask {
 
 /// Creates a bounded mpsc channel for communicating between asynchronous tasks.
 ///
-/// Being bounded, this channel provides back pressure to ensure that the sender
+/// Being bounded, this channel provides backpressure to ensure that the sender
 /// outpaces the receiver by only a limited amount. The channel's capacity is
 /// equal to `buffer + num-senders`. In other words, each sender gets a
 /// guaranteed slot in the channel capacity, and on top of that there are
 /// `buffer` "first come, first serve" slots available to all senders.
 ///
-/// The [`Receiver`](Receiver) returned implements the [`Stream`](Stream) trait,
-/// while [`Sender`](Sender) implements [`Sink`](Sink).
+/// The [`Receiver`](Receiver) returned implements the
+/// [`Stream`](futures_core::Stream) trait, while [`Sender`](Sender) implements
+/// `Sink`.
 pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
     // Check that the requested buffer size does not exceed the maximum buffer
     // size permitted by the system.

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -28,7 +28,7 @@
 //! A mostly lock-free multi-producer, single consumer queue for sending
 //! messages between asynchronous tasks.
 //!
-//! The queue implementatio is essentially the same one used for mpsc channels
+//! The queue implementation is essentially the same one used for mpsc channels
 //! in the standard library.
 //!
 //! Note that the current implementation of this queue has a caveat of the `pop`

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -25,11 +25,11 @@
  * policies, either expressed or implied, of Dmitry Vyukov.
  */
 
-//! A mostly lock-free multi-producer, single consumer queue.
+//! A mostly lock-free multi-producer, single consumer queue for sending
+//! messages between asynchronous tasks.
 //!
-//! This module contains an implementation of a concurrent MPSC queue. This
-//! queue can be used to share data between threads, and is also used as the
-//! building block of channels in rust.
+//! The queue implementatio is essentially the same one used for mpsc channels
+//! in the standard library.
 //!
 //! Note that the current implementation of this queue has a caveat of the `pop`
 //! method, and see the method for more information about it. Due to this

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -8,6 +8,7 @@ use std::thread;
 use futures::future::poll_fn;
 use futures::prelude::*;
 use futures::task;
+use futures::never::Never;
 use futures_channel::oneshot::*;
 use futures_executor::block_on;
 
@@ -44,9 +45,9 @@ struct WaitForCancel {
 
 impl Future for WaitForCancel {
     type Item = ();
-    type Error = ();
+    type Error = Never;
 
-    fn poll(&mut self, cx: &mut task::Context) -> Poll<(), ()> {
+    fn poll(&mut self, cx: &mut task::Context) -> Poll<(), Never> {
         self.tx.poll_cancel(cx)
     }
 }


### PR DESCRIPTION
Also slightly tweaked some APIs.

I was pretty confused by the sender-side APIs for mpsc channels -- especially in the unbounded case. It seemed like there was a ton of redundancy, and the docs don't distinguish between e.g. `start_send` and `unbounded_send`. Let's clarify that before landing.