### PR TITLE
Register Waker with AtomicWaker instead of context

### DIFF
--- a/futures-core/src/task/atomic_waker.rs
+++ b/futures-core/src/task/atomic_waker.rs
@@ -5,7 +5,7 @@ use core::cell::UnsafeCell;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::{Acquire, Release};
 
-use task::{self, Waker};
+use task::Waker;
 
 /// A synchronization primitive for task wakeup.
 ///
@@ -72,7 +72,7 @@ impl AtomicWaker {
         }
     }
 
-    /// Registers the current task to be notified on calls to `notify`.
+    /// Registers the waker to be notified on calls to `notify`.
     ///
     /// The new task will take place of any previous tasks that were registered
     /// by previous calls to `register`. Any calls to `notify` that happen after
@@ -87,10 +87,7 @@ impl AtomicWaker {
     /// idea. Concurrent calls to `register` will attempt to register different
     /// tasks to be notified. One of the callers will win and have its task set,
     /// but there is no guarantee as to which caller will succeed.
-    pub fn register(&self, cx: &mut task::Context) {
-        // Get a new task handle
-        let task = cx.waker();
-
+    pub fn register(&self, task: Waker) {
         match self.state.compare_and_swap(WAITING, LOCKED_WRITE, Acquire) {
             WAITING => {
                 unsafe {

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -255,7 +255,7 @@ impl<T> Stream for FuturesUnordered<T>
 
     fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<T::Item>, T::Error> {
         // Ensure `parent` is correctly set.
-        self.inner.parent.register(cx);
+        self.inner.parent.register(cx.waker());
 
         loop {
             let node = match unsafe { self.inner.dequeue() } {


### PR DESCRIPTION
This patch changes the AtomicWaker::register API to take a `Waker`
instance instead of `&mut Context`.

The existing implementation only needed the context to get a waker
handle. Switching the API to take the waker explicitly increases the
flexibility of `AtomicWaker`. There are cases where one wishes to
register a waker that is not associated with the current context.