### PR TITLE
Remove references to APR book

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -2,9 +2,6 @@
 //!
 //! This crate provides channels that can be used to communicate between
 //! asynchronous tasks.
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
 
 #![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/futures-channel/0.2")]

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -1,7 +1,4 @@
-//! Futures
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
+//! Futures.
 
 use Poll;
 use task;

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,7 +1,4 @@
 //! Core traits and types for asynchronous operations in Rust.
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
 
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations, warnings)]

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -1,7 +1,4 @@
-//! Asynchronous streams
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
+//! Asynchronous streams.
 
 use Poll;
 use task;

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -1,7 +1,4 @@
 //! Task notification.
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
 
 use core::fmt;
 

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -1,7 +1,4 @@
 //! Built-in executors and related tools.
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
 
 #![no_std]
 #![deny(missing_docs)]

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -3,9 +3,6 @@
 //! This crate contains the `AsyncRead` and `AsyncWrite` traits, the
 //! asynchronous analogs to `std::io::{Read, Write}`. The primary difference is
 //! that these traits integrate with the asynchronous task system.
-//!
-//! See [Asynchronous Programming in Rust](https://aturon.github.io/apr/) for an
-//! overview.
 
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -18,11 +18,6 @@
 //! threading. Large asynchronous computations are built up using futures,
 //! streams and sinks, and then spawned as independent tasks that are run to
 //! completion, but *do not block* the thread running them.
-//!
-//! **The best way to learn about this crate is through the [Asynchronous
-//! Programming in Rust](https://aturon.github.io/apr/) book**, which provides a
-//! comprehensive introduction. The docs within this crate, by contrast, are
-//! intended primarily as a reference.
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/futures/0.2")]


### PR DESCRIPTION
I've mostly updated the book, but also realized that I want to make some substantial changes to the early presentation, and figured better to just remove it for now and unblock 0.2.