### PR TITLE
Remove erroneous backtick from documentation

### DIFF
--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -59,7 +59,7 @@ pub trait Future {
     /// - `Ok(Async::Pending)` if the future is not ready yet
     /// - `Ok(Async::Ready(val))` with the result `val` of this future if it finished
     /// successfully.
-    /// - `Err(err)`` if the future is finished but resolved to an error `err`.
+    /// - `Err(err)` if the future is finished but resolved to an error `err`.
     ///
     /// Once a future has finished, clients should not `poll` it again.
     ///


### PR DESCRIPTION
Before: `Err(err)`` if the future is finished but resolved to an error `err`.

After: `Err(err)` if the future is finished but resolved to an error `err`.

I hope merging into master is okay, if not, just tell me.