### PR TITLE
Fix unused import when building futures-sink with no_std

### DIFF
--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -21,11 +21,12 @@ macro_rules! if_std {
     )*)
 }
 
-use futures_core::{Async, Poll, task};
+use futures_core::{Poll, task};
 
 if_std! {
     mod channel_impls;
 
+    use futures_core::Async;
     use futures_core::never::Never;
 
     impl<T> Sink for ::std::vec::Vec<T> {


### PR DESCRIPTION
Just a minor warning I noticed while trying out the `futures 0.2` `no_std` support.