### PR TITLE
fix UnboundedSender::poll_ready to check for channel being closed

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -487,6 +487,18 @@ impl<T> Sender<T> {
         Ok(())
     }
 
+    fn poll_ready_nb(&self) -> Poll<(), SendError> {
+        let state = decode_state(self.inner.state.load(SeqCst));
+        if state.is_open {
+            Ok(Async::Ready(()))
+        } else {
+            Err(SendError {
+                kind: SendErrorKind::Full,
+            })
+        }
+    }
+
+
     // Push message to the queue and signal to the receiver
     fn queue_push_and_signal(&self, msg: Option<T>) {
         // Push the message onto the message queue
@@ -646,8 +658,8 @@ impl<T> Sender<T> {
 
 impl<T> UnboundedSender<T> {
     /// Check if the channel is ready to receive a message.
-    pub fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), SendError> {
-        self.0.poll_ready(cx)
+    pub fn poll_ready(&self, _: &mut task::Context) -> Poll<(), SendError> {
+        self.0.poll_ready_nb()
     }
 
     /// Returns whether this channel is closed without needing a context.
@@ -660,7 +672,8 @@ impl<T> UnboundedSender<T> {
     /// This method should only be called after `poll_ready` has been used to
     /// verify that the channel is ready to receive a message.
     pub fn start_send(&mut self, msg: T) -> Result<(), SendError> {
-        self.0.start_send(msg)
+        self.0.do_send_nb(Some(msg))
+            .map_err(|e| e.err)
     }
 
     /// Sends a message along this channel.

--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -28,7 +28,7 @@ impl<T> Sink for UnboundedSender<T> {
     type SinkError = SendError;
 
     fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
-        self.poll_ready(cx)
+        UnboundedSender::poll_ready(&*self, cx)
     }
 
     fn start_send(&mut self, msg: T) -> Result<(), Self::SinkError> {
@@ -48,8 +48,8 @@ impl<'a, T> Sink for &'a UnboundedSender<T> {
     type SinkItem = T;
     type SinkError = SendError;
 
-    fn poll_ready(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
-        Ok(Async::Ready(()))
+    fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        UnboundedSender::poll_ready(*self, cx)
     }
 
     fn start_send(&mut self, msg: T) -> Result<(), Self::SinkError> {


### PR DESCRIPTION
It's quite confusing that the unbounded sender can return ready when you have a borrow of it:

```rust
let (tx, rx) = mpsc::unbounded();
drop(rx);
(&tx).poll_ready().unwrap(); // reports ready
(tx).poll_ready().unwrap(); // errors
```

This changes the behavior to be consistent.