### PR TITLE
change mpsc::Receiver's error to Never

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -85,6 +85,7 @@ use std::usize;
 
 use futures_core::task::{self, Waker};
 use futures_core::{Async, Poll, Stream};
+use futures_core::never::Never;
 
 use mpsc::queue::{Queue, PopResult};
 
@@ -837,9 +838,9 @@ impl<T> Receiver<T> {
 
 impl<T> Stream for Receiver<T> {
     type Item = T;
-    type Error = ();
+    type Error = Never;
 
-    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<T>, ()> {
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         loop {
             // Try to read a message off of the message queue.
             let msg = match self.next_message() {
@@ -904,9 +905,9 @@ impl<T> UnboundedReceiver<T> {
 
 impl<T> Stream for UnboundedReceiver<T> {
     type Item = T;
-    type Error = ();
+    type Error = Never;
 
-    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<T>, ()> {
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         self.0.poll_next(cx)
     }
 }

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -169,7 +169,7 @@ pub trait StreamExt: Stream {
     ///
     /// # fn main() {
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
-    /// let rx = rx.map_err(|()| 3);
+    /// let rx = rx.map_err(|_| 3);
     /// # }
     /// ```
     fn map_err<U, F>(self, f: F) -> MapErr<Self, F>
@@ -289,7 +289,7 @@ pub trait StreamExt: Stream {
     /// let rx = rx.then(|result| {
     ///     match result {
     ///         Ok(e) => Ok(e + 3),
-    ///         Err(()) => Err(4),
+    ///         Err(_) => Err(4),
     ///     }
     /// });
     /// # }
@@ -338,9 +338,9 @@ pub trait StreamExt: Stream {
     ///
     /// let rx = rx.and_then(|result| {
     ///     if result % 2 == 0 {
-    ///         Ok(result)
+    ///         Ok(Some(result))
     ///     } else {
-    ///         Err(())
+    ///         Ok(None)
     ///     }
     /// });
     /// # }


### PR DESCRIPTION
This matches `oneshot::Receiver`, making it clearer that you don't need to handle the error case with mpsc channels.