### PR TITLE
add Receiver::try_next method

### DIFF
--- a/futures-channel/tests/mpsc-close.rs
+++ b/futures-channel/tests/mpsc-close.rs
@@ -19,7 +19,7 @@ fn smoke() {
     });
 
     // `receiver` needs to be dropped for `sender` to stop sending and therefore before the join.
-    block_on(receiver.take(3).for_each(|_| Ok(()))).unwrap();
+    drop(block_on(receiver.take(3).for_each(|_| Ok(()))).unwrap());
 
     t.join().unwrap()
 }


### PR DESCRIPTION
Adds `try_next`, allowing popping values out of the channel when not in the context of a futures task. This is especially useful in combination with `Receiver::close()`.

My use case: I have a channel type that wraps `mpsc`'s channel. When the receiver drops, I need to drain it and signal all untouched values with a special error message. That'd happen in my `Drop` impl, where there is not `task::Context` available.