### PR TITLE
split up the purpose for try_send vs start_send

### DIFF
--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -39,13 +39,16 @@ fn send_recv_no_buffer() {
         assert!(tx.start_send(1).is_ok());
         assert!(tx.poll_ready(cx).unwrap().is_pending());
 
-        // Send second message
+        // poll_ready said Pending, so no room in buffer, therefore new sends
+        // should get rejected with is_full.
+        assert!(tx.start_send(0).unwrap_err().is_full());
         assert!(tx.poll_ready(cx).unwrap().is_pending());
 
         // Take the value
         assert_eq!(rx.poll_next(cx).unwrap(), Async::Ready(Some(1)));
         assert!(tx.poll_ready(cx).unwrap().is_ready());
 
+        // Send second message
         assert!(tx.poll_ready(cx).unwrap().is_ready());
         assert!(tx.start_send(2).is_ok());
         assert!(tx.poll_ready(cx).unwrap().is_pending());


### PR DESCRIPTION
- `try_send` will return the message back if there is an error.
- `start_send` will consume the message always.
- Change `TryChannelClosed` to `TrySendError`, since the former sounds
  like there was an error trying to close the channel.
- Change `ChannelClosed` to `SendError`, so that it may also notify in
  `start_send` if the queue is full.

If the user called `start_send` when the queue was full, they could
receive an error that the channel was disconnected instead, which is
misleading.

Additionally, when `ChannelClosed<T>` would have a `T` and when it
wasn't was not very clear, especially when it was the error value for
`poll_ready`, `poll_flush`, and `poll_close`.

Finally, there was bug that `start_send` would always push on the queue
even if the requested buffer size was met, essentially making all
channels unbounded unless you used `try_send`.

-----

Currently there is no real difference between `try_send` and `start_send`, other than they return different error types, one that always has the message, and one that sometimes does. With this new separation, it is clearer when to use which: if you want to try to get the value back, use `try_send`. Otherwise, use `start_send`.