### PR TITLE
add Sender::is_closed method

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -601,6 +601,11 @@ impl<T> Sender<T> {
         Ok(self.poll_unparked(Some(cx)))
     }
 
+    /// Returns whether this channel is closed without needing a context.
+    pub fn is_closed(&self) -> bool {
+        !decode_state(self.inner.state.load(SeqCst)).is_open
+    }
+
     fn poll_unparked(&mut self, cx: Option<&mut task::Context>) -> Async<()> {
         // First check the `maybe_parked` variable. This avoids acquiring the
         // lock in most cases
@@ -632,6 +637,11 @@ impl<T> UnboundedSender<T> {
     /// Check if the channel is ready to receive a message.
     pub fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), ChannelClosed<T>> {
         self.0.poll_ready(cx)
+    }
+
+    /// Returns whether this channel is closed without needing a context.
+    pub fn is_closed(&self) -> bool {
+        self.0.is_closed()
     }
 
     /// Send a message on the channel.


### PR DESCRIPTION
It useful to be able to check if the channel is closed without registered to a task.

I didn't do it in this PR because I'm unsure of the name, but it's related: as mention in https://github.com/rust-lang-nursery/futures-rs/issues/775, it would be useful to close a channel from a `Sender`. I'm not sure if it should be required to have a `Context`, like with `poll_close`, so that someone could signal a close in another thread, but I'm sure the name `close` is reserved to be the mini-future for `poll_close` that borrows self.