### PR TITLE
change Async::is_not_ready() to Async::is_pending()

### DIFF
--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -37,10 +37,10 @@ fn send_recv_no_buffer() {
 
         // Send first message
         assert!(tx.start_send(1).is_ok());
-        assert!(tx.poll_ready(cx).unwrap().is_not_ready());
+        assert!(tx.poll_ready(cx).unwrap().is_pending());
 
         // Send second message
-        assert!(tx.poll_ready(cx).unwrap().is_not_ready());
+        assert!(tx.poll_ready(cx).unwrap().is_pending());
 
         // Take the value
         assert_eq!(rx.poll_next(cx).unwrap(), Async::Ready(Some(1)));
@@ -48,7 +48,7 @@ fn send_recv_no_buffer() {
 
         assert!(tx.poll_ready(cx).unwrap().is_ready());
         assert!(tx.start_send(2).is_ok());
-        assert!(tx.poll_ready(cx).unwrap().is_not_ready());
+        assert!(tx.poll_ready(cx).unwrap().is_pending());
 
         // Take the value
         assert_eq!(rx.poll_next(cx).unwrap(), Async::Ready(Some(2)));
@@ -500,7 +500,7 @@ fn try_send_2() {
 
     let th = thread::spawn(|| {
         block_on(poll_fn(|cx| {
-            assert!(tx.poll_ready(cx).unwrap().is_not_ready());
+            assert!(tx.poll_ready(cx).unwrap().is_pending());
             Ok::<_, ()>(Async::Ready(()))
         })).unwrap();
 

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -17,8 +17,8 @@ fn smoke_poll() {
     let (mut tx, rx) = channel::<u32>();
     let mut rx = Some(rx);
     let f = poll_fn(|cx| {
-        assert!(tx.poll_cancel(cx).unwrap().is_not_ready());
-        assert!(tx.poll_cancel(cx).unwrap().is_not_ready());
+        assert!(tx.poll_cancel(cx).unwrap().is_pending());
+        assert!(tx.poll_cancel(cx).unwrap().is_pending());
         drop(rx.take());
         assert!(tx.poll_cancel(cx).unwrap().is_ready());
         assert!(tx.poll_cancel(cx).unwrap().is_ready());

--- a/futures-core/src/poll.rs
+++ b/futures-core/src/poll.rs
@@ -60,7 +60,7 @@ impl<T> Async<T> {
     }
 
     /// Returns whether this is `Async::Pending`
-    pub fn is_not_ready(&self) -> bool {
+    pub fn is_pending(&self) -> bool {
         !self.is_ready()
     }
 }

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -119,14 +119,14 @@ where
     }
 
     fn poll_flush(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
-        if self.try_empty_stream(cx)?.is_not_ready() {
+        if self.try_empty_stream(cx)?.is_pending() {
             return Ok(Async::Pending);
         }
         self.sink.poll_flush(cx)
     }
 
     fn poll_close(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
-        if self.try_empty_stream(cx)?.is_not_ready() {
+        if self.try_empty_stream(cx)?.is_pending() {
             return Ok(Async::Pending);
         }
         self.sink.poll_close(cx)

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -36,7 +36,7 @@ impl<S, U, F> Future for ForEach<S, U, F>
     fn poll(&mut self, cx: &mut task::Context) -> Poll<S, S::Error> {
         loop {
             if let Some(mut fut) = self.fut.take() {
-                if fut.poll(cx)?.is_not_ready() {
+                if fut.poll(cx)?.is_pending() {
                     self.fut = Some(fut);
                     return Ok(Async::Pending);
                 }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -145,7 +145,7 @@ fn select_cancels() {
     let d = d.map(move |d| { dtx.send(d).unwrap(); d });
 
     let f = b.select(d).then(unselect);
-    // assert!(f.poll(&mut Task::new()).is_not_ready());
+    // assert!(f.poll(&mut Task::new()).is_pending());
     assert!(brx.try_recv().is_err());
     assert!(drx.try_recv().is_err());
     a.send(1).unwrap();
@@ -161,8 +161,8 @@ fn select_cancels() {
     let d = d.map(move |d| { dtx.send(d).unwrap(); d });
 
     let mut f = executor::spawn(b.select(d).then(unselect));
-    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_not_ready());
-    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_not_ready());
+    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_pending());
+    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_pending());
     a.send(1).unwrap();
     assert!(f.poll_future_notify(&notify_panic(), 0).ok().unwrap().is_ready());
     drop((c, f));
@@ -207,7 +207,7 @@ fn join_incomplete() {
     let (a, b) = oneshot::channel::<i32>();
     let (tx, rx) = channel();
     let mut f = executor::spawn(ok(1).join(b).map(move |r| tx.send(r).unwrap()));
-    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_not_ready());
+    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_pending());
     assert!(rx.try_recv().is_err());
     a.send(2).unwrap();
     assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_ready());
@@ -216,7 +216,7 @@ fn join_incomplete() {
     let (a, b) = oneshot::channel::<i32>();
     let (tx, rx) = channel();
     let mut f = executor::spawn(b.join(Ok(2)).map(move |r| tx.send(r).unwrap()));
-    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_not_ready());
+    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_pending());
     assert!(rx.try_recv().is_err());
     a.send(1).unwrap();
     assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_ready());
@@ -225,7 +225,7 @@ fn join_incomplete() {
     let (a, b) = oneshot::channel::<i32>();
     let (tx, rx) = channel();
     let mut f = executor::spawn(ok(1).join(b).map_err(move |_r| tx.send(2).unwrap()));
-    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_not_ready());
+    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_pending());
     assert!(rx.try_recv().is_err());
     drop(a);
     assert!(f.poll_future_notify(&notify_noop(), 0).is_err());
@@ -234,7 +234,7 @@ fn join_incomplete() {
     let (a, b) = oneshot::channel::<i32>();
     let (tx, rx) = channel();
     let mut f = executor::spawn(b.join(Ok(2)).map_err(move |_r| tx.send(1).unwrap()));
-    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_not_ready());
+    assert!(f.poll_future_notify(&notify_noop(), 0).ok().unwrap().is_pending());
     assert!(rx.try_recv().is_err());
     drop(a);
     assert!(f.poll_future_notify(&notify_noop(), 0).is_err());

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -25,8 +25,8 @@ fn smoke() {
             assert_eq!(*lock, 1);
             *lock = 2;
 
-            assert!(b.poll_lock().is_not_ready());
-            assert!(a.poll_lock().is_not_ready());
+            assert!(b.poll_lock().is_pending());
+            assert!(a.poll_lock().is_pending());
         }
 
         assert!(b.poll_lock().is_ready());

--- a/tests/fuse.rs
+++ b/tests/fuse.rs
@@ -11,5 +11,5 @@ use support::*;
 fn fuse() {
     let mut future = executor::spawn(ok::<i32, u32>(2).fuse());
     assert!(future.poll_future_notify(&notify_panic(), 0).unwrap().is_ready());
-    assert!(future.poll_future_notify(&notify_panic(), 0).unwrap().is_not_ready());
+    assert!(future.poll_future_notify(&notify_panic(), 0).unwrap().is_pending());
 }

--- a/tests/futures_ordered.rs
+++ b/tests/futures_ordered.rs
@@ -18,7 +18,7 @@ fn works_1() {
 
     let mut spawn = futures::executor::spawn(stream);
     b_tx.send(99).unwrap();
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
 
     a_tx.send(33).unwrap();
     c_tx.send(33).unwrap();
@@ -43,7 +43,7 @@ fn works_2() {
     a_tx.send(33).unwrap();
     b_tx.send(33).unwrap();
     assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_ready());
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
     c_tx.send(33).unwrap();
     assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_ready());
 }
@@ -75,12 +75,12 @@ fn queue_never_unblocked() {
 
     let mut spawn = futures::executor::spawn(stream);
     for _ in 0..10 {
-        assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+        assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
     }
 
     b_tx.send(Box::new(())).unwrap();
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
     c_tx.send(Box::new(())).unwrap();
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
 }

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -73,15 +73,15 @@ fn finished_future_ok() {
 
     let mut spawn = futures::executor::spawn(stream);
     for _ in 0..10 {
-        assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+        assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
     }
 
     b_tx.send(Box::new(())).unwrap();
     let next = spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap();
     assert!(next.is_ready());
     c_tx.send(Box::new(())).unwrap();
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
-    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_not_ready());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
+    assert!(spawn.poll_stream_notify(&support::notify_noop(), 0).unwrap().is_pending());
 }
 
 #[test]

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -115,7 +115,7 @@ fn mpsc_blocking_start_send() {
         let flag = Flag::new();
         let mut task = executor::spawn(StartSendFut::new(tx, 1));
 
-        assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+        assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
         assert!(!flag.get());
         sassert_next(&mut rx, 0);
         assert!(flag.get());
@@ -143,7 +143,7 @@ fn with_flush() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     tx.send(()).unwrap();
     assert!(flag.get());
 
@@ -240,7 +240,7 @@ fn with_flush_propagate() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.flush());
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     assert!(!flag.get());
     assert_eq!(task.get_mut().get_mut().unwrap().get_mut().force_flush(), vec![0, 1]);
     assert!(flag.get());
@@ -340,7 +340,7 @@ fn buffer() {
 
     let flag = Flag::new();
     let mut task = executor::spawn(sink.send(2));
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     assert!(!flag.get());
     allow.start();
     assert!(flag.get());
@@ -376,19 +376,19 @@ fn fanout_backpressure() {
     let flag = Flag::new();
     let mut task = executor::spawn(sink.send(2));
     assert!(!flag.get());
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     let (item, left_recv) = left_recv.into_future().wait().unwrap();
     assert_eq!(item, Some(0));
     assert!(flag.get());
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     let (item, right_recv) = right_recv.into_future().wait().unwrap();
     assert_eq!(item, Some(0));
     assert!(flag.get());
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     let (item, left_recv) = left_recv.into_future().wait().unwrap();
     assert_eq!(item, Some(1));
     assert!(flag.get());
-    assert!(task.poll_future_notify(&flag, 0).unwrap().is_not_ready());
+    assert!(task.poll_future_notify(&flag, 0).unwrap().is_pending());
     let (item, right_recv) = right_recv.into_future().wait().unwrap();
     assert_eq!(item, Some(1));
     assert!(flag.get());

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,7 +27,7 @@ pub fn assert_done<T, F>(f: F, result: Result<T::Item, T::Error>)
 }
 
 pub fn assert_empty<T: Future, F: FnMut() -> T>(mut f: F) {
-    assert!(executor::spawn(f()).poll_future_notify(&notify_panic(), 0).ok().unwrap().is_not_ready());
+    assert!(executor::spawn(f()).poll_future_notify(&notify_panic(), 0).ok().unwrap().is_pending());
 }
 
 pub fn sassert_done<S: Stream>(s: &mut S) {


### PR DESCRIPTION
This makes the methods symmetrical with their variants, whereas before, it was less obvious that `is_not_ready` was for `Async::Pending`.