### PR TITLE
Ensure building `futures-executor` on `no_std` environments works

### DIFF
--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -11,14 +11,14 @@ Executors for asynchronous tasks based on the futures-rs library.
 """
 
 [features]
-std = ["futures-core/std", "futures-util/std", "futures-channel/std"]
+std = ["num_cpus", "futures-core/std", "futures-util/std", "futures-channel/std"]
 default = ["std"]
 
 [dependencies]
 futures-core = { path = "../futures-core", version = "0.2.0", default-features = false}
 futures-util = { path = "../futures-util", version = "0.2.0", default-features = false}
 futures-channel = { path = "../futures-channel", version = "0.2.0", default-features = false}
-num_cpus = "1.0"
+num_cpus = { version = "1.0", optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.2", default-features = false }


### PR DESCRIPTION
`num_cpus` is not capable of running in a `no_std` environment so just remove it as a dependency when building without `std`.