### PR TITLE
fix travis badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library is an implementation of **zero-cost futures** in Rust.
 
-[![Build Status](https://travis-ci.org/alexcrichton/futures-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/futures-rs)
+[![Build Status](https://travis-ci.org/rust-lang-nursery/futures-rs.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/futures-rs)
 [![Build status](https://ci.appveyor.com/api/projects/status/yl5w3ittk4kggfsh?svg=true)](https://ci.appveyor.com/project/alexcrichton/futures-rs)
 [![Crates.io](https://img.shields.io/crates/v/futures.svg?maxAge=2592000)](https://crates.io/crates/futures)
 


### PR DESCRIPTION
Fixes the travis badge in the README after the move into the `rust-lang-nursery` org.

The appveyor project that is linked is also wrong (when you navigate to https://ci.appveyor.com/project/alexcrichton/futures-rs you can see that the last build is over a month ago), but it seems this needs enabling on appveyor first.