### PR TITLE
Only include AtomicWaker with std build

### DIFF
--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -13,9 +13,6 @@ if_not_std! {
     type Exec<'a> = ();
 }
 
-mod atomic_waker;
-pub use self::atomic_waker::AtomicWaker;
-
 /// Information about the currently-running task.
 ///
 /// Contexts are always tied to the stack, since they are set up specifically
@@ -58,6 +55,9 @@ impl<'a> Context<'a> {
 }
 
 if_std! {
+    mod atomic_waker;
+    pub use self::atomic_waker::AtomicWaker;
+
     use std::boxed::Box;
     use Future;
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -353,10 +353,8 @@ pub mod task {
     //! The remaining types and traits in the module are used for implementing
     //! executors or dealing with synchronization issues around task wakeup.
 
-    pub use futures_core::task::{
-        AtomicWaker, Context, LocalMap, Waker, UnsafeWake,
-    };
+    pub use futures_core::task::{Context, LocalMap, Waker, UnsafeWake};
 
     #[cfg(feature = "std")]
-    pub use futures_core::task::{LocalKey, Wake};
+    pub use futures_core::task::{AtomicWaker, LocalKey, Wake};
 }


### PR DESCRIPTION
Workaround for #842 

This is not my preferred solution, but it's the best solution I can think of that works on stable rust