### PR TITLE
stream::select_all: replace "use_std" feature check with "std" check

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -93,7 +93,7 @@ if_std! {
     pub use self::catch_unwind::CatchUnwind;
     pub use self::chunks::Chunks;
     pub use self::collect::Collect;
-    pub use self::select_all::SelectAll;
+    pub use self::select_all::{select_all, SelectAll};
     pub use self::split::{SplitStream, SplitSink, ReuniteError};
     pub use self::futures_unordered::{futures_unordered, FuturesUnordered};
     pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
@@ -988,27 +988,4 @@ pub trait StreamExt: Stream {
     {
         Either::Right(self)
     }
-}
-
-/// Convert a list of streams into a `Stream` of results from the streams.
-///
-/// This essentially takes a list of streams (e.g. a vector, an iterator, etc.)
-/// and bundles them together into a single stream.
-/// The stream will yield items as they become available on the underlying
-/// streams internally, in the order they become available.
-///
-/// Note that the returned set can also be used to dynamically push more
-/// futures into the set as they become available.
-#[cfg(feature = "use_std")]
-pub fn select_all<I>(streams: I) -> SelectAll<I::Item>
-    where I: IntoIterator,
-          I::Item: Stream
-{
-    let mut set = SelectAll::new();
-
-    for stream in streams {
-        set.push(stream);
-    }
-
-    return set
 }

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -77,3 +77,25 @@ impl<S: Stream> Stream for SelectAll<S> {
         }
     }
 }
+
+/// Convert a list of streams into a `Stream` of results from the streams.
+///
+/// This essentially takes a list of streams (e.g. a vector, an iterator, etc.)
+/// and bundles them together into a single stream.
+/// The stream will yield items as they become available on the underlying
+/// streams internally, in the order they become available.
+///
+/// Note that the returned set can also be used to dynamically push more
+/// futures into the set as they become available.
+pub fn select_all<I>(streams: I) -> SelectAll<I::Item>
+    where I: IntoIterator,
+          I::Item: Stream
+{
+    let mut set = SelectAll::new();
+
+    for stream in streams {
+        set.push(stream);
+    }
+
+    return set
+}


### PR DESCRIPTION
This also moves the select_all fn into select_all.rs,
since that's where it should be (this uses if_std to
check for std, and prevents further issues with
not updating a feature name)

This e.g. leads to hiding this function from the current 0.2.0-alpha doc.