### PR TITLE
Integrate futures-stable into futures crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "futures-channel",
   "futures-executor",
   "futures-io",
-  "futures-util",
   "futures-sink",
+  "futures-stable",
+  "futures-util",
 ]

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -11,7 +11,7 @@ The core traits and types in for the `futures` library.
 """
 
 [dependencies]
-pin-api = { version = "0.1.2", default-features = false }
+pin-api = { version = "0.1.3", default-features = false }
 
 [features]
 default = ["std"]

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -10,6 +10,10 @@ description = """
 The core traits and types in for the `futures` library.
 """
 
+[dependencies]
+pin-api = { version = "0.1.2", default-features = false }
+
 [features]
 default = ["std"]
-std = []
+std = ["pin-api/std"]
+nightly = ["pin-api/nightly"]

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -142,6 +142,15 @@ if_std! {
         }
     }
 
+    #[cfg(feature = "nightly")]
+    impl<F: ?Sized + Future> Future for ::pin_api::PinBox<F> {
+        type Item = F::Item;
+        type Error = F::Error;
+
+        fn poll(&mut self, cx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+            unsafe { ::pin_api::PinMut::get_mut(&mut self.as_pin_mut()).poll(cx) }
+        }
+    }
 
     impl<F: Future> Future for ::std::panic::AssertUnwindSafe<F> {
         type Item = F::Item;

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -11,6 +11,9 @@
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(feature = "nightly")]
+extern crate pin_api;
+
 macro_rules! if_std {
     ($($i:item)*) => ($(
         #[cfg(feature = "std")]

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -83,6 +83,16 @@ if_std! {
         }
     }
 
+    #[cfg(feature = "nightly")]
+    impl<S: ?Sized + Stream> Stream for ::pin_api::PinBox<S> {
+        type Item = S::Item;
+        type Error = S::Error;
+
+        fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+            unsafe { ::pin_api::PinMut::get_mut(&mut self.as_pin_mut()).poll_next(cx) }
+        }
+    }
+
     impl<S: Stream> Stream for ::std::panic::AssertUnwindSafe<S> {
         type Item = S::Item;
         type Error = S::Error;

--- a/futures-stable/Cargo.toml
+++ b/futures-stable/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 
 [dependencies.pin-api]
-version = "0.1.2"
+version = "0.1.3"
 default-features = false
 
 [dependencies.futures-core]

--- a/futures-stable/Cargo.toml
+++ b/futures-stable/Cargo.toml
@@ -23,4 +23,4 @@ default-features = false
 [features]
 nightly = ["pin-api/nightly"]
 std = ["pin-api/std", "futures-core/std", "futures-executor/std"]
-default = ["std", "nightly"]
+default = ["std"]

--- a/futures-stable/Cargo.toml
+++ b/futures-stable/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "futures-stable"
+description = "futures which support internal references"
+version = "0.2.0"
+authors = ["boats <boats@mozilla.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang-nursery/futures-rs"
+
+[dependencies.pin-api]
+version = "0.1.2"
+default-features = false
+
+[dependencies.futures-core]
+path = "../futures-core"
+version = "0.2.0"
+default-features = false
+
+[dependencies.futures-executor]
+path = "../futures-executor"
+version = "0.2.0"
+default-features = false
+
+[features]
+nightly = ["pin-api/nightly"]
+std = ["pin-api/std", "futures-core/std", "futures-executor/std"]
+default = ["std", "nightly"]

--- a/futures-stable/src/executor.rs
+++ b/futures-stable/src/executor.rs
@@ -1,0 +1,35 @@
+use futures_core::{Future, Never};
+use futures_core::executor::{Executor, SpawnError};
+use futures_executor::{ThreadPool, LocalPool, LocalExecutor};
+use pin_api::PinBox;
+
+use StableFuture;
+use UnsafePin;
+
+pub trait StableExecutor: Executor {
+    fn spawn_pinned(&mut self, f: PinBox<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError>;
+}
+
+impl StableExecutor for ThreadPool {
+    fn spawn_pinned(&mut self, f: PinBox<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
+        unsafe { self.spawn(f.into_box_unchecked()) }
+    }
+}
+
+impl StableExecutor for LocalExecutor {
+    fn spawn_pinned(&mut self, f: PinBox<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
+        unsafe { self.spawn(f.into_box_unchecked()) }
+    }
+}
+
+pub fn block_on_stable<F: StableFuture>(f: F) -> Result<F::Item, F::Error> {
+    let mut pool = LocalPool::new();
+    let mut exec = pool.executor();
+
+    // run our main future to completion
+    let res = pool.run_until(unsafe { UnsafePin::new(f) }, &mut exec);
+    // run any remainingspawned tasks to completion
+    pool.run(&mut exec);
+
+    res
+}

--- a/futures-stable/src/lib.rs
+++ b/futures-stable/src/lib.rs
@@ -1,0 +1,95 @@
+#![no_std]
+#![cfg_attr(feature = "nightly", feature(arbitrary_self_types))]
+
+macro_rules! if_nightly {
+    ($($i:item)*) => ($(
+        #[cfg(feature = "nightly")]
+        $i
+    )*)
+}
+
+if_nightly! {
+    macro_rules! if_std {
+        ($($i:item)*) => ($(
+            #[cfg(feature = "std")]
+            $i
+        )*)
+    }
+
+    extern crate pin_api;
+    extern crate futures_core;
+    extern crate futures_executor;
+
+    use pin_api::PinMut;
+    use futures_core::{Future, Stream, Poll, task};
+
+    if_std! {
+        mod executor;
+        mod unsafe_pin;
+
+        use pin_api::PinBox;
+
+        pub use executor::{StableExecutor, block_on_stable};
+        use unsafe_pin::UnsafePin;
+    }
+
+    pub trait StableFuture {
+        type Item;
+        type Error;
+
+        fn poll(self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error>;
+
+        #[cfg(feature = "std")]
+        fn pin<'a>(self) -> PinBox<Future<Item = Self::Item, Error = Self::Error> + Send + 'a>
+            where Self: Send + Sized + 'a
+        {
+            PinBox::new(unsafe { UnsafePin::new(self) })
+        }
+
+        #[cfg(feature = "std")]
+        fn pin_local<'a>(self) -> PinBox<Future<Item = Self::Item, Error = Self::Error> + 'a>
+            where Self: Sized + 'a
+        {
+            PinBox::new(unsafe { UnsafePin::new(self) })
+        }
+    }
+
+    impl<F: Future> StableFuture for F {
+        type Item = F::Item;
+        type Error = F::Error;
+
+        fn poll(mut self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+            F::poll(unsafe { PinMut::get_mut(&mut self) }, ctx)
+        }
+    }
+
+    pub trait StableStream {
+        type Item;
+        type Error;
+
+        fn poll_next(self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error>;
+
+        #[cfg(feature = "std")]
+        fn pin<'a>(self) -> PinBox<Stream<Item = Self::Item, Error = Self::Error> + Send + 'a>
+            where Self: Send + Sized + 'a
+        {
+            PinBox::new(unsafe { UnsafePin::new(self) })
+        }
+
+        #[cfg(feature = "std")]
+        fn pin_local<'a>(self) -> PinBox<Stream<Item = Self::Item, Error = Self::Error> + 'a>
+            where Self: Sized + 'a
+        {
+            PinBox::new(unsafe { UnsafePin::new(self) })
+        }
+    }
+
+    impl<S: Stream> StableStream for S {
+        type Item = S::Item;
+        type Error = S::Error;
+
+        fn poll_next(mut self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+            S::poll_next(unsafe { PinMut::get_mut(&mut self) }, ctx)
+        }
+    }
+}

--- a/futures-stable/src/unsafe_pin.rs
+++ b/futures-stable/src/unsafe_pin.rs
@@ -1,0 +1,30 @@
+use pin_api::PinMut;
+use futures_core::{Future, Stream, Poll, task};
+
+use {StableFuture, StableStream};
+
+pub(crate) struct UnsafePin<T> {
+    inner: T,
+}
+
+impl<T> UnsafePin<T> {
+    pub(crate) unsafe fn new(inner: T) -> UnsafePin<T> {
+        UnsafePin { inner }
+    }
+}
+
+impl<'a, T: StableFuture> Future for UnsafePin<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+    fn poll(&mut self, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
+        T::poll(unsafe { PinMut::new_unchecked(&mut self.inner) }, ctx)
+    }
+}
+
+impl<'a, T: StableStream> Stream for UnsafePin<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+    fn poll_next(&mut self, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        T::poll_next(unsafe { PinMut::new_unchecked(&mut self.inner) }, ctx)
+    }
+}

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -24,8 +24,10 @@ futures-channel = { path = "../futures-channel", version = "0.2.0", default-feat
 futures-executor = { path = "../futures-executor", version = "0.2.0", default-features = false }
 futures-io = { path = "../futures-io", version = "0.2.0", default-features = false }
 futures-sink = { path = "../futures-sink", version = "0.2.0", default-features = false }
+futures-stable = { path = "../futures-stable", version = "0.2.0", default-features = false }
 futures-util = { path = "../futures-util", version = "0.2.0", default-features = false }
 
 [features]
-std = ["futures-core/std", "futures-executor/std", "futures-io/std", "futures-sink/std", "futures-util/std"]
+nightly = ["futures-stable/nightly"]
+std = ["futures-core/std", "futures-executor/std", "futures-io/std", "futures-sink/std", "futures-stable/std", "futures-util/std"]
 default = ["std"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -32,6 +32,7 @@ extern crate futures_channel;
 extern crate futures_executor;
 extern crate futures_io;
 extern crate futures_sink;
+extern crate futures_stable;
 extern crate futures_util;
 
 pub use futures_core::future::{Future, IntoFuture};
@@ -364,4 +365,12 @@ pub mod task {
 
     #[cfg(feature = "std")]
     pub use futures_core::task::{LocalKey, Wake};
+}
+
+#[cfg(feature = "nightly")]
+pub mod stable {
+    pub use futures_stable::{StableFuture, StableStream};
+
+    #[cfg(feature = "std")]
+    pub use futures_stable::{StableExecutor, block_on_stable};
 }


### PR DESCRIPTION
futures-stable provides adapters to work with futures that contain
internal self-references.

futures-stable only works on nightly. A new nightly feature is
added to futures to turn futures-stable on. The futures-stable
items are re-exported from the `stable` submodule.

Also on nightly only, Future and Stream are implemented for
PinBoxes of futures and streams.