### PR TITLE
Derive PartialEq and Eq for Waker

### DIFF
--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -232,6 +232,7 @@ pub unsafe trait UnsafeWake {
 /// If you're implementing an executor, the recommended way to create a `Waker`
 /// is via `Waker::from` applied to an `Arc<T>` value where `T: Wake`. The
 /// unsafe `new` constructor should be used only in niche, `no_std` settings.
+#[derive(PartialEq, Eq)]
 pub struct Waker {
     inner: *mut UnsafeWake,
 }


### PR DESCRIPTION
These impls can be useful sometimes - I see no reason not to include them.