### PR TITLE
Fix bug in AtomicWaker

### DIFF
--- a/futures-core/src/task/atomic_waker.rs
+++ b/futures-core/src/task/atomic_waker.rs
@@ -110,6 +110,8 @@ impl AtomicWaker {
     ///     type Error = Never;
     ///
     ///     fn poll(&mut self, cx: &mut task::Context) -> Poll<(), Never> {
+    ///         // Register **before** checkin `set` to avoid a race condition
+    ///         // that would result in lost notifications.
     ///         self.waker.register(cx.waker());
     ///
     ///         if self.set.load(SeqCst) {

--- a/futures-core/src/task/atomic_waker.rs
+++ b/futures-core/src/task/atomic_waker.rs
@@ -110,7 +110,7 @@ impl AtomicWaker {
     ///     type Error = Never;
     ///
     ///     fn poll(&mut self, cx: &mut task::Context) -> Poll<(), Never> {
-    ///         // Register **before** checkin `set` to avoid a race condition
+    ///         // Register **before** checking `set` to avoid a race condition
     ///         // that would result in lost notifications.
     ///         self.waker.register(cx.waker());
     ///

--- a/futures-core/src/task/atomic_waker.rs
+++ b/futures-core/src/task/atomic_waker.rs
@@ -177,7 +177,7 @@ impl AtomicWaker {
                 if actual == curr {
                     // Notify the task
                     unsafe {
-                        if let Some(ref waker) = *self.waker.get() {
+                        if let Some(waker) = (*self.waker.get()).take() {
                             waker.wake();
                         }
                     }


### PR DESCRIPTION
The original implementation of `AtomicWaker` required calls to
`register` to be coordinated. As such, there could be no concurrent
updates to the waker.

This requirement was removed by adding some additional internal
coordination to allow concurrent calls to `register`. However, this
change left an instance of the waker handle being used outside of the
coordination logic.

This patch fixes the bug by moving the usage of the `waker` instance
inside the lock's critical section.

This patch also reduces spurious notifications by removing the waker
once it has been notified.