### PR TITLE
Expose task::Context to lazy

### DIFF
--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -40,7 +40,7 @@ fn run_until_single_future() {
     {
         let mut pool = LocalPool::new();
         let mut exec = pool.executor();
-        let fut = lazy(|| {
+        let fut = lazy(|_| {
             cnt += 1;
             DONE
         });
@@ -55,7 +55,7 @@ fn run_until_ignores_spawned() {
     let mut pool = LocalPool::new();
     let mut exec = pool.executor();
     exec.spawn_local(Box::new(pending())).unwrap();
-    pool.run_until(lazy(|| DONE), &mut exec).unwrap();
+    pool.run_until(lazy(|_| DONE), &mut exec).unwrap();
 }
 
 #[test]
@@ -63,7 +63,7 @@ fn run_until_executes_spawned() {
     let (tx, rx) = oneshot::channel();
     let mut pool = LocalPool::new();
     let mut exec = pool.executor();
-    exec.spawn_local(Box::new(lazy(move || {
+    exec.spawn_local(Box::new(lazy(move |_| {
         tx.send(()).unwrap();
         DONE
     }))).unwrap();
@@ -79,8 +79,8 @@ fn run_executes_spawned() {
     let mut exec = pool.executor();
     let mut exec2 = pool.executor();
 
-    exec.spawn_local(Box::new(lazy(move || {
-        exec2.spawn_local(Box::new(lazy(move || {
+    exec.spawn_local(Box::new(lazy(move |_| {
+        exec2.spawn_local(Box::new(lazy(move |_| {
             cnt2.set(cnt2.get() + 1);
             DONE
         }))).unwrap();
@@ -103,7 +103,7 @@ fn run_spawn_many() {
 
     for _ in 0..ITER {
         let cnt = cnt.clone();
-        exec.spawn_local(Box::new(lazy(move || {
+        exec.spawn_local(Box::new(lazy(move |_| {
             cnt.set(cnt.get() + 1);
             DONE
         }))).unwrap();
@@ -120,7 +120,7 @@ fn nesting_run() {
     let mut pool = LocalPool::new();
     let mut exec = pool.executor();
 
-    exec.spawn(Box::new(lazy(|| {
+    exec.spawn(Box::new(lazy(|_| {
         let mut pool = LocalPool::new();
         let mut exec = pool.executor();
         pool.run(&mut exec);

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -741,7 +741,7 @@ pub trait FutureExt: Future {
     /// let mut future = future::ok::<i32, u32>(2);
     /// assert!(block_on(future.catch_unwind()).is_ok());
     ///
-    /// let mut future = future::lazy(|| -> FutureResult<i32, u32> {
+    /// let mut future = future::lazy(|_| -> FutureResult<i32, u32> {
     ///     panic!();
     ///     future::ok::<i32, u32>(2)
     /// });

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -119,7 +119,7 @@ pub mod executor {
     //! ```
     //! use futures::executor::ThreadPool;
     //! # use futures::future::{Future, lazy};
-    //! # let my_app: Box<Future<Item = (), Error = ()>> = Box::new(lazy(|| Ok(())));
+    //! # let my_app: Box<Future<Item = (), Error = ()>> = Box::new(lazy(|_| Ok(())));
     //!
     //! // assumping `my_app: Future`
     //! ThreadPool::new().run(my_app);

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -14,7 +14,7 @@ use support::*;
 
 #[test]
 fn smoke() {
-    let future = future::lazy(|| {
+    let future = future::lazy(|_| {
         let (a, b) = BiLock::new(1);
 
         {

--- a/tests/ready_queue.rs
+++ b/tests/ready_queue.rs
@@ -13,7 +13,7 @@ impl AssertSendSync for FuturesUnordered<()> {}
 
 #[test]
 fn basic_usage() {
-    future::lazy(move || {
+    future::lazy(move |_| {
         let mut queue = FuturesUnordered::new();
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
@@ -43,7 +43,7 @@ fn basic_usage() {
 
 #[test]
 fn resolving_errors() {
-    future::lazy(move || {
+    future::lazy(move |_| {
         let mut queue = FuturesUnordered::new();
         let (tx1, rx1) = oneshot::channel();
         let (tx2, rx2) = oneshot::channel();
@@ -73,7 +73,7 @@ fn resolving_errors() {
 
 #[test]
 fn dropping_ready_queue() {
-    future::lazy(move || {
+    future::lazy(move |_| {
         let mut queue = FuturesUnordered::new();
         let (mut tx1, rx1) = oneshot::channel::<()>();
         let (mut tx2, rx2) = oneshot::channel::<()>();
@@ -148,7 +148,7 @@ fn stress() {
 
 #[test]
 fn panicking_future_dropped() {
-    future::lazy(move || {
+    future::lazy(move |_| {
         let mut queue = FuturesUnordered::new();
         queue.push(future::poll_fn(|| -> Poll<i32, i32> {
             panic!()

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -185,7 +185,7 @@ fn recursive_poll_with_unpark() {
     let f1 = run_stream.shared();
     let f2 = f1.clone();
     let f3 = f1.clone();
-    tx0.unbounded_send(Box::new(future::lazy(move || {
+    tx0.unbounded_send(Box::new(future::lazy(move |_| {
         task::current().notify();
         f1.map(|_|()).map_err(|_|())
             .select(rx1.map_err(|_|()))

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -109,7 +109,7 @@ impl<S: Sink> Future for StartSendFut<S> {
 fn mpsc_blocking_start_send() {
     let (mut tx, mut rx) = mpsc::channel::<i32>(0);
 
-    futures::future::lazy(|| {
+    futures::future::lazy(|_| {
         assert_eq!(tx.start_send(0).unwrap(), AsyncSink::Ready);
 
         let flag = Flag::new();


### PR DESCRIPTION
I'm currently working on moving the hyper 0.12.x branch over to the futures 0.2 alpha release.

As part of this, I'm starting to notice a few places where I would like to get hold of `task::Context` without needing to write a special future for it.

Here is an example:

```rust
fut.and_then(move |res| {
    // how do I get access to `cx`?
    if let Ok(Async::Pending) = pooled.tx.poll_ready(cx) {
        // do stuff
    }

    Ok(Async::Ready(res))
});
```

I tried using `poll_fn`, since that gives me the `task::Context` as an argument, but since it has a `FnMut` it doesn't work for most of cases I've tried.

Therefore I would like to propose this change, introducing `task::Context` as an argument to the closure passed in to `lazy`, similar to how it works for `poll_fn`.

Let me know what you think!