### PR TITLE
use `*const UnsafeWake` instead of `mut`

### DIFF
--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -232,7 +232,7 @@ pub unsafe trait UnsafeWake {
 /// is via `Waker::from` applied to an `Arc<T>` value where `T: Wake`. The
 /// unsafe `new` constructor should be used only in niche, `no_std` settings.
 pub struct Waker {
-    inner: *mut UnsafeWake,
+    inner: *const UnsafeWake,
 }
 
 unsafe impl Send for Waker {}
@@ -249,7 +249,7 @@ impl Waker {
     /// use the `Waker::from` function instead which works with the safe
     /// `Arc` type and the safe `Wake` trait.
     #[inline]
-    pub unsafe fn new(inner: *mut UnsafeWake) -> Waker {
+    pub unsafe fn new(inner: *const UnsafeWake) -> Waker {
         Waker { inner: inner }
     }
 
@@ -369,7 +369,7 @@ if_std! {
     {
         fn from(rc: Arc<T>) -> Waker {
             unsafe {
-                let ptr = mem::transmute::<Arc<T>, *mut ArcWrapped<T>>(rc);
+                let ptr = mem::transmute::<Arc<T>, *const ArcWrapped<T>>(rc);
                 Waker::new(ptr)
             }
         }

--- a/futures-util/src/stream/futures_unordered.rs
+++ b/futures-util/src/stream/futures_unordered.rs
@@ -538,7 +538,7 @@ impl<'a, T> From<NodeToHandle<'a, T>> for Waker {
     fn from(handle: NodeToHandle<'a, T>) -> Waker {
         unsafe {
             let ptr = handle.0.clone();
-            let ptr = mem::transmute::<Arc<Node<T>>, *mut ArcNode<T>>(ptr);
+            let ptr = mem::transmute::<Arc<Node<T>>, *const ArcNode<T>>(ptr);
             Waker::new(hide_lt(ptr))
         }
     }
@@ -573,8 +573,8 @@ unsafe impl<T> UnsafeWake for ArcNode<T> {
     }
 }
 
-unsafe fn hide_lt<T>(p: *mut ArcNode<T>) -> *mut UnsafeWake {
-    mem::transmute(p as *mut UnsafeWake)
+unsafe fn hide_lt<T>(p: *const ArcNode<T>) -> *const UnsafeWake {
+    mem::transmute(p as *const UnsafeWake)
 }
 
 impl<T> Node<T> {


### PR DESCRIPTION
Hi,

I couldn't find a good reason to use `*mut UnsafeWake` in the git history (it was introduced in 42f690993 as `pub struct NotifyHandle { inner: *mut UnsafeNotify, }`).

Given that the `UnsafeWake` trait methods take `&self` (i.e. don't need `mut`) and `Arc::{from,into}_raw` operates with `*const T` I suggest using `*const UnsafeWake` instead.