### PR TITLE
Rewrite `AtomicTask`, fixing unsoundness

### DIFF
--- a/src/task_impl/atomic_task.rs
+++ b/src/task_impl/atomic_task.rs
@@ -190,7 +190,7 @@ impl AtomicTask {
 
                     loop {
                         let res = self.state.compare_exchange(
-                            curr, WAITING, Release, Acquire);
+                            curr, WAITING, AcqRel, Acquire);
 
                         match res {
                             Ok(_) => {


### PR DESCRIPTION
**This is a work in progress** I am creating the PR early in case anyone wants to take an early look.

The `AtomicTask` abstraction was initially added as an internal utility for a specific use case. It has since been included in the public API.

The original implementation was edited incrementally, unfortunately adding bugs. An attempt (#868) was made to fix an unsoundness issue as well as another bug, but this unfortunately introduced new unsoundness due to another pre-existing bug that just happened to be hidden by the bug that was fixed... i.e., it was a mess.

This PR attempts to resolve the issues by taking starting from scratch.

Preliminary testing finds that this PR fixes the issue tracked in https://github.com/tokio-rs/tokio/issues/236, but more thorough testing and reviewing is needed.

### Remaining

* [x] More extensive testing against Tokio
* [x] Document implementation.