### PR TITLE
Clean up a few futures-util issues

### DIFF
--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -18,7 +18,8 @@ fn sequence() {
     let t = thread::spawn(move || {
         block_on(send(amt, tx)).unwrap()
     });
-    let mut list = block_on(rx.collect()).unwrap().into_iter();
+    let list: Vec<_> = block_on(rx.collect()).unwrap();
+    let mut list = list.into_iter();
     for i in (1..amt + 1).rev() {
         assert_eq!(list.next(), Some(i));
     }

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -23,7 +23,8 @@ fn send_recv() {
     let (tx, rx) = mpsc::channel::<i32>(16);
 
     block_on(tx.send(1)).unwrap();
-    assert_eq!(block_on(rx.collect()).unwrap(), vec![1]);
+    let v: Vec<_> = block_on(rx.collect()).unwrap();
+    assert_eq!(v, vec![1]);
 }
 
 #[test]
@@ -84,7 +85,8 @@ fn send_recv_threads() {
         block_on(tx.send(1)).unwrap();
     });
 
-    assert_eq!(block_on(rx.take(1).collect()).unwrap(), vec![1]);
+    let v: Vec<_> = block_on(rx.take(1).collect()).unwrap();
+    assert_eq!(v, vec![1]);
 
     t.join().unwrap();
 }
@@ -218,7 +220,7 @@ fn stress_shared_unbounded() {
     let (tx, rx) = mpsc::unbounded::<i32>();
 
     let t = thread::spawn(move|| {
-        let result = block_on(rx.collect()).unwrap();
+        let result: Vec<_> = block_on(rx.collect()).unwrap();
         assert_eq!(result.len(), (AMT * NTHREADS) as usize);
         for item in result {
             assert_eq!(item, 1);
@@ -247,7 +249,7 @@ fn stress_shared_bounded_hard() {
     let (tx, rx) = mpsc::channel::<i32>(0);
 
     let t = thread::spawn(move|| {
-        let result = block_on(rx.collect()).unwrap();
+        let result: Vec<_> = block_on(rx.collect()).unwrap();
         assert_eq!(result.len(), (AMT * NTHREADS) as usize);
         for item in result {
             assert_eq!(item, 1);
@@ -367,7 +369,8 @@ fn stress_drop_sender() {
     }
 
     for _ in 0..10000 {
-        assert_eq!(block_on(list().collect()).unwrap(), vec![1, 2, 3]);
+        let v: Vec<_> = block_on(list().collect()).unwrap();
+        assert_eq!(v, vec![1, 2, 3]);
     }
 }
 
@@ -456,7 +459,7 @@ fn stress_poll_ready() {
         }
         drop(tx);
 
-        let result = block_on(rx.collect()).unwrap();
+        let result: Vec<_> = block_on(rx.collect()).unwrap();
         assert_eq!(result.len() as u32, AMT * NTHREADS);
 
         for thread in threads {
@@ -485,7 +488,7 @@ fn try_send_1() {
         }
     });
 
-    let result = block_on(rx.collect()).unwrap();
+    let result: Vec<_> = block_on(rx.collect()).unwrap();
     for (i, j) in result.into_iter().enumerate() {
         assert_eq!(i, j);
     }

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -68,11 +68,11 @@ fn send_shared_recv() {
     let tx2 = tx1.clone();
 
     block_on(tx1.send(1)).unwrap();
-    let (item, rx) = block_on(rx.into_future()).ok().unwrap();
+    let (item, rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(item, Some(1));
 
     block_on(tx2.send(2)).unwrap();
-    let item = block_on(rx.into_future()).ok().unwrap().0;
+    let item = block_on(rx.next()).ok().unwrap().0;
     assert_eq!(item, Some(2));
 }
 
@@ -100,11 +100,11 @@ fn send_recv_threads_no_capacity() {
         block_on(a.send(2).join(b.send(()))).unwrap();
     });
 
-    let readyrx = block_on(readyrx.into_future()).ok().unwrap().1;
-    let (item, rx) = block_on(rx.into_future()).ok().unwrap();
+    let readyrx = block_on(readyrx.next()).ok().unwrap().1;
+    let (item, rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(item, Some(1));
-    drop(block_on(readyrx.into_future()).ok().unwrap());
-    let item = block_on(rx.into_future()).ok().unwrap().0;
+    drop(block_on(readyrx.next()).ok().unwrap());
+    let item = block_on(rx.next()).ok().unwrap().0;
     assert_eq!(item, Some(2));
 
     t.join().unwrap();
@@ -297,7 +297,7 @@ fn stress_receiver_multi_task_bounded_hard() {
                 };
                 if i % 5 == 0 {
                     let rx = rx.unwrap();
-                    let (item, rest) = block_on(rx.into_future()).ok().unwrap();
+                    let (item, rest) = block_on(rx.next()).ok().unwrap();
 
                     if item.is_none() {
                         break;
@@ -386,13 +386,13 @@ fn stress_close_receiver_iter() {
     });
 
     // Read one message to make sure thread effectively started
-    let (item, mut rx) = block_on(rx.into_future()).ok().unwrap();
+    let (item, mut rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(Some(1), item);
 
     rx.close();
 
     for i in 2.. {
-        let (item, r) = block_on(rx.into_future()).ok().unwrap();
+        let (item, r) = block_on(rx.next()).ok().unwrap();
         rx = r;
         match item {
             Some(r) => assert!(i == r),
@@ -512,11 +512,11 @@ fn try_send_2() {
     });
 
     drop(block_on(readyrx));
-    let (item, rx) = block_on(rx.into_future()).ok().unwrap();
+    let (item, rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(item, Some("hello"));
-    let (item, rx) = block_on(rx.into_future()).ok().unwrap();
+    let (item, rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(item, Some("goodbye"));
-    let item = block_on(rx.into_future()).ok().unwrap().0;
+    let item = block_on(rx.next()).ok().unwrap().0;
     assert_eq!(item, None);
 
     th.join().unwrap();
@@ -531,15 +531,15 @@ fn try_send_fail() {
     // This should fail
     assert!(tx.try_send("fail").is_err());
 
-    let (item, rx) = block_on(rx.into_future()).ok().unwrap();
+    let (item, rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(item, Some("hello"));
 
     tx.try_send("goodbye").unwrap();
     drop(tx);
 
-    let (item, rx) = block_on(rx.into_future()).ok().unwrap();
+    let (item, rx) = block_on(rx.next()).ok().unwrap();
     assert_eq!(item, Some("goodbye"));
-    let item = block_on(rx.into_future()).ok().unwrap().0;
+    let item = block_on(rx.next()).ok().unwrap().0;
     assert_eq!(item, None);
 }
 

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -556,12 +556,14 @@ pub trait FutureExt: Future {
     ///
     /// # fn main() {
     /// let future = future::ok::<_, bool>(17);
-    /// let mut stream = future.into_stream().collect();
-    /// assert_eq!(Ok(vec![17]), block_on(stream));
+    /// let stream = future.into_stream();
+    /// let collected: Vec<_> = block_on(stream.collect()).unwrap();
+    /// assert_eq!(collected, vec![17]);
     ///
     /// let future = future::err::<bool, _>(19);
-    /// let mut stream = future.into_stream().collect();
-    /// assert_eq!(Err(19), block_on(stream));
+    /// let stream = future.into_stream();
+    /// let collected: Result<Vec<_>, _> = block_on(stream.collect());
+    /// assert_eq!(collected, Err(19));
     /// # }
     /// ```
     fn into_stream(self) -> IntoStream<Self>
@@ -651,7 +653,7 @@ pub trait FutureExt: Future {
     /// let future_of_a_stream = future::ok::<_, bool>(stream::iter_ok(stream_items));
     ///
     /// let stream = future_of_a_stream.flatten_stream();
-    /// let list = block_on(stream.collect()).unwrap();
+    /// let list: Vec<_> = block_on(stream.collect()).unwrap();
     /// assert_eq!(list, vec![17, 18, 19]);
     /// # }
     /// ```

--- a/futures-util/src/stream/future.rs
+++ b/futures-util/src/stream/future.rs
@@ -3,7 +3,7 @@ use futures_core::task;
 
 /// A combinator used to temporarily convert a stream into a future.
 ///
-/// This future is returned by the `Stream::into_future` method.
+/// This future is returned by the `Stream::next` method.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct StreamFuture<S> {

--- a/futures-util/src/stream/iter_result.rs
+++ b/futures-util/src/stream/iter_result.rs
@@ -25,13 +25,13 @@ pub struct IterResult<I> {
 ///
 /// # fn main() {
 /// let mut stream = stream::iter_result(vec![Ok(17), Err(false), Ok(19)]);
-/// let (item, stream) = block_on(stream.into_future()).unwrap();
+/// let (item, stream) = block_on(stream.next()).unwrap();
 /// assert_eq!(Some(17), item);
-/// let (err, stream) = block_on(stream.into_future()).unwrap_err();
+/// let (err, stream) = block_on(stream.next()).unwrap_err();
 /// assert_eq!(false, err);
-/// let (item, stream) = block_on(stream.into_future()).unwrap();
+/// let (item, stream) = block_on(stream.next()).unwrap();
 /// assert_eq!(Some(19), item);
-/// let (item, _) = block_on(stream.into_future()).unwrap();
+/// let (item, _) = block_on(stream.next()).unwrap();
 /// assert_eq!(None, item);
 /// # }
 /// ```

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -113,7 +113,7 @@ pub trait StreamExt: Stream {
     ///
     /// The returned future can be used to compose streams and futures together by
     /// placing everything into the "world of futures".
-    fn into_future(self) -> StreamFuture<Self>
+    fn next(self) -> StreamFuture<Self>
         where Self: Sized
     {
         future::new(self)

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -78,6 +78,7 @@ pub use self::recover::Recover;
 
 if_std! {
     use std;
+    use std::iter::Extend;
 
     mod buffered;
     mod buffer_unordered;
@@ -419,7 +420,7 @@ pub trait StreamExt: Stream {
     /// # }
     /// ```
     #[cfg(feature = "std")]
-    fn collect(self) -> Collect<Self>
+    fn collect<C: Default + Extend<Self::Item>>(self) -> Collect<Self, C>
         where Self: Sized
     {
         collect::new(self)
@@ -732,7 +733,7 @@ pub trait StreamExt: Stream {
     /// // collect all the results
     /// let stream = stream_panicking.catch_unwind().then(|r| Ok::<_, ()>(r));
     ///
-    /// let results = block_on(stream.collect()).unwrap();
+    /// let results: Vec<_> = block_on(stream.collect()).unwrap();
     /// match results[0] {
     ///     Ok(Ok(10)) => {}
     ///     _ => panic!("unexpected result!"),
@@ -821,7 +822,7 @@ pub trait StreamExt: Stream {
     /// let stream = stream1.chain(stream2)
     ///     .then(|result| Ok::<_, ()>(result));
     ///
-    /// let result = block_on(stream.collect()).unwrap();
+    /// let result: Vec<_> = block_on(stream.collect()).unwrap();
     /// assert_eq!(result, vec![
     ///     Ok(10),
     ///     Err(false),

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -19,10 +19,12 @@ pub struct Once<T, E>(Option<Result<T, E>>);
 ///
 /// # fn main() {
 /// let mut stream = stream::once::<(), _>(Err(17));
-/// assert_eq!(Err(17), block_on(stream.collect()));
+/// let collected: Result<Vec<_>, _> = block_on(stream.collect());
+/// assert_eq!(collected, Err(17));
 ///
 /// let mut stream = stream::once::<_, ()>(Ok(92));
-/// assert_eq!(Ok(vec![92]), block_on(stream.collect()));
+/// let collected: Result<Vec<_>, _> = block_on(stream.collect());
+/// assert_eq!(collected, Ok(vec![92]));
 /// # }
 /// ```
 pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -1,4 +1,4 @@
-use futures_core::{Poll, Async, Stream};
+use futures_core::{Poll, Async, Stream, IntoFuture, Future};
 use futures_core::task;
 
 /// A stream which emits single element and then EOF.
@@ -6,7 +6,7 @@ use futures_core::task;
 /// This stream will never block and is always ready.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
-pub struct Once<T, E>(Option<Result<T, E>>);
+pub struct Once<F>(Option<F>);
 
 /// Creates a stream of single element
 ///
@@ -18,28 +18,34 @@ pub struct Once<T, E>(Option<Result<T, E>>);
 /// use futures_executor::block_on;
 ///
 /// # fn main() {
-/// let mut stream = stream::once::<(), _>(Err(17));
+/// let mut stream = stream::once::<Result<(), _>>(Err(17));
 /// let collected: Result<Vec<_>, _> = block_on(stream.collect());
 /// assert_eq!(collected, Err(17));
 ///
-/// let mut stream = stream::once::<_, ()>(Ok(92));
+/// let mut stream = stream::once::<Result<_, ()>>(Ok(92));
 /// let collected: Result<Vec<_>, _> = block_on(stream.collect());
 /// assert_eq!(collected, Ok(vec![92]));
 /// # }
 /// ```
-pub fn once<T, E>(item: Result<T, E>) -> Once<T, E> {
-    Once(Some(item))
+pub fn once<F: IntoFuture>(item: F) -> Once<F::Future> {
+    Once(Some(item.into_future()))
 }
 
-impl<T, E> Stream for Once<T, E> {
-    type Item = T;
-    type Error = E;
+impl<F: Future> Stream for Once<F> {
+    type Item = F::Item;
+    type Error = F::Error;
 
-    fn poll_next(&mut self, _: &mut task::Context) -> Poll<Option<T>, E> {
-        match self.0.take() {
-            Some(Ok(e)) => Ok(Async::Ready(Some(e))),
-            Some(Err(e)) => Err(e),
-            None => Ok(Async::Ready(None)),
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<F::Item>, F::Error> {
+        if let Some(mut f) = self.0.take() {
+            match f.poll(cx)? {
+                Async::Ready(x) => Ok(Async::Ready(Some(x))),
+                Async::Pending => {
+                    self.0 = Some(f);
+                    Ok(Async::Pending)
+                }
+            }
+        } else {
+            Ok(Async::Ready(None))
         }
     }
 }

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -58,7 +58,7 @@ impl<S: Stream> SelectAll<S> {
     /// ensure that `SelectAll::poll` is called in order to receive task
     /// notifications.
     pub fn push(&mut self, stream: S) {
-        self.inner.push(stream.into_future());
+        self.inner.push(stream.next());
     }
 }
 


### PR DESCRIPTION
This PR knocks out a couple of the remaining breaking changes to `futures-util` ahead of the initial 0.2.0 release. Remaining breaking issues are punted.