### PR TITLE
Revise `block_on` to use a global thread pool for spawned tasks 

### DIFF
--- a/futures-core/src/task/context.rs
+++ b/futures-core/src/task/context.rs
@@ -1,0 +1,121 @@
+use core::fmt;
+use executor::Executor;
+use task::{Waker, LocalMap};
+
+/// Information about the currently-running task.
+///
+/// Contexts are always tied to the stack, since they are set up specifically
+/// when performing a single `poll` step on a task.
+pub struct Context<'a> {
+    waker: &'a Waker,
+    pub(crate) map: &'a mut LocalMap,
+    executor: Option<&'a mut Executor>,
+}
+
+impl<'a> Context<'a> {
+    /// Create a new task context without the ability to `spawn`.
+    ///
+    /// This constructor should *only* be used for `no_std` contexts, where the
+    /// standard `Executor` trait is not available.
+    pub fn without_spawn(map: &'a mut LocalMap, waker: &'a Waker) -> Context<'a> {
+        Context { waker, map, executor: None }
+    }
+
+    /// Get the [`Waker`](::task::Waker) associated with the current task.
+    ///
+    /// The waker can subsequently be used to wake up the task when some
+    /// event of interest has happened.
+    pub fn waker(&self) -> &Waker {
+        self.waker
+    }
+
+    fn with_parts<'b, F, R>(&'b mut self, f: F) -> R
+        where F: FnOnce(&'b Waker, &'b mut LocalMap, Option<&'b mut Executor>) -> R
+    {
+        // reborrow the executor
+        let executor: Option<&'b mut Executor> = match self.executor {
+            None => None,
+            Some(ref mut e) => Some(&mut **e),
+        };
+        f(self.waker, self.map, executor)
+    }
+
+    /// Produce a context like the current one, but using the given waker
+    /// instead.
+    ///
+    /// This advanced method is primarily used when building "internal
+    /// schedulers" within a task, where you want to provide some customized
+    /// wakeup logic.
+    pub fn with_waker<'b>(&'b mut self, waker: &'b Waker) -> Context<'b> {
+        self.with_parts(|_, map, executor| {
+            Context { map, executor, waker }
+        })
+    }
+
+    /// Produce a context like the current one, but using the given task locals
+    /// instead.
+    ///
+    /// This advanced method is primarily used when building "internal
+    /// schedulers" within a task.
+    pub fn with_locals<'b>(&'b mut self, map: &'b mut LocalMap)
+                           -> Context<'b>
+    {
+        self.with_parts(move |waker, _, executor| {
+            Context { map, executor, waker }
+        })
+    }
+}
+
+if_std! {
+    use std::boxed::Box;
+    use Future;
+    use never::Never;
+
+    impl<'a> Context<'a> {
+        /// Create a new task context.
+        ///
+        /// Task contexts are equipped with:
+        ///
+        /// - Task-local data
+        /// - A means of waking the task
+        /// - A means of spawning new tasks, i.e. an [executor]()
+        pub fn new(map: &'a mut LocalMap, waker: &'a Waker, executor: &'a mut Executor) -> Context<'a> {
+            Context { waker, map, executor: Some(executor) }
+        }
+
+        /// Get the default executor associated with this task, if any
+        ///
+        /// This method is useful primarily if you want to explicitly handle
+        /// spawn failures.
+        pub fn executor(&mut self) -> Option<&mut Executor> {
+            match self.executor {
+                Some(ref mut e) => Some(*e),
+                None => None
+            }
+        }
+
+        /// Spawn a future onto the default executor.
+        ///
+        /// # Panics
+        ///
+        /// This method will panic if the default executor is unable to spawn
+        /// or does not exist.
+        ///
+        /// To handle executor errors, use [executor()](self::Context::executor)
+        /// instead.
+        pub fn spawn<F>(&mut self, f: F)
+            where F: Future<Item = (), Error = Never> + 'static + Send
+        {
+            self.executor()
+                .expect("No default executor found")
+                .spawn(Box::new(f)).unwrap()
+        }
+    }
+}
+
+impl<'a> fmt::Debug for Context<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Context")
+            .finish()
+    }
+}

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -1,134 +1,34 @@
 //! Task notification.
 
 use core::fmt;
-use executor::Executor;
+
+mod wake;
+pub use self::wake::{UnsafeWake, Waker};
+
+mod context;
+pub use self::context::Context;
 
 if_std! {
-    use core::marker::PhantomData;
-    use never::Never;
+    pub use self::wake::Wake;
+
+    mod data;
+    pub use self::data::LocalKey;
 }
+
+#[cfg(not(feature = "std"))]
+mod data {
+    pub struct LocalMap;
+
+    pub fn local_map() -> LocalMap {
+        LocalMap
+    }
+}
+
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 mod atomic_waker;
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub use self::atomic_waker::AtomicWaker;
-
-/// Information about the currently-running task.
-///
-/// Contexts are always tied to the stack, since they are set up specifically
-/// when performing a single `poll` step on a task.
-pub struct Context<'a> {
-    waker: &'a Waker,
-    map: &'a mut LocalMap,
-    executor: Option<&'a mut Executor>,
-}
-
-impl<'a> Context<'a> {
-    /// Create a new task context without the ability to `spawn`.
-    ///
-    /// This constructor should *only* be used for `no_std` contexts, where the
-    /// standard `Executor` trait is not available.
-    pub fn without_spawn(map: &'a mut LocalMap, waker: &'a Waker) -> Context<'a> {
-        Context { waker, map, executor: None }
-    }
-
-    /// Get the [`Waker`](::task::Waker) associated with the current task.
-    ///
-    /// The waker can subsequently be used to wake up the task when some
-    /// event of interest has happened.
-    pub fn waker(&self) -> &Waker {
-        self.waker
-    }
-
-    fn with_parts<'b, F, R>(&'b mut self, f: F) -> R
-        where F: FnOnce(&'b Waker, &'b mut LocalMap, Option<&'b mut Executor>) -> R
-    {
-        // reborrow the executor
-        let executor: Option<&'b mut Executor> = match self.executor {
-            None => None,
-            Some(ref mut e) => Some(&mut **e),
-        };
-        f(self.waker, self.map, executor)
-    }
-
-    /// Produce a context like the current one, but using the given waker
-    /// instead.
-    ///
-    /// This advanced method is primarily used when building "internal
-    /// schedulers" within a task, where you want to provide some customized
-    /// wakeup logic.
-    pub fn with_waker<'b>(&'b mut self, waker: &'b Waker) -> Context<'b> {
-        self.with_parts(|_, map, executor| {
-            Context { map, executor, waker }
-        })
-    }
-
-    /// Produce a context like the current one, but using the given task locals
-    /// instead.
-    ///
-    /// This advanced method is primarily used when building "internal
-    /// schedulers" within a task.
-    pub fn with_locals<'b>(&'b mut self, map: &'b mut LocalMap)
-        -> Context<'b>
-    {
-        self.with_parts(move |waker, _, executor| {
-            Context { map, executor, waker }
-        })
-    }
-}
-
-if_std! {
-    use std::boxed::Box;
-    use Future;
-
-    impl<'a> Context<'a> {
-        /// Create a new task context.
-        ///
-        /// Task contexts are equipped with:
-        ///
-        /// - Task-local data
-        /// - A means of waking the task
-        /// - A means of spawning new tasks, i.e. an [executor]()
-        pub fn new(map: &'a mut LocalMap, waker: &'a Waker, executor: &'a mut Executor) -> Context<'a> {
-            Context { waker, map, executor: Some(executor) }
-        }
-
-        /// Get the default executor associated with this task, if any
-        ///
-        /// This method is useful primarily if you want to explicitly handle
-        /// spawn failures.
-        pub fn executor(&mut self) -> Option<&mut Executor> {
-            match self.executor {
-                Some(ref mut e) => Some(*e),
-                None => None
-            }
-        }
-
-        /// Spawn a future onto the default executor.
-        ///
-        /// # Panics
-        ///
-        /// This method will panic if the default executor is unable to spawn
-        /// or does not exist.
-        ///
-        /// To handle executor errors, use [executor()](self::Context::executor)
-        /// instead.
-        pub fn spawn<F>(&mut self, f: F)
-            where F: Future<Item = (), Error = Never> + 'static + Send
-        {
-            self.executor()
-                .expect("No default executor found")
-                .spawn(Box::new(f)).unwrap()
-        }
-    }
-}
-
-impl<'a> fmt::Debug for Context<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Context")
-         .finish()
-    }
-}
 
 /// A map storing task-local data.
 pub struct LocalMap {
@@ -147,251 +47,5 @@ impl fmt::Debug for LocalMap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("LocalMap")
          .finish()
-    }
-}
-
-/// An unsafe trait for implementing custom memory management for a
-/// [`Waker`](::task::Waker).
-///
-/// A [`Waker`](::task::Waker) is a cloneable trait object for `Wake`, and is
-/// most often essentially just `Arc<Wake>`. However, in some contexts
-/// (particularly `no_std`), it's desirable to avoid `Arc` in favor of some
-/// custom memory management strategy. This trait is designed to allow for such
-/// customization.
-///
-/// A default implementation of the `UnsafeWake` trait is provided for the
-/// `Arc` type in the standard library. If the `std` feature of this crate
-/// is not available however, you'll be required to implement your own
-/// instance of this trait to pass it into `Waker::new`.
-///
-/// # Unsafety
-///
-/// This trait manually encodes the memory management of the underlying trait
-/// object. Implementors of this trait must guarantee:
-///
-/// * Calls to `clone_raw` produce uniquely owned `Waker` handles. These handles
-/// should be independently usable and droppable.
-///
-/// * Calls to `drop_raw` work with `self` as a raw pointer, deallocating
-///   resources associated with it. This is a pretty unsafe operation as it's
-///   invalidating the `self` pointer, so extreme care needs to be taken.
-///
-/// In general it's recommended to review the trait documentation as well as the
-/// implementation for `Arc` in this crate before attempting a custom
-/// implementation.
-pub unsafe trait UnsafeWake {
-    /// Creates a new `Waker` from this instance of `UnsafeWake`.
-    ///
-    /// This function will create a new uniquely owned handle that under the
-    /// hood references the same notification instance. In other words calls
-    /// to `wake` on the returned handle should be equivalent to calls to
-    /// `wake` on this handle.
-    ///
-    /// # Unsafety
-    ///
-    /// This is also unsafe to call because it's asserting the `UnsafeWake`
-    /// value is in a consistent state, i.e. hasn't been dropped.
-    unsafe fn clone_raw(&self) -> Waker;
-
-    /// Drops this instance of `UnsafeWake`, deallocating resources
-    /// associated with it.
-    ///
-    /// This method is intended to have a signature such as:
-    ///
-    /// ```ignore
-    /// fn drop_raw(self: *mut Self);
-    /// ```
-    ///
-    /// Unfortunately in Rust today that signature is not object safe.
-    /// Nevertheless it's recommended to implement this function *as if* that
-    /// were its signature. As such it is not safe to call on an invalid
-    /// pointer, nor is the validity of the pointer guaranteed after this
-    /// function returns.
-    ///
-    /// # Unsafety
-    ///
-    /// This is also unsafe to call because it's asserting the `UnsafeWake`
-    /// value is in a consistent state, i.e. hasn't been dropped
-    unsafe fn drop_raw(&self);
-
-    /// Indicates that the associated task is ready to make progress and should
-    /// be `poll`ed.
-    ///
-    /// Executors generally maintain a queue of "ready" tasks; `wake` should place
-    /// the associated task onto this queue.
-    ///
-    /// # Panics
-    ///
-    /// Implementations should avoid panicking, but clients should also be prepared
-    /// for panics.
-    ///
-    /// # Unsafety
-    ///
-    /// This is also unsafe to call because it's asserting the `UnsafeWake`
-    /// value is in a consistent state, i.e. hasn't been dropped
-    unsafe fn wake(&self);
-}
-
-/// A `Waker` is a handle for waking up a task by notifying its executor that it
-/// is ready to be run.
-///
-/// This handle contains a trait object pointing to an instance of the `Wake`
-/// trait, allowing notifications to get routed through it. Usually `Waker`
-/// instances are provided by an executor.
-///
-/// If you're implementing an executor, the recommended way to create a `Waker`
-/// is via `Waker::from` applied to an `Arc<T>` value where `T: Wake`. The
-/// unsafe `new` constructor should be used only in niche, `no_std` settings.
-pub struct Waker {
-    inner: *const UnsafeWake,
-}
-
-unsafe impl Send for Waker {}
-unsafe impl Sync for Waker {}
-
-impl Waker {
-    /// Constructs a new `Waker` directly.
-    ///
-    /// Note that most code will not need to call this. Implementers of the
-    /// `UnsafeWake` trait will typically provide a wrapper that calls this
-    /// but you otherwise shouldn't call it directly.
-    ///
-    /// If you're working with the standard library then it's recommended to
-    /// use the `Waker::from` function instead which works with the safe
-    /// `Arc` type and the safe `Wake` trait.
-    #[inline]
-    pub unsafe fn new(inner: *const UnsafeWake) -> Waker {
-        Waker { inner: inner }
-    }
-
-    /// Wake up the task associated with this `Waker`.
-    pub fn wake(&self) {
-        unsafe { (*self.inner).wake() }
-    }
-
-    /// Returns whether or not this `Waker` and `other` awaken the same task.
-    ///
-    /// This function works on a best-effort basis, and may return false even
-    /// when the `Waker`s would awaken the same task. However, if this function
-    /// returns true, it is guaranteed that the `Waker`s will awaken the same
-    /// task.
-    ///
-    /// This function is primarily used for optimization purposes.
-    pub fn will_wake(&self, other: &Waker) -> bool {
-        self.inner == other.inner
-    }
-}
-
-impl Clone for Waker {
-    #[inline]
-    fn clone(&self) -> Self {
-        unsafe {
-            (*self.inner).clone_raw()
-        }
-    }
-}
-
-impl fmt::Debug for Waker {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Waker")
-         .finish()
-    }
-}
-
-impl Drop for Waker {
-    fn drop(&mut self) {
-        unsafe {
-            (*self.inner).drop_raw()
-        }
-    }
-}
-
-if_std! {
-    use std::mem;
-    use std::ptr;
-    use std::sync::Arc;
-
-    mod data;
-
-    pub use self::data::LocalKey;
-
-    /// A way of waking up a specific task.
-    ///
-    /// Any task executor must provide a way of signaling that a task it owns
-    /// is ready to be `poll`ed again. Executors do so by implementing this trait.
-    ///
-    /// Note that, rather than working directly with `Wake` trait objects, this
-    /// library instead uses a custom [`Waker`](::task::Waker) to allow for
-    /// customization of memory management.
-    pub trait Wake: Send + Sync {
-        /// Indicates that the associated task is ready to make progress and should
-        /// be `poll`ed.
-        ///
-        /// Executors generally maintain a queue of "ready" tasks; `wake` should place
-        /// the associated task onto this queue.
-        ///
-        /// # Panics
-        ///
-        /// Implementations should avoid panicking, but clients should also be prepared
-        /// for panics.
-        fn wake(arc_self: &Arc<Self>);
-    }
-
-    // Safe implementation of `UnsafeWake` for `Arc` in the standard library.
-    //
-    // Note that this is a very unsafe implementation! The crucial pieces is that
-    // these two values are considered equivalent:
-    //
-    // * Arc<T>
-    // * *const ArcWrapped<T>
-    //
-    // We don't actually know the layout of `ArcWrapped<T>` as it's an
-    // implementation detail in the standard library. We can work, though, by
-    // casting it through and back an `Arc<T>`.
-    //
-    // This also means that you won't actually find `UnsafeWake for Arc<T>`
-    // because it's the wrong level of indirection. These methods are sort of
-    // receiving Arc<T>, but not an owned version. It's... complicated. We may be
-    // one of the first users of unsafe trait objects!
-
-    struct ArcWrapped<T>(PhantomData<T>);
-
-    unsafe impl<T: Wake + 'static> UnsafeWake for ArcWrapped<T> {
-        unsafe fn clone_raw(&self) -> Waker {
-            let me: *const ArcWrapped<T> = self;
-            let arc = (*(&me as *const *const ArcWrapped<T> as *const Arc<T>)).clone();
-            Waker::from(arc)
-        }
-
-        unsafe fn drop_raw(&self) {
-            let mut me: *const ArcWrapped<T> = self;
-            let me = &mut me as *mut *const ArcWrapped<T> as *mut Arc<T>;
-            ptr::drop_in_place(me);
-        }
-
-        unsafe fn wake(&self) {
-            let me: *const ArcWrapped<T> = self;
-            T::wake(&*(&me as *const *const ArcWrapped<T> as *const Arc<T>))
-        }
-    }
-
-    impl<T> From<Arc<T>> for Waker
-        where T: Wake + 'static,
-    {
-        fn from(rc: Arc<T>) -> Waker {
-            unsafe {
-                let ptr = mem::transmute::<Arc<T>, *const ArcWrapped<T>>(rc);
-                Waker::new(ptr)
-            }
-        }
-    }
-}
-
-#[cfg(not(feature = "std"))]
-mod data {
-    pub struct LocalMap;
-
-    pub fn local_map() -> LocalMap {
-        LocalMap
     }
 }

--- a/futures-core/src/task/wake.rs
+++ b/futures-core/src/task/wake.rs
@@ -1,0 +1,235 @@
+use core::fmt;
+
+/// An unsafe trait for implementing custom memory management for a
+/// [`Waker`](::task::Waker).
+///
+/// A [`Waker`](::task::Waker) is a cloneable trait object for `Wake`, and is
+/// most often essentially just `Arc<Wake>`. However, in some contexts
+/// (particularly `no_std`), it's desirable to avoid `Arc` in favor of some
+/// custom memory management strategy. This trait is designed to allow for such
+/// customization.
+///
+/// A default implementation of the `UnsafeWake` trait is provided for the
+/// `Arc` type in the standard library. If the `std` feature of this crate
+/// is not available however, you'll be required to implement your own
+/// instance of this trait to pass it into `Waker::new`.
+///
+/// # Unsafety
+///
+/// This trait manually encodes the memory management of the underlying trait
+/// object. Implementors of this trait must guarantee:
+///
+/// * Calls to `clone_raw` produce uniquely owned `Waker` handles. These handles
+/// should be independently usable and droppable.
+///
+/// * Calls to `drop_raw` work with `self` as a raw pointer, deallocating
+///   resources associated with it. This is a pretty unsafe operation as it's
+///   invalidating the `self` pointer, so extreme care needs to be taken.
+///
+/// In general it's recommended to review the trait documentation as well as the
+/// implementation for `Arc` in this crate before attempting a custom
+/// implementation.
+pub unsafe trait UnsafeWake {
+    /// Creates a new `Waker` from this instance of `UnsafeWake`.
+    ///
+    /// This function will create a new uniquely owned handle that under the
+    /// hood references the same notification instance. In other words calls
+    /// to `wake` on the returned handle should be equivalent to calls to
+    /// `wake` on this handle.
+    ///
+    /// # Unsafety
+    ///
+    /// This is also unsafe to call because it's asserting the `UnsafeWake`
+    /// value is in a consistent state, i.e. hasn't been dropped.
+    unsafe fn clone_raw(&self) -> Waker;
+
+    /// Drops this instance of `UnsafeWake`, deallocating resources
+    /// associated with it.
+    ///
+    /// This method is intended to have a signature such as:
+    ///
+    /// ```ignore
+    /// fn drop_raw(self: *mut Self);
+    /// ```
+    ///
+    /// Unfortunately in Rust today that signature is not object safe.
+    /// Nevertheless it's recommended to implement this function *as if* that
+    /// were its signature. As such it is not safe to call on an invalid
+    /// pointer, nor is the validity of the pointer guaranteed after this
+    /// function returns.
+    ///
+    /// # Unsafety
+    ///
+    /// This is also unsafe to call because it's asserting the `UnsafeWake`
+    /// value is in a consistent state, i.e. hasn't been dropped
+    unsafe fn drop_raw(&self);
+
+    /// Indicates that the associated task is ready to make progress and should
+    /// be `poll`ed.
+    ///
+    /// Executors generally maintain a queue of "ready" tasks; `wake` should place
+    /// the associated task onto this queue.
+    ///
+    /// # Panics
+    ///
+    /// Implementations should avoid panicking, but clients should also be prepared
+    /// for panics.
+    ///
+    /// # Unsafety
+    ///
+    /// This is also unsafe to call because it's asserting the `UnsafeWake`
+    /// value is in a consistent state, i.e. hasn't been dropped
+    unsafe fn wake(&self);
+}
+
+/// A `Waker` is a handle for waking up a task by notifying its executor that it
+/// is ready to be run.
+///
+/// This handle contains a trait object pointing to an instance of the `Wake`
+/// trait, allowing notifications to get routed through it. Usually `Waker`
+/// instances are provided by an executor.
+///
+/// If you're implementing an executor, the recommended way to create a `Waker`
+/// is via `Waker::from` applied to an `Arc<T>` value where `T: Wake`. The
+/// unsafe `new` constructor should be used only in niche, `no_std` settings.
+pub struct Waker {
+    inner: *const UnsafeWake,
+}
+
+unsafe impl Send for Waker {}
+unsafe impl Sync for Waker {}
+
+impl Waker {
+    /// Constructs a new `Waker` directly.
+    ///
+    /// Note that most code will not need to call this. Implementers of the
+    /// `UnsafeWake` trait will typically provide a wrapper that calls this
+    /// but you otherwise shouldn't call it directly.
+    ///
+    /// If you're working with the standard library then it's recommended to
+    /// use the `Waker::from` function instead which works with the safe
+    /// `Arc` type and the safe `Wake` trait.
+    #[inline]
+    pub unsafe fn new(inner: *const UnsafeWake) -> Waker {
+        Waker { inner: inner }
+    }
+
+    /// Wake up the task associated with this `Waker`.
+    pub fn wake(&self) {
+        unsafe { (*self.inner).wake() }
+    }
+
+    /// Returns whether or not this `Waker` and `other` awaken the same task.
+    ///
+    /// This function works on a best-effort basis, and may return false even
+    /// when the `Waker`s would awaken the same task. However, if this function
+    /// returns true, it is guaranteed that the `Waker`s will awaken the same
+    /// task.
+    ///
+    /// This function is primarily used for optimization purposes.
+    pub fn will_wake(&self, other: &Waker) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Clone for Waker {
+    #[inline]
+    fn clone(&self) -> Self {
+        unsafe {
+            (*self.inner).clone_raw()
+        }
+    }
+}
+
+impl fmt::Debug for Waker {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Waker")
+            .finish()
+    }
+}
+
+impl Drop for Waker {
+    fn drop(&mut self) {
+        unsafe {
+            (*self.inner).drop_raw()
+        }
+    }
+}
+
+if_std! {
+    use std::mem;
+    use std::ptr;
+    use std::sync::Arc;
+    use core::marker::PhantomData;
+
+    /// A way of waking up a specific task.
+    ///
+    /// Any task executor must provide a way of signaling that a task it owns
+    /// is ready to be `poll`ed again. Executors do so by implementing this trait.
+    ///
+    /// Note that, rather than working directly with `Wake` trait objects, this
+    /// library instead uses a custom [`Waker`](::task::Waker) to allow for
+    /// customization of memory management.
+    pub trait Wake: Send + Sync {
+        /// Indicates that the associated task is ready to make progress and should
+        /// be `poll`ed.
+        ///
+        /// Executors generally maintain a queue of "ready" tasks; `wake` should place
+        /// the associated task onto this queue.
+        ///
+        /// # Panics
+        ///
+        /// Implementations should avoid panicking, but clients should also be prepared
+        /// for panics.
+        fn wake(arc_self: &Arc<Self>);
+    }
+
+    // Safe implementation of `UnsafeWake` for `Arc` in the standard library.
+    //
+    // Note that this is a very unsafe implementation! The crucial pieces is that
+    // these two values are considered equivalent:
+    //
+    // * Arc<T>
+    // * *const ArcWrapped<T>
+    //
+    // We don't actually know the layout of `ArcWrapped<T>` as it's an
+    // implementation detail in the standard library. We can work, though, by
+    // casting it through and back an `Arc<T>`.
+    //
+    // This also means that you won't actually find `UnsafeWake for Arc<T>`
+    // because it's the wrong level of indirection. These methods are sort of
+    // receiving Arc<T>, but not an owned version. It's... complicated. We may be
+    // one of the first users of unsafe trait objects!
+
+    struct ArcWrapped<T>(PhantomData<T>);
+
+    unsafe impl<T: Wake + 'static> UnsafeWake for ArcWrapped<T> {
+        unsafe fn clone_raw(&self) -> Waker {
+            let me: *const ArcWrapped<T> = self;
+            let arc = (*(&me as *const *const ArcWrapped<T> as *const Arc<T>)).clone();
+            Waker::from(arc)
+        }
+
+        unsafe fn drop_raw(&self) {
+            let mut me: *const ArcWrapped<T> = self;
+            let me = &mut me as *mut *const ArcWrapped<T> as *mut Arc<T>;
+            ptr::drop_in_place(me);
+        }
+
+        unsafe fn wake(&self) {
+            let me: *const ArcWrapped<T> = self;
+            T::wake(&*(&me as *const *const ArcWrapped<T> as *const Arc<T>))
+        }
+    }
+
+    impl<T> From<Arc<T>> for Waker
+        where T: Wake + 'static,
+    {
+        fn from(rc: Arc<T>) -> Waker {
+            unsafe {
+                let ptr = mem::transmute::<Arc<T>, *const ArcWrapped<T>>(rc);
+                Waker::new(ptr)
+            }
+        }
+    }
+}

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -19,6 +19,7 @@ futures-core = { path = "../futures-core", version = "0.2.0-beta", default-featu
 futures-util = { path = "../futures-util", version = "0.2.0-beta", default-features = false}
 futures-channel = { path = "../futures-channel", version = "0.2.0-beta", default-features = false}
 num_cpus = { version = "1.0", optional = true }
+lazy_static = "1.0"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.2.0-beta", default-features = false }

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -22,5 +22,5 @@ num_cpus = { version = "1.0", optional = true }
 lazy_static = "1.0"
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.2.0-beta", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.2.0-beta", default-features = false }
+futures = { path = "../futures", version = "0.2.0-beta" }
+futures-channel = { path = "../futures-channel", version = "0.2.0-beta" }

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -8,6 +8,9 @@
 #[macro_use]
 extern crate std;
 
+#[macro_use]
+extern crate lazy_static;
+
 macro_rules! if_std {
     ($($i:item)*) => ($(
         #[cfg(feature = "std")]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -188,7 +188,9 @@ impl LocalPool {
 }
 
 lazy_static! {
-    static ref GLOBAL_POOL: ThreadPool = ThreadPool::new();
+    static ref GLOBAL_POOL: ThreadPool = ThreadPool::builder()
+        .name_prefix("block_on-")
+        .create() ;
 }
 
 /// Run a future to completion on the current thread.

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -11,6 +11,7 @@ use futures_util::stream::FuturesUnordered;
 
 use thread::ThreadNotify;
 use enter;
+use ThreadPool;
 
 struct Task {
     fut: Box<Future<Item = (), Error = Never>>,
@@ -186,26 +187,20 @@ impl LocalPool {
     }
 }
 
+lazy_static! {
+    static ref GLOBAL_POOL: ThreadPool = ThreadPool::new();
+}
+
 /// Run a future to completion on the current thread.
 ///
 /// This function will block the caller until the given future has completed.
-/// Any tasks spawned onto the default executor will *also* be run on the
-/// current thread, **but they may not complete before the function
-/// returns**. Instead, once the starting future has completed, these other
-/// tasks are simply dropped.
+/// The default executor for the future is a global `ThreadPool`.
 ///
 /// Use a [`LocalPool`](LocalPool) if you need finer-grained control over
 /// spawned tasks.
 pub fn block_on<F: Future>(f: F) -> Result<F::Item, F::Error> {
     let mut pool = LocalPool::new();
-    let mut exec = pool.executor();
-
-    // run our main future to completion
-    let res = pool.run_until(f, &mut exec);
-    // run any remainingspawned tasks to completion
-    pool.run(&mut exec);
-
-    res
+    pool.run_until(f, &mut GLOBAL_POOL.clone())
 }
 
 impl Executor for LocalExecutor {

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -156,9 +156,8 @@ pub mod executor {
     //!
     //! There is also a convenience function,
     //! [`block_on`](::executor::block_on), for simply running a future to
-    //! completion on the current thread. However, any tasks spawned by the
-    //! future will *also* be run on the current thread (via `LocalPool`), and
-    //! will be dropped when the primary future completes.
+    //! completion on the current thread, while routing any spawned tasks
+    //! to a global thread pool.
     // TODO: add docs (or link to apr) for implementing an executor
 
     pub use futures_executor::{


### PR DESCRIPTION
Per discussion with @seanmonstar, revise the `block_on` to set the default executor to be a lazily-initialized global thread pool. This provides a much more usable bridge between the sync and async worlds, since spawned tasks are no longer dropped when the future completes.

Ultimately we'll probably want to make the executor used here configurable, but since this is purely about the sync bridge, I don't think it's very pressing.

This PR also includes an unrelated drive-by refactor of the `task` module into submodules; I thought I was going to work the code there but ended up not -- but I've been wanting to do the refactor anyway.