### PR TITLE
change block_on to not allow background tasks

### DIFF
--- a/futures-executor/src/blocking.rs
+++ b/futures-executor/src/blocking.rs
@@ -1,0 +1,37 @@
+use std::boxed::Box;
+
+use futures_core::Future;
+use futures_core::executor::{Executor, SpawnError};
+use futures_core::never::Never;
+
+use local_pool::LocalPool;
+
+/// Run a future to completion on the current thread.
+///
+/// This function will block the caller until the given future has completed.
+///
+/// Use a [`LocalPool`](super::LocalPool) if you need finer-grained control over
+/// spawned tasks.
+///
+/// # Panics
+///
+/// This should not be used to block on more complicated `Future`s that require
+/// spawning additional tasks. This will panic when they try to do so. You
+/// should consider a more complete executor situation for those kinds of
+/// tasks.
+pub fn block_on<F: Future>(f: F) -> Result<F::Item, F::Error> {
+    let mut pool = LocalPool::new();
+    pool.run_until(f, &mut BlockOnBackgroundExecutor)
+}
+
+struct BlockOnBackgroundExecutor;
+
+impl Executor for BlockOnBackgroundExecutor {
+    fn spawn(&mut self, _: Box<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {
+        panic!("block_on cannot be used with Futures that need to spawn additional tasks")
+    }
+
+    fn status(&self) -> Result<(), SpawnError> {
+        Err(SpawnError::shutdown())
+    }
+}

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -21,10 +21,13 @@ if_std! {
     extern crate futures_channel;
     extern crate num_cpus;
 
+    mod blocking;
+    pub use blocking::block_on;
+
     mod thread;
 
     mod local_pool;
-    pub use local_pool::{block_on, LocalPool, LocalExecutor};
+    pub use local_pool::{LocalPool, LocalExecutor};
 
     mod unpark_mutex;
     mod thread_pool;

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -186,27 +186,6 @@ impl LocalPool {
     }
 }
 
-/// Run a future to completion on the current thread.
-///
-/// This function will block the caller until the given future has completed.
-/// Any tasks spawned onto the default executor will *also* be run on the
-/// current thread, **but they may not complete before the function
-/// returns**. Instead, once the starting future has completed, these other
-/// tasks are simply dropped.
-///
-/// Use a [`LocalPool`](LocalPool) if you need finer-grained control over
-/// spawned tasks.
-pub fn block_on<F: Future>(f: F) -> Result<F::Item, F::Error> {
-    let mut pool = LocalPool::new();
-    let mut exec = pool.executor();
-
-    // run our main future to completion
-    let res = pool.run_until(f, &mut exec);
-    // run any remainingspawned tasks to completion
-    pool.run(&mut exec);
-
-    res
-}
 
 impl Executor for LocalExecutor {
     fn spawn(&mut self, f: Box<Future<Item = (), Error = Never> + Send>) -> Result<(), SpawnError> {

--- a/futures-executor/tests/block_on.rs
+++ b/futures-executor/tests/block_on.rs
@@ -1,0 +1,24 @@
+extern crate futures_core;
+extern crate futures_executor;
+
+use futures_core::{task, Async, Future, Poll};
+use futures_core::never::Never;
+use futures_executor::block_on;
+
+struct SpawnsMore;
+
+impl Future for SpawnsMore {
+    type Item = ();
+    type Error = Never;
+
+    fn poll(&mut self, cx: &mut task::Context) -> Poll<(), Never> {
+        cx.spawn(SpawnsMore);
+        Ok(Async::Ready(()))
+    }
+}
+
+#[test]
+#[should_panic]
+fn block_on_cannot_spawn_more() {
+    let _ = block_on(SpawnsMore);
+}


### PR DESCRIPTION
This is an alternative to #890. Instead of using a global thread pool that can't be configured, and making it easy for users to use `block_on` with bigger tasks than they should, this instead makes it so the executor used with `block_on` universally panics when used.

This means it's still a fine tool for cross-thread synchronization:

```rust
let (tx, rx) = oneshot::channel();

thread::spawn(move || {
    let msg = block_on(rx);
    // ...
});
```

However, it is **not recommended** to use this for things like hyper's responses futures, which should instead have a better setup for task execution.

```rust
// this panics when the `ResponseFuture` tries to spawn its
// background Connection task, but with a message that
// problem was trying to use `block_on`, and the user should
// use something else.
let res = block_on(client.get(uri));
```