### PR TITLE
Fix no_std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ matrix:
         - cargo build --manifest-path futures/Cargo.toml --features nightly
         - cargo test --manifest-path futures-macro-await/Cargo.toml --features nightly
         - cargo test --manifest-path futures/Cargo.toml --features nightly --test async_await_tests
+    - rust: nightly
+      script:
+        - rustup component add rust-src
+        - cargo install xargo
+        - xargo build --manifest-path futures/Cargo.toml --target thumbv6m-none-eabi --no-default-features --features nightly
     - rust: 1.20.0
       script: cargo test --all
     - rust: nightly

--- a/futures-async-runtime/Cargo.toml
+++ b/futures-async-runtime/Cargo.toml
@@ -16,10 +16,12 @@ Runtime for the async/await macros in the `futures` crate.
 [dependencies.futures-core]
 version = "0.2.0-beta"
 path = "../futures-core"
+default-features = false
 
 [dependencies.futures-stable]
 version = "0.2.0-beta"
 path = "../futures-stable"
+default-features = false
 
 [features]
 nightly = ["futures-core/nightly", "futures-stable/nightly"]

--- a/futures-async-runtime/src/lib.rs
+++ b/futures-async-runtime/src/lib.rs
@@ -1,17 +1,22 @@
+#![no_std]
 #![cfg_attr(feature = "nightly", feature(generator_trait))]
 #![cfg_attr(feature = "nightly", feature(on_unimplemented))]
 #![cfg_attr(feature = "nightly", feature(arbitrary_self_types))]
 #![cfg_attr(feature = "nightly", feature(optin_builtin_traits))]
 #![cfg_attr(feature = "nightly", feature(pin))]
 
-macro_rules! if_nightly {
+macro_rules! if_nightly_and_std {
     ($($i:item)*) => ($(
-        #[cfg(feature = "nightly")]
+        #[cfg(all(feature = "nightly", feature = "std"))]
         $i
     )*)
 }
 
-if_nightly! {
+#[cfg(all(feature = "nightly", feature = "std"))]
+#[macro_use]
+extern crate std;
+
+if_nightly_and_std! {
     extern crate futures_core;
     extern crate futures_stable;
 

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -11,7 +11,7 @@ Executors for asynchronous tasks based on the futures-rs library.
 """
 
 [features]
-std = ["num_cpus", "futures-core/std", "futures-util/std", "futures-channel/std"]
+std = ["num_cpus", "futures-core/std", "futures-util/std", "futures-channel/std", "lazy_static"]
 default = ["std"]
 
 [dependencies]
@@ -19,7 +19,7 @@ futures-core = { path = "../futures-core", version = "0.2.0-beta", default-featu
 futures-util = { path = "../futures-util", version = "0.2.0-beta", default-features = false}
 futures-channel = { path = "../futures-channel", version = "0.2.0-beta", default-features = false}
 num_cpus = { version = "1.0", optional = true }
-lazy_static = "1.0"
+lazy_static = { version = "1.0", optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.2.0-beta" }

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -8,9 +8,6 @@
 #[macro_use]
 extern crate std;
 
-#[macro_use]
-extern crate lazy_static;
-
 macro_rules! if_std {
     ($($i:item)*) => ($(
         #[cfg(feature = "std")]
@@ -19,6 +16,9 @@ macro_rules! if_std {
 }
 
 if_std! {
+    #[macro_use]
+    extern crate lazy_static;
+
     extern crate futures_core;
     extern crate futures_util;
     extern crate futures_channel;

--- a/futures-macro-await/src/lib.rs
+++ b/futures-macro-await/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! An internal helper crate to workaround limitations in the
 //! `use_extern_macros` feature with re-exported Macros 1.0 macros.
 //!

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -399,6 +399,7 @@ pub mod stable {
 #[cfg(feature = "nightly")]
 #[doc(hidden)]
 pub mod __rt {
+    #[cfg(feature = "std")]
     pub extern crate std;
     pub use futures_async_runtime::*;
 }


### PR DESCRIPTION
Also adds a representative `no_std` target into the travis build matrix to avoid accidental breakage in the future. Hopefully this doesn't slow CI down too much.