### PR TITLE
Introduce WithExecutor adaptor

### DIFF
--- a/futures-core/src/task/context.rs
+++ b/futures-core/src/task/context.rs
@@ -110,6 +110,19 @@ if_std! {
                 .expect("No default executor found")
                 .spawn(Box::new(f)).unwrap()
         }
+
+        /// Produce a context like the current one, but using the given executor
+        /// instead.
+        ///
+        /// This advanced method is primarily used when building "internal
+        /// schedulers" within a task.
+        pub fn with_executor<'b>(&'b mut self, executor: &'b mut Executor)
+                            -> Context<'b>
+        {
+            self.with_parts(move |waker, map, _| {
+                Context { map, executor: Some(executor), waker }
+            })
+        }
     }
 }
 

--- a/futures-util/src/future/with_executor.rs
+++ b/futures-util/src/future/with_executor.rs
@@ -1,0 +1,33 @@
+use futures_core::{Future, Poll};
+use futures_core::task;
+use futures_core::executor::Executor;
+
+/// Future for the `with_executor` combinator, assigning an executor
+/// to be used when spawning other futures.
+///
+/// This is created by the `Future::with_executor` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct WithExecutor<F, E> where F: Future, E: Executor {
+    executor: E,
+    future: F
+}
+
+pub fn new<F, E>(future: F, executor: E) -> WithExecutor<F, E>
+    where F: Future,
+          E: Executor,
+{
+    WithExecutor { executor, future }
+}
+
+impl<F, E> Future for WithExecutor<F, E>
+    where F: Future,
+          E: Executor,
+{
+    type Item = F::Item;
+    type Error = F::Error;
+
+    fn poll(&mut self, cx: &mut task::Context) -> Poll<F::Item, F::Error> {
+        self.future.poll(&mut cx.with_executor(&mut self.executor))
+    }
+}


### PR DESCRIPTION
Introduces the `WithExecutor` adapter, which assigns an executor to be used when spawning tasks from within the future.

The main driver for me is to enable the use-case of overriding the default thread pool for `block_on`:

```rust
block_on(future.with_executor(pool))
```

By making this a combinator it opens up more use-cases, such as this pattern:

```rust
spawn_with_handle(future).with_executor(pool)
```