### PR TITLE
Revert "Replace the Future impl for Option with IntoFuture"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/future/option.rs
+++ b/src/future/option.rs
@@ -1,33 +1,13 @@
 //! Definition of the `Option` (optional step) combinator
 
-use {Future, IntoFuture, Poll, Async};
-use core::option;
+use {Future, Poll, Async};
 
-/// An optional future.
-///
-/// Created by `Option::into_future`.
-#[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless polled"]
-pub struct Option<F> {
-    inner: option::Option<F>,
-}
+impl<F, T, E> Future for Option<F> where F: Future<Item=T, Error=E> {
+    type Item = Option<T>;
+    type Error = E;
 
-impl<F> IntoFuture for option::Option<F> where F: Future {
-    type Future = Option<F>;
-    type Item = option::Option<F::Item>;
-    type Error = F::Error;
-
-    fn into_future(self) -> Self::Future {
-        Option { inner: self }
-    }
-}
-
-impl<F> Future for Option<F> where F: Future {
-    type Item = option::Option<F::Item>;
-    type Error = F::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.inner {
+    fn poll(&mut self) -> Poll<Option<T>, E> {
+        match *self {
             None => Ok(Async::Ready(None)),
             Some(ref mut x) => x.poll().map(|x| x.map(Some)),
         }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -356,8 +356,8 @@ fn select2() {
 
 #[test]
 fn option() {
-    assert_eq!(Ok(Some(())), Some(ok::<(), ()>(())).into_future().wait());
-    assert_eq!(Ok(None), None::<FutureResult<(), ()>>.into_future().wait());
+    assert_eq!(Ok(Some(())), Some(ok::<(), ()>(())).wait());
+    assert_eq!(Ok(None), <Option<FutureResult<(), ()>> as Future>::wait(None));
 }
 
 #[test]


### PR DESCRIPTION
This reverts commit db7799587562627e03ba011058cb4f02645f76fb.

This was a breaking change which accidentally slipped into the 0.1.19 release.