### PR TITLE
Remove some feature attributes which got stable in Rust 1.26

### DIFF
--- a/futures-async-runtime/src/lib.rs
+++ b/futures-async-runtime/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "nightly", feature(conservative_impl_trait))]
 #![cfg_attr(feature = "nightly", feature(generator_trait))]
 #![cfg_attr(feature = "nightly", feature(on_unimplemented))]
 #![cfg_attr(feature = "nightly", feature(arbitrary_self_types))]

--- a/futures-async-runtime/src/old-lib.rs
+++ b/futures-async-runtime/src/old-lib.rs
@@ -12,7 +12,6 @@
 //!
 //! See the crates's README for more information about usage.
 
-#![feature(conservative_impl_trait)]
 #![feature(generator_trait)]
 #![feature(use_extern_macros)]
 #![feature(on_unimplemented)]

--- a/futures-macro-async/src/lib.rs
+++ b/futures-macro-async/src/lib.rs
@@ -9,7 +9,7 @@
 //! Currently this crate depends on `syn` and `quote` to do all the heavy
 //! lifting, this is just a very small shim around creating a closure/future out
 //! of a generator.
-#![cfg_attr(feature = "nightly", feature(proc_macro, match_default_bindings))]
+#![cfg_attr(feature = "nightly", feature(proc_macro))]
 #![recursion_limit = "128"]
 
 


### PR DESCRIPTION
I forgot to remove some other stable features in \#915.