### PR TITLE
Use different await! macro between async and async_move

### DIFF
--- a/futures-async-runtime/src/lib.rs
+++ b/futures-async-runtime/src/lib.rs
@@ -22,7 +22,9 @@ if_nightly! {
 
     use std::cell::Cell;
     use std::mem;
+    use std::mem::Pin;
     use std::ptr;
+    use std::marker::PhantomData;
     use futures_core::task;
 
     pub use self::future::*;
@@ -85,5 +87,20 @@ if_nightly! {
             }
             f(unsafe { &mut *r.0 })
         })
+    }
+
+    pub struct PinTemporary<'a, T: 'a> {
+        data: T,
+        _marker: PhantomData<&'a &'a mut ()>,
+    }
+
+    pub fn pinned<'a, T: 'a>(data: T) -> PinTemporary<'a, T> {
+        PinTemporary { data, _marker: PhantomData }
+    }
+
+    impl<'a, T> PinTemporary<'a, T> {
+        pub fn as_pin(&'a mut self) -> Pin<'a, T> {
+            unsafe { Pin::new_unchecked(&mut self.data) }
+        }
     }
 }

--- a/futures-async-runtime/src/lib.rs
+++ b/futures-async-runtime/src/lib.rs
@@ -22,9 +22,7 @@ if_nightly! {
 
     use std::cell::Cell;
     use std::mem;
-    use std::mem::Pin;
     use std::ptr;
-    use std::marker::PhantomData;
     use futures_core::task;
 
     pub use self::future::*;
@@ -87,20 +85,5 @@ if_nightly! {
             }
             f(unsafe { &mut *r.0 })
         })
-    }
-
-    pub struct PinTemporary<'a, T: 'a> {
-        data: T,
-        _marker: PhantomData<&'a &'a mut ()>,
-    }
-
-    pub fn pinned<'a, T: 'a>(data: T) -> PinTemporary<'a, T> {
-        PinTemporary { data, _marker: PhantomData }
-    }
-
-    impl<'a, T> PinTemporary<'a, T> {
-        pub fn as_pin(&'a mut self) -> Pin<'a, T> {
-            unsafe { Pin::new_unchecked(&mut self.data) }
-        }
     }
 }

--- a/futures-macro-await/src/lib.rs
+++ b/futures-macro-await/src/lib.rs
@@ -33,26 +33,9 @@
 #[macro_export]
 macro_rules! await {
     ($e:expr) => ({
-        let mut future = ::futures::__rt::pinned($e);
-        let mut pin = future.as_pin();
-        loop {
-            let poll = ::futures::__rt::in_ctx(|ctx| {
-                let pin = ::futures::__rt::std::mem::Pin::borrow(&mut pin);
-                ::futures::__rt::StableFuture::poll(pin, ctx)
-            });
-            // Allow for #[feature(never_type)] and Future<Error = !>
-            #[allow(unreachable_code, unreachable_patterns)]
-            match poll {
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
-                    break ::futures::__rt::std::result::Result::Ok(e)
-                }
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Pending) => {}
-                ::futures::__rt::std::result::Result::Err(e) => {
-                    break ::futures::__rt::std::result::Result::Err(e)
-                }
-            }
-            yield ::futures::__rt::Async::Pending
-        }
+        // This macro is just here for documetation purposes, see
+        // futures-macro-async/src/lib.rs for the implementation.
+        __await!($e)
     })
 }
 

--- a/futures/tests/async_await/pinned.rs
+++ b/futures/tests/async_await/pinned.rs
@@ -21,6 +21,21 @@ fn qux(x: i32) -> Result<i32, i32> {
     await!(baz(x).pin())
 }
 
+// This test is to check that the internal __await macro generated in each
+// function does not leak across function boundaries. If it did then calling
+// the #[async] version of __await in the #[async_move] function should cause
+// a 'borrow may still be in use when generator yields' error, while calling
+// the #[async_move] version in the #[async] function should fail because `bar`
+// does not implement `Future`.
+#[async_move]
+fn qux2(x: i32) -> Result<i32, i32> {
+    #[async]
+    fn baz2(x: i32) -> Result<i32, i32> {
+        await!(bar(&x))
+    }
+    await!(baz2(x).pin())
+}
+
 #[async_stream(item = u64)]
 fn _stream1() -> Result<(), i32> {
     fn integer() -> u64 { 1 }
@@ -46,5 +61,6 @@ fn main() {
     assert_eq!(block_on_stable(bar(&1)), Ok(1));
     assert_eq!(block_on_stable(baz(17)), Ok(17));
     assert_eq!(block_on_stable(qux(17)), Ok(17));
+    assert_eq!(block_on_stable(qux2(17)), Ok(17));
     assert_eq!(block_on_stable(uses_async_for()), Ok(vec![0, 1]));
 }

--- a/futures/tests/async_await/pinned.rs
+++ b/futures/tests/async_await/pinned.rs
@@ -1,4 +1,4 @@
-use futures::stable::block_on_stable;
+use futures::stable::{block_on_stable, StableFuture};
 use futures::prelude::*;
 
 #[async]
@@ -14,6 +14,11 @@ fn bar(x: &i32) -> Result<i32, i32> {
 #[async]
 fn baz(x: i32) -> Result<i32, i32> {
     await!(bar(&x))
+}
+
+#[async_move]
+fn qux(x: i32) -> Result<i32, i32> {
+    await!(baz(x).pin())
 }
 
 #[async_stream(item = u64)]
@@ -40,5 +45,6 @@ fn main() {
     assert_eq!(block_on_stable(foo()), Ok(1));
     assert_eq!(block_on_stable(bar(&1)), Ok(1));
     assert_eq!(block_on_stable(baz(17)), Ok(17));
+    assert_eq!(block_on_stable(qux(17)), Ok(17));
     assert_eq!(block_on_stable(uses_async_for()), Ok(vec![0, 1]));
 }


### PR DESCRIPTION
Fixes #924, asserts that we're currently in an immovable generator when polling `StableFuture`s inside `#[async]` functions, and polls via the `Future` trait inside `#[async_move]` functions (so you need to `PinBox` any `StableFuture`s you are `await`ing there).

I'm not certain this is the best solution, but after actually implementing it it seems reasonable to me.

@cramertj I believe you had some reservations about this stack pinning API? Doing a closure based API here is difficult since you can't yield through the closure, I think it should be possible with a couple of layers of extra generators, but I wasn't able to get the lifetimes working out on my first attempt.

r? @withoutboats 