### PR TITLE
fix compilation of #[async(pinned)] and #[async(pinned_send)]

### DIFF
--- a/futures/tests/async_await/pinned.rs
+++ b/futures/tests/async_await/pinned.rs
@@ -1,19 +1,38 @@
 use futures::stable::block_on_stable;
 use futures::prelude::*;
+use std::boxed::PinBox;
 
 #[async]
 fn foo() -> Result<i32, i32> {
     Ok(1)
 }
 
-#[async]
+#[async(pinned)]
 fn bar(x: &i32) -> Result<i32, i32> {
     Ok(*x)
 }
 
 #[async]
+fn bar2(x: &i32) -> Result<i32, i32> {
+    Ok(*x)
+}
+
+#[async(pinned)]
 fn baz(x: i32) -> Result<i32, i32> {
     await!(bar(&x))
+}
+
+#[async(pinned_send)]
+fn baz2(x: i32) -> Result<i32, i32> {
+    await!(bar2(&x))
+}
+
+#[async]
+fn qux(
+    x: PinBox<Future<Item = i32, Error = i32>>,
+    y: PinBox<Future<Item = i32, Error = i32> + Send>,
+) -> Result<i32, i32> {
+    Ok(await!(x)? + await!(y)?)
 }
 
 #[async_stream(item = u64)]
@@ -40,5 +59,6 @@ fn main() {
     assert_eq!(block_on_stable(foo()), Ok(1));
     assert_eq!(block_on_stable(bar(&1)), Ok(1));
     assert_eq!(block_on_stable(baz(17)), Ok(17));
+    assert_eq!(block_on_stable(qux(baz(11), baz2(22))), Ok(33));
     assert_eq!(block_on_stable(uses_async_for()), Ok(vec![0, 1]));
 }


### PR DESCRIPTION
On the current master branch, #[async(pinned)] and #[async(pinned_send)] are not working.
It seems to be working for me with this commit, but I'm not a 100% sure if I understand pinning correctly.