### PR TITLE
Update async_block* macros to support Stable & Unpin 

### DIFF
--- a/futures-macro-async/src/lib.rs
+++ b/futures-macro-async/src/lib.rs
@@ -456,6 +456,35 @@ if_nightly! {
         let expr = ExpandAsyncFor.fold_expr(expr);
 
         let mut tokens = quote_cs! {
+            ::futures::__rt::gen_pinned
+        };
+
+        // Use some manual token construction here instead of `quote_cs!` to ensure
+        // that we get the `call_site` span instead of the default span.
+        let span = Span::call_site();
+        syn::token::Paren(span).surround(&mut tokens, |tokens| {
+            syn::token::Static(span).to_tokens(tokens);
+            syn::token::Move(span).to_tokens(tokens);
+            syn::token::OrOr([span, span]).to_tokens(tokens);
+            syn::token::Brace(span).surround(tokens, |tokens| {
+                (quote_cs! {
+                    if false { yield ::futures::__rt::Async::Pending }
+                }).to_tokens(tokens);
+                expr.to_tokens(tokens);
+            });
+        });
+
+        tokens.into()
+    }
+
+    #[proc_macro]
+    pub fn async_block_unpin(input: TokenStream) -> TokenStream {
+        let input = TokenStream::from(TokenTree::Group(Group::new(Delimiter::Brace, input)));
+        let expr = syn::parse(input)
+            .expect("failed to parse tokens as an expression");
+        let expr = ExpandAsyncFor.fold_expr(expr);
+
+        let mut tokens = quote_cs! {
             ::futures::__rt::gen_move
         };
 
@@ -478,6 +507,35 @@ if_nightly! {
 
     #[proc_macro]
     pub fn async_stream_block(input: TokenStream) -> TokenStream {
+        let input = TokenStream::from(TokenTree::Group(Group::new(Delimiter::Brace, input)));
+        let expr = syn::parse(input)
+            .expect("failed to parse tokens as an expression");
+        let expr = ExpandAsyncFor.fold_expr(expr);
+
+        let mut tokens = quote_cs! {
+            ::futures::__rt::gen_stream_pinned
+        };
+
+        // Use some manual token construction here instead of `quote_cs!` to ensure
+        // that we get the `call_site` span instead of the default span.
+        let span = Span::call_site();
+        syn::token::Paren(span).surround(&mut tokens, |tokens| {
+            syn::token::Static(span).to_tokens(tokens);
+            syn::token::Move(span).to_tokens(tokens);
+            syn::token::OrOr([span, span]).to_tokens(tokens);
+            syn::token::Brace(span).surround(tokens, |tokens| {
+                (quote_cs! {
+                    if false { yield ::futures::__rt::Async::Pending }
+                }).to_tokens(tokens);
+                expr.to_tokens(tokens);
+            });
+        });
+
+        tokens.into()
+    }
+
+    #[proc_macro]
+    pub fn async_stream_block_unpin(input: TokenStream) -> TokenStream {
         let input = TokenStream::from(TokenTree::Group(Group::new(Delimiter::Brace, input)));
         let expr = syn::parse(input)
             .expect("failed to parse tokens as an expression");

--- a/futures-macro-async/src/lib.rs
+++ b/futures-macro-async/src/lib.rs
@@ -459,6 +459,8 @@ if_nightly! {
             ::futures::__rt::gen_pinned
         };
 
+        let await = await();
+
         // Use some manual token construction here instead of `quote_cs!` to ensure
         // that we get the `call_site` span instead of the default span.
         let span = Span::call_site();
@@ -468,6 +470,7 @@ if_nightly! {
             syn::token::OrOr([span, span]).to_tokens(tokens);
             syn::token::Brace(span).surround(tokens, |tokens| {
                 (quote_cs! {
+                    #await
                     if false { yield ::futures::__rt::Async::Pending }
                 }).to_tokens(tokens);
                 expr.to_tokens(tokens);
@@ -488,6 +491,8 @@ if_nightly! {
             ::futures::__rt::gen_move
         };
 
+        let await = await_move();
+
         // Use some manual token construction here instead of `quote_cs!` to ensure
         // that we get the `call_site` span instead of the default span.
         let span = Span::call_site();
@@ -496,6 +501,7 @@ if_nightly! {
             syn::token::OrOr([span, span]).to_tokens(tokens);
             syn::token::Brace(span).surround(tokens, |tokens| {
                 (quote_cs! {
+                    #await
                     if false { yield ::futures::__rt::Async::Pending }
                 }).to_tokens(tokens);
                 expr.to_tokens(tokens);
@@ -516,6 +522,8 @@ if_nightly! {
             ::futures::__rt::gen_stream_pinned
         };
 
+        let await = await();
+
         // Use some manual token construction here instead of `quote_cs!` to ensure
         // that we get the `call_site` span instead of the default span.
         let span = Span::call_site();
@@ -525,6 +533,7 @@ if_nightly! {
             syn::token::OrOr([span, span]).to_tokens(tokens);
             syn::token::Brace(span).surround(tokens, |tokens| {
                 (quote_cs! {
+                    #await
                     if false { yield ::futures::__rt::Async::Pending }
                 }).to_tokens(tokens);
                 expr.to_tokens(tokens);
@@ -545,6 +554,8 @@ if_nightly! {
             ::futures::__rt::gen_stream
         };
 
+        let await = await_move();
+
         // Use some manual token construction here instead of `quote_cs!` to ensure
         // that we get the `call_site` span instead of the default span.
         let span = Span::call_site();
@@ -553,6 +564,7 @@ if_nightly! {
             syn::token::OrOr([span, span]).to_tokens(tokens);
             syn::token::Brace(span).surround(tokens, |tokens| {
                 (quote_cs! {
+                    #await
                     if false { yield ::futures::__rt::Async::Pending }
                 }).to_tokens(tokens);
                 expr.to_tokens(tokens);

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -297,22 +297,24 @@ pub mod prelude {
         AsyncWriteExt,
     };
 
-     #[cfg(feature = "nightly")]
-     pub use futures_macro_async::{
-         async,
-         async_move,
-         async_stream,
-         async_stream_move,
-         async_block,
-         async_stream_block
-     };
- 
-     #[cfg(feature = "nightly")]
-     pub use futures_macro_await::{
-         await,
-         stream_yield,
-         await_item
-     };
+    #[cfg(feature = "nightly")]
+    pub use futures_macro_async::{
+        async,
+        async_move,
+        async_stream,
+        async_stream_move,
+        async_block,
+        async_block_unpin,
+        async_stream_block,
+        async_stream_block_unpin,
+    };
+
+    #[cfg(feature = "nightly")]
+    pub use futures_macro_await::{
+        await,
+        stream_yield,
+        await_item
+    };
 }
 
 pub mod sink {


### PR DESCRIPTION
I'm not sold on the name, especially since it uses a completely different meaning to the `pinned` argument to `#[async]`. I could do the same as has happened to `#[async]` and change `async_block` to return a `StableFuture` along with a new `async_block_move` macro for `Future`.

My preferred way to do this would be to keep a single `async_block` macro and pass an argument to it as posited in #918 for `#[async(move)]` (along with the change to `StableFuture` by default); I've been trying to come up with a way to nicely pass attributes to the `async_block` macro, but I can't think of anything I'm really attached to. The best I came up with was something like:

```rust
async_block!(move, {
    await!(bar(&x));
});
```

which I believe is unambiguous because `$($ident,)+ { $($tt)+ }` cannot be parsed as an `expr`.