### PR TITLE
Revert "Allow creation of CpuPool to be fallible."

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -19,7 +19,7 @@
 //! # fn main() {
 //!
 //! // Create a worker thread pool with four threads
-//! let pool = CpuPool::new(4).unwrap();
+//! let pool = CpuPool::new(4);
 //!
 //! // Execute some work on the thread pool, optionally closing over data.
 //! let a = pool.spawn(long_running_future(2));
@@ -40,7 +40,6 @@
 extern crate futures;
 extern crate num_cpus;
 
-use std::io;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -148,24 +147,16 @@ impl CpuPool {
     ///
     /// ```rust
     /// # use futures_cpupool::{Builder, CpuPool};
-    /// # use std::io;
     /// #
-    /// # fn new(size: usize) -> io::Result<CpuPool> {
+    /// # fn new(size: usize) -> CpuPool {
     /// Builder::new().pool_size(size).create()
     /// # }
     /// ```
     ///
-    /// # Errors
-    ///
-    /// This method yields an [`io::Result`] to capture any failure to
-    /// create the thread at the OS level.
-    ///
-    /// [`io::Result`]: https://doc.rust-lang.org/stable/std/io/type.Result.html
-    ///
     /// # Panics
     ///
     /// Panics if `size == 0`.
-    pub fn new(size: usize) -> io::Result<CpuPool> {
+    pub fn new(size: usize) -> CpuPool {
         Builder::new().pool_size(size).create()
     }
 
@@ -176,20 +167,12 @@ impl CpuPool {
     ///
     /// ```rust
     /// # use futures_cpupool::{Builder, CpuPool};
-    /// # use std::io;
     /// #
-    /// # fn new_num_cpus() -> io::Result<CpuPool> {
+    /// # fn new_num_cpus() -> CpuPool {
     /// Builder::new().create()
     /// # }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// This method yields an [`io::Result`] to capture any failure to
-    /// create the thread at the OS level.
-    ///
-    /// [`io::Result`]: https://doc.rust-lang.org/stable/std/io/type.Result.html
-    pub fn new_num_cpus() -> io::Result<CpuPool> {
+    pub fn new_num_cpus() -> CpuPool {
         Builder::new().create()
     }
 
@@ -415,17 +398,10 @@ impl Builder {
 
     /// Create CpuPool with configured parameters
     ///
-    /// # Errors
-    ///
-    /// This method yields an [`io::Result`] to capture any failure to
-    /// create the thread at the OS level.
-    ///
-    /// [`io::Result`]: https://doc.rust-lang.org/stable/std/io/type.Result.html
-    ///
     /// # Panics
     ///
     /// Panics if `pool_size == 0`.
-    pub fn create(&mut self) -> io::Result<CpuPool> {
+    pub fn create(&mut self) -> CpuPool {
         let (tx, rx) = mpsc::channel();
         let pool = CpuPool {
             inner: Arc::new(Inner {
@@ -448,9 +424,9 @@ impl Builder {
             if self.stack_size > 0 {
                 thread_builder = thread_builder.stack_size(self.stack_size);
             }
-            thread_builder.spawn(move || inner.work(after_start, before_stop))?;
+            thread_builder.spawn(move || inner.work(after_start, before_stop)).unwrap();
         }
-        Ok(pool)
+        return pool
     }
 }
 


### PR DESCRIPTION
Reverts https://github.com/rust-lang-nursery/futures-rs/pull/939

This was a breaking change, and shouldn't have landed on the 0.1 branch.