### PR TITLE
Fixes future::Shared's Send/Sync bounds (Issue #952)

### DIFF
--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -234,8 +234,17 @@ impl Wake for Notifier {
     }
 }
 
-unsafe impl<F: Future> Sync for Inner<F> {}
-unsafe impl<F: Future> Send for Inner<F> {}
+unsafe impl<F> Sync for Inner<F> 
+    where F: Future + Send,
+          F::Item: Send + Sync,
+          F::Error: Send + Sync
+{}
+
+unsafe impl<F> Send for Inner<F>
+    where F: Future + Send,
+          F::Item: Send + Sync,
+          F::Error: Send + Sync
+{}
 
 impl<F> fmt::Debug for Inner<F>
     where F: Future + fmt::Debug,


### PR DESCRIPTION
Send/Sync where implemented even if Shared
should not have been Send/Sync (Issue #952)