### PR TITLE
Add Sink and Stream implementation for VecDeque

### DIFF
--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -71,6 +71,9 @@ impl<'a, S: ?Sized + Stream> Stream for &'a mut S {
 }
 
 if_std! {
+    use Async;
+    use never::Never;
+
     impl<S: ?Sized + Stream> Stream for ::std::boxed::Box<S> {
         type Item = S::Item;
         type Error = S::Error;
@@ -96,6 +99,15 @@ if_std! {
 
         fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<S::Item>, S::Error> {
             self.0.poll_next(cx)
+        }
+    }
+
+    impl<T> Stream for ::std::collections::VecDeque<T> {
+        type Item = T;
+        type Error = Never;
+
+        fn poll_next(&mut self, _cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+            Ok(Async::Ready(self.pop_front()))
         }
     }
 }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -51,6 +51,28 @@ if_std! {
         }
     }
 
+    impl<T> Sink for ::std::collections::VecDeque<T> {
+        type SinkItem = T;
+        type SinkError = Never;
+
+        fn poll_ready(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+            Ok(Async::Ready(()))
+        }
+
+        fn start_send(&mut self, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+            self.push_back(item);
+            Ok(())
+        }
+
+        fn poll_flush(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+            Ok(Async::Ready(()))
+        }
+
+        fn poll_close(&mut self, _: &mut task::Context) -> Poll<(), Self::SinkError> {
+            Ok(Async::Ready(()))
+        }
+    }
+
     impl<S: ?Sized + Sink> Sink for ::std::boxed::Box<S> {
         type SinkItem = S::SinkItem;
         type SinkError = S::SinkError;
@@ -133,7 +155,7 @@ pub trait Sink {
     /// send**.
     ///
     /// Implementations of `poll_ready` and `start_send` will usually involve
-    /// flushing behind the scenes in order to make room for new messages. 
+    /// flushing behind the scenes in order to make room for new messages.
     /// It is only necessary to call `poll_flush` if you need to guarantee that
     /// *all* of the items placed into the `Sink` have been sent.
     ///


### PR DESCRIPTION
Using `VecDeque` for being both `Sink` and `Stream` in library that uses futures is pretty natural for cases where consuming api might be both synchronous and asynchronous, on the sync side, also for tests