### PR TITLE
Rename pinned attribute

### DIFF
--- a/futures-macro-async/src/lib.rs
+++ b/futures-macro-async/src/lib.rs
@@ -264,10 +264,10 @@ if_nightly! {
     #[proc_macro_attribute]
     pub fn async(attribute: TokenStream, function: TokenStream) -> TokenStream {
         let attribute = match &attribute.to_string() as &str {
-            "( pinned )" => Attribute::PinnedBoxed,
-            "( pinned_send )" => Attribute::PinnedBoxedSend,
+            "( boxed )" => Attribute::PinnedBoxed,
+            "( boxed_send )" => Attribute::PinnedBoxedSend,
             "" => Attribute::Pinned,
-            _ => panic!("the #[async] attribute currently only takes `pinned` `pinned_send` as an arg"),
+            _ => panic!("the #[async] attribute currently only takes `boxed` `boxed_send` as an arg"),
         };
 
         async_inner(attribute, function, quote_cs! { ::futures::__rt::gen_pinned }, |output, lifetimes| {
@@ -352,9 +352,9 @@ if_nightly! {
         for arg in args.0 {
             match arg {
                 AsyncStreamArg(term, None) => {
-                    if term == "pinned" {
+                    if term == "boxed" {
                         if boxed {
-                            panic!("duplicate 'pinned' argument to #[async_stream]");
+                            panic!("duplicate 'boxed' argument to #[async_stream]");
                         }
                         boxed = true;
                     } else {

--- a/futures/tests/async_await/pinned.rs
+++ b/futures/tests/async_await/pinned.rs
@@ -37,27 +37,27 @@ fn qux2(x: i32) -> Result<i32, i32> {
     await!(baz2(x).pin())
 }
 
-#[async(pinned)]
+#[async(boxed)]
 fn boxed(x: i32) -> Result<i32, i32> {
     Ok(x)
 }
 
-#[async(pinned)]
+#[async(boxed)]
 fn boxed_borrow(x: &i32) -> Result<i32, i32> {
     Ok(*x)
 }
 
-#[async(pinned_send)]
+#[async(boxed_send)]
 fn boxed_send(x: i32) -> Result<i32, i32> {
     Ok(x)
 }
 
-#[async(pinned_send)]
+#[async(boxed_send)]
 fn boxed_send_borrow(x: &i32) -> Result<i32, i32> {
     Ok(*x)
 }
 
-#[async(pinned_send)]
+#[async(boxed_send)]
 fn spawnable() -> Result<(), Never> {
     Ok(())
 }
@@ -71,7 +71,7 @@ fn _stream1() -> Result<(), i32> {
     Ok(())
 }
 
-#[async_stream(pinned, item = u64)]
+#[async_stream(boxed, item = u64)]
 fn _stream_boxed() -> Result<(), i32> {
     fn integer() -> u64 { 1 }
     let x = &integer();


### PR DESCRIPTION
The first step to solve the name inconsistency issue of `async` attributes #918.