### PR TITLE
Add functions to create a new stream

### DIFF
--- a/futures-core/src/stream/iterator.rs
+++ b/futures-core/src/stream/iterator.rs
@@ -1,0 +1,52 @@
+use {Stream, Future, IntoFuture, Poll, Async};
+use task;
+
+/// A stream from a sequence of futures and blocks on each future step-by-step.
+///
+/// Created by the [`from_iter`](::stream::from_iter) function.
+#[derive(Debug, Clone)]
+pub struct StreamIterator<I, F> {
+    iter: I,
+    last: Option<F>,
+}
+
+impl<I, F> Stream for StreamIterator<I, F::Future>
+    where I: Iterator<Item=F>,
+          F: IntoFuture,
+{
+    type Item = <F::Future as Future>::Item;
+    type Error = <F::Future as Future>::Error;
+
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        match self.last {
+            Some(ref mut fut) => Ok(fut.poll(cx)?.map(Some)),
+            None => match self.iter.next() {
+                Some(fut) => {
+                    self.last = Some(fut.into_future());
+                    self.poll_next(cx)
+                }
+                None => Ok(Async::Ready(None)),
+            }
+        }
+    }
+}
+
+/// Creates a new stream from a sequence of futures.
+///
+/// # Examples
+///
+/// ```
+/// use futures_core::{future, stream::*};
+///
+/// let many_futures = vec![future::ok(1), future::err(2)];
+/// let stream_from_futures = from_iter(many_futures);
+/// ```
+pub fn from_iter<I, F>(iter: I) -> StreamIterator<I::IntoIter, F::Future>
+    where I: IntoIterator<Item=F>,
+          F: IntoFuture,
+{
+    StreamIterator {
+        iter: iter.into_iter(),
+        last: None,
+    }
+}

--- a/futures-core/src/stream/iterator.rs
+++ b/futures-core/src/stream/iterator.rs
@@ -23,7 +23,7 @@ impl<I, F> Stream for StreamIterator<I, F::Future>
             None => match self.iter.next() {
                 Some(fut) => {
                     self.last = Some(fut.into_future());
-                    self.poll_next(cx)
+                    Ok(self.last.as_mut().unwrap().poll(cx)?.map(Some))
                 }
                 None => Ok(Async::Ready(None)),
             }
@@ -36,7 +36,8 @@ impl<I, F> Stream for StreamIterator<I, F::Future>
 /// # Examples
 ///
 /// ```
-/// use futures_core::{future, stream::*};
+/// use futures_core::future;
+/// use futures_core::stream::*;
 ///
 /// let many_futures = vec![future::ok(1), future::err(2)];
 /// let stream_from_futures = from_iter(many_futures);

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -3,6 +3,11 @@
 use Poll;
 use task;
 
+mod iterator;
+pub use self::iterator::{from_iter, StreamIterator};
+mod sources;
+pub use self::sources::{empty, Empty, once, Once};
+
 /// A stream of values produced asynchronously.
 ///
 /// If `Future` is an asynchronous version of `Result`, then `Stream` is an

--- a/futures-core/src/stream/sources.rs
+++ b/futures-core/src/stream/sources.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
-use std::fmt;
+use core::marker::PhantomData;
+use core::fmt;
 
 use {Stream, Future, Poll, Async};
 use task;

--- a/futures-core/src/stream/sources.rs
+++ b/futures-core/src/stream/sources.rs
@@ -1,0 +1,99 @@
+use std::marker::PhantomData;
+use std::fmt;
+
+use {Stream, Future, Poll, Async};
+use task;
+
+/// An empty stream.
+///
+/// Created by the [`empty`](::stream::empty) function.
+pub struct Empty<T, E>(PhantomData<(T, E)>);
+
+impl<T, E> Stream for Empty<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll_next(&mut self, _cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        Ok(Async::Ready(None))
+    }
+}
+
+impl<T, E> fmt::Debug for Empty<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.pad("Empty")
+    }
+}
+
+impl<T, E> Default for Empty<T, E> {
+    fn default() -> Self {
+        Empty(PhantomData)
+    }
+}
+
+impl<T, E> Clone for Empty<T, E> {
+    fn clone(&self) -> Self {
+        Empty(PhantomData)
+    }
+}
+
+/// Creates an empty stream.
+///
+/// # Examples
+///
+/// ```
+/// use futures_core::stream::*;
+///
+/// let empty_stream = empty::<u32, u32>();
+/// ```
+pub fn empty<T, E>() -> Empty<T, E> {
+    Empty(PhantomData)
+}
+
+/// A stream that can produce only one item.
+///
+/// Created by the [`once`](::stream::once) function.
+#[derive(Debug, Clone)]
+pub struct Once<F: Future> {
+    inner: Option<F>,
+}
+
+impl<F: Future> Stream for Once<F> {
+    type Item = <F as Future>::Item;
+    type Error = <F as Future>::Error;
+
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        let res;
+
+        match self.inner {
+            None => return Ok(Async::Ready(None)),
+            Some(ref mut fut) => match fut.poll(cx) {
+                Ok(Async::Pending) => return Ok(Async::Pending),
+                Ok(Async::Ready(item)) => {
+                    res = Ok(Async::Ready(Some(item)));
+                }
+                Err(err) => {
+                    res = Err(err);
+                }
+            }
+        }
+
+        self.inner.take();
+        res
+    }
+}
+
+/// Creates a new stream from a future.
+///
+/// # Examples
+///
+/// ```
+/// use futures_core::{future, stream::*};
+///
+/// let a_future = future::ok::<u32, u32>(1);
+/// let a_stream = once(a_future);
+/// ```
+pub fn once<F: Future>(value: F) -> Once<F> {
+    Once {
+        inner: Some(value),
+    }
+}

--- a/futures-core/src/stream/sources.rs
+++ b/futures-core/src/stream/sources.rs
@@ -87,7 +87,8 @@ impl<F: Future> Stream for Once<F> {
 /// # Examples
 ///
 /// ```
-/// use futures_core::{future, stream::*};
+/// use futures_core::future;
+/// use futures_core::stream::*;
 ///
 /// let a_future = future::ok::<u32, u32>(1);
 /// let a_stream = once(a_future);


### PR DESCRIPTION
`stream::from_iter` creates a stream from a sequence of futures. Related issue #970 
`stream::empty` creates an empty stream.
`stream::once` creates a single-element stream from a future.