### PR TITLE
Either fixes

### DIFF
--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -11,9 +11,10 @@ The asynchronous `Sink` trait for the futures-rs library.
 """
 
 [features]
-std = ["futures-core/std", "futures-channel/std"]
+std = ["either/use_std", "futures-core/std", "futures-channel/std"]
 default = ["std"]
 
 [dependencies]
+either = { version = "1.4", default-features = false, optional = true }
 futures-core = { path = "../futures-core", version = "0.2.0", default-features = false }
 futures-channel = { path = "../futures-channel", version = "0.2.0", default-features = false }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -23,6 +23,48 @@ macro_rules! if_std {
 
 use futures_core::{Poll, task};
 
+#[cfg(feature = "either")]
+extern crate either;
+#[cfg(feature = "either")]
+use either::Either;
+#[cfg(feature = "either")]
+impl<A, B> Sink for Either<A, B>
+    where A: Sink,
+          B: Sink<SinkItem=<A as Sink>::SinkItem,
+                  SinkError=<A as Sink>::SinkError>
+{
+    type SinkItem = <A as Sink>::SinkItem;
+    type SinkError = <A as Sink>::SinkError;
+
+    fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        match *self {
+            Either::Left(ref mut x) => x.poll_ready(cx),
+            Either::Right(ref mut x) => x.poll_ready(cx),
+        }
+    }
+
+    fn start_send(&mut self, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+        match *self {
+            Either::Left(ref mut x) => x.start_send(item),
+            Either::Right(ref mut x) => x.start_send(item),
+        }
+    }
+
+    fn poll_flush(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        match *self {
+            Either::Left(ref mut x) => x.poll_flush(cx),
+            Either::Right(ref mut x) => x.poll_flush(cx),
+        }
+    }
+
+    fn poll_close(&mut self, cx: &mut task::Context) -> Poll<(), Self::SinkError> {
+        match *self {
+            Either::Left(ref mut x) => x.poll_close(cx),
+            Either::Right(ref mut x) => x.poll_close(cx),
+        }
+    }
+}
+
 if_std! {
     mod channel_impls;
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -12,7 +12,7 @@ Common utilities and extension traits for the futures-rs library.
 
 [features]
 std = ["futures-core/std", "futures-io/std", "futures-sink/std", "either/use_std"]
-default = ["std", "futures-core/either"]
+default = ["std", "futures-core/either", "futures-sink/either"]
 bench = []
 
 [dependencies]

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -509,7 +509,39 @@ pub trait FutureExt: Future {
     /// assert_eq!(x, block_on(future).unwrap());
     /// # }
     /// ```
+    #[deprecated(note = "use `left_future` instead")]
     fn left<B>(self) -> Either<Self, B>
+        where B: Future<Item = Self::Item, Error = Self::Error>,
+              Self: Sized
+    {
+        Either::Left(self)
+    }
+
+    /// Wrap this future in an `Either` future, making it the left-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `right_future` method to write `if`
+    /// statements that evaluate to different futures in different branches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate futures;
+    /// use futures::executor::block_on;
+    /// use futures::future::*;
+    ///
+    /// # fn main() {
+    /// let x = 6;
+    /// let future = if x < 10 {
+    ///     ok::<_, bool>(x).left_future()
+    /// } else {
+    ///     empty().right_future()
+    /// };
+    ///
+    /// assert_eq!(x, block_on(future).unwrap());
+    /// # }
+    /// ```
+    fn left_future<B>(self) -> Either<Self, B>
         where B: Future<Item = Self::Item, Error = Self::Error>,
               Self: Sized
     {
@@ -519,7 +551,7 @@ pub trait FutureExt: Future {
     /// Wrap this future in an `Either` future, making it the right-hand variant
     /// of that `Either`.
     ///
-    /// This can be used in combination with the `left` method to write `if`
+    /// This can be used in combination with the `left_future` method to write `if`
     /// statements that evaluate to different futures in different branches.
     ///
     /// # Examples
@@ -540,7 +572,39 @@ pub trait FutureExt: Future {
     /// assert_eq!(x, block_on(future).unwrap());
     /// # }
     /// ```
+    #[deprecated(note = "use `right_future` instead")]
     fn right<A>(self) -> Either<A, Self>
+        where A: Future<Item = Self::Item, Error = Self::Error>,
+              Self: Sized,
+    {
+        Either::Right(self)
+    }
+
+    /// Wrap this future in an `Either` future, making it the right-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `left_future` method to write `if`
+    /// statements that evaluate to different futures in different branches.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate futures;
+    /// use futures::executor::block_on;
+    /// use futures::future::*;
+    ///
+    /// # fn main() {
+    /// let x = 6;
+    /// let future = if x < 10 {
+    ///     ok::<_, bool>(x).left_future()
+    /// } else {
+    ///     empty().right_future()
+    /// };
+    ///
+    /// assert_eq!(x, block_on(future).unwrap());
+    /// # }
+    /// ```
+    fn right_future<A>(self) -> Either<A, Self>
         where A: Future<Item = Self::Item, Error = Self::Error>,
               Self: Sized,
     {

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -5,6 +5,7 @@
 
 use futures_core::{Stream, IntoFuture};
 use futures_sink::Sink;
+use super::future::Either;
 
 mod close;
 mod fanout;
@@ -218,5 +219,29 @@ pub trait SinkExt: Sink {
               Self: Sized
     {
         send_all::new(self, stream)
+    }
+
+    /// Wrap this sink in an `Either` sink, making it the left-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `right_sink` method to write `if`
+    /// statements that evaluate to different streams in different branches.
+    fn left_sink<B>(self) -> Either<Self, B>
+        where B: Sink<SinkItem = Self::SinkItem, SinkError = Self::SinkError>,
+              Self: Sized
+    {
+        Either::Left(self)
+    }
+
+    /// Wrap this stream in an `Either` stream, making it the right-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `left_sink` method to write `if`
+    /// statements that evaluate to different streams in different branches.
+    fn right_sink<B>(self) -> Either<B, Self>
+        where B: Sink<SinkItem = Self::SinkItem, SinkError = Self::SinkError>,
+              Self: Sized
+    {
+        Either::Right(self)
     }
 }

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -962,12 +962,12 @@ pub trait StreamExt: Stream {
         recover::new(self, f)
     }
 
-
     /// Wrap this stream in an `Either` stream, making it the left-hand variant
     /// of that `Either`.
     ///
     /// This can be used in combination with the `right` method to write `if`
     /// statements that evaluate to different streams in different branches.
+    #[deprecated(note = "use `left_stream` instead")]
     fn left<B>(self) -> Either<Self, B>
         where B: Stream<Item = Self::Item, Error = Self::Error>,
               Self: Sized
@@ -980,7 +980,32 @@ pub trait StreamExt: Stream {
     ///
     /// This can be used in combination with the `left` method to write `if`
     /// statements that evaluate to different streams in different branches.
+    #[deprecated(note = "use `right_stream` instead")]
     fn right<B>(self) -> Either<B, Self>
+        where B: Stream<Item = Self::Item, Error = Self::Error>,
+              Self: Sized
+    {
+        Either::Right(self)
+    }
+
+    /// Wrap this stream in an `Either` stream, making it the left-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `right_stream` method to write `if`
+    /// statements that evaluate to different streams in different branches.
+    fn left_stream<B>(self) -> Either<Self, B>
+        where B: Stream<Item = Self::Item, Error = Self::Error>,
+              Self: Sized
+    {
+        Either::Left(self)
+    }
+
+    /// Wrap this stream in an `Either` stream, making it the right-hand variant
+    /// of that `Either`.
+    ///
+    /// This can be used in combination with the `left_stream` method to write `if`
+    /// statements that evaluate to different streams in different branches.
+    fn right_stream<B>(self) -> Either<B, Self>
         where B: Stream<Item = Self::Item, Error = Self::Error>,
               Self: Sized
     {

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -19,6 +19,17 @@ mod support;
 use support::*;
 
 #[test]
+fn either_sink() {
+    let mut s = if true {
+        Vec::<i32>::new().left_sink()
+    } else {
+        VecDeque::<i32>::new().right_sink()
+    };
+
+    s.start_send(0).unwrap();
+}
+
+#[test]
 fn vec_sink() {
     let mut v = Vec::new();
     v.start_send(0).unwrap();


### PR DESCRIPTION
`.left` and `.right` overlap w/ the inherent methods on the `Either` type, which makes chaining painful (e.g. you need `Either::right(fut.left())` rather than `fut.left().right()`).

This also adds an either impl for `Sink`.