### PR TITLE
Use swap_remove in select_all to avoid O(n) copies

### DIFF
--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -59,7 +59,7 @@ impl<A> Future for SelectAll<A>
         }).next();
         match item {
             Some((idx, res)) => {
-                self.inner.remove(idx);
+                self.inner.swap_remove(idx);
                 let rest = mem::replace(&mut self.inner, Vec::new());
                 match res {
                     Ok(e) => Ok(Async::Ready((e, idx, rest))),


### PR DESCRIPTION
Fix https://github.com/rust-lang-nursery/futures-rs/issues/969