### PR TITLE
Rewrite the mpsc channels

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -5,18 +5,19 @@
 //! [`Sender`](Sender) handles. [`Receiver`](Receiver) implements
 //! [`Stream`](futures_core::Stream) and allows a task to read values out of the
 //! channel. If there is no message to read from the channel, the current task
-//! will be notified when a new value is sent. [`Sender`](Sender) implements the
+//! will be awoken when a new value is sent. [`Sender`](Sender) implements the
 //! `Sink` trait and allows a task to send messages into
 //! the channel. If the channel is at capacity, the send will be rejected and
-//! the task will be notified when additional capacity is available. In other
-//! words, the channel provides backpressure.
+//! the task will be awoken when additional capacity is available. This process
+//! of delaying sends beyond a certain capacity is often referred to as
+//! "backpressure".
 //!
-//! Unbounded channels are also available using the [`unbounded`](unbounded)
-//! constructor.
+//! Unbounded channels (channels without backpressure) are also available using
+//! the [`unbounded`](unbounded) function.
 //!
 //! # Disconnection
 //!
-//! When all [`Sender`](Sender) handles have been dropped, it is no longer
+//! When all [`Sender`](Sender)s have been dropped, it is no longer
 //! possible to send values into the channel. This is considered the termination
 //! event of the stream. As such, [`Receiver::poll_next`](Receiver::poll_next)
 //! will return `Ok(Ready(None))`.
@@ -37,53 +38,32 @@
 // At the core, the channel uses an atomic FIFO queue for message passing. This
 // queue is used as the primary coordination primitive. In order to enforce
 // capacity limits and handle back pressure, a secondary FIFO queue is used to
-// send parked task handles.
+// send wakers for blocked Sender tasks.
 //
 // The general idea is that the channel is created with a `buffer` size of `n`.
-// The channel capacity is `n + num-senders`. Each sender gets one "guaranteed"
-// slot to hold a message. This allows `Sender` to know for a fact that a send
-// will succeed *before* starting to do the actual work of sending the value.
-// Since most of this work is lock-free, once the work starts, it is impossible
-// to safely revert.
+// The channel capacity is limited to `n`.
 //
-// If the sender is unable to process a send operation, then the current
-// task is parked and the handle is sent on the parked task queue.
+// When a sender tries to send (via `poll_ready_helper`) it will attempt to
+// increment the current number of "send reservations". If incrementing this
+// count would result in `> n` reservations, the `Sender` task is scheduled
+// to receive a wakeup when the number of "send reservations" drops.
 //
 // Note that the implementation guarantees that the channel capacity will never
 // exceed the configured limit, however there is no *strict* guarantee that the
-// receiver will wake up a parked task *immediately* when a slot becomes
-// available. However, it will almost always unpark a task when a slot becomes
-// available and it is *guaranteed* that a sender will be unparked when the
-// message that caused the sender to become parked is read out of the channel.
-//
-// The steps for sending a message are roughly:
-//
-// 1) Increment the channel message count
-// 2) If the channel is at capacity, push the task handle onto the wait queue
-// 3) Push the message onto the message queue.
-//
-// The steps for receiving a message are roughly:
-//
-// 1) Pop a message from the message queue
-// 2) Pop a task handle from the wait queue
-// 3) Decrement the channel message count.
-//
-// It's important for the order of operations on lock-free structures to happen
-// in reverse order between the sender and receiver. This makes the message
-// queue the primary coordination structure and establishes the necessary
-// happens-before semantics required for the acquire / release semantics used
-// by the queue structure.
+// receiver will wake up a `Sender` task *immediately* when a slot becomes
+// available. However, it will always awaken a `Sender` if one is blocked when
+// a message is received.
 
 use std::fmt;
 use std::error::Error;
 use std::any::Any;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::usize;
 
-use futures_core::task::{self, Waker};
+use futures_core::task::{self, Waker, AtomicWaker};
 use futures_core::{Async, Poll, Stream};
 use futures_core::never::Never;
 
@@ -99,24 +79,44 @@ pub struct Sender<T> {
     // Channel state shared between the sender and receiver.
     inner: Arc<Inner<T>>,
 
-    // Handle to the task that is blocked on this sender. This handle is sent
-    // to the receiver half in order to be notified when the sender becomes
-    // unblocked.
-    sender_task: Arc<Mutex<SenderTask>>,
+    // Waker for to the task that is blocked on this sender.
+    // This handle is sent to the receiver half in order to be notified when
+    // the sender becomes unblocked.
+    //
+    // When the sender is dropped, it sets the waker to `None` so that the
+    // receiver knows to wake up a different sender instead.
+    sender_waker: Arc<Mutex<SenderWaker>>,
 
-    // True if the sender might be blocked. This is an optimization to avoid
-    // having to lock the mutex most of the time.
-    maybe_parked: bool,
+    // Cached value of `permission_to_send` in `SenderWaker` above.
+    // If `permission_to_send_cached` is true, then `permission_to_send`
+    // must also be true. However, `permission_to_send` may be true even
+    // when `permission_to_send_cached` is false.
+    permission_to_send_cached: bool,
 }
 
-/// The transmission end of an unbounded mpsc channel.
-///
-/// This value is created by the [`unbounded`](unbounded) function.
 #[derive(Debug)]
-pub struct UnboundedSender<T>(Sender<T>);
+struct SenderWaker {
+    /// An optional task to wake. `None` if the `Sender` has been dropped
+    /// or has 
+    waker: Option<Waker>,
 
-trait AssertKinds: Send + Sync + Clone {}
-impl AssertKinds for UnboundedSender<u32> {}
+    /// Whether or not the permission to send has already been acquired.
+    /// If this is false, then the sender must compare-exchange-increment
+    /// the number of cueued messages in `Inner` before it can be considered
+    /// "ready" to send a message. Once a message is sent, this goes back to
+    /// false. If the Sender is dropped while this flag is true, then the
+    /// number of cueued messages in `Inner` must be decremented so that other
+    /// `Sender`s can send.
+    ///
+    /// If `permission_to_send` is true, `waker` should be `None`.
+    permission_to_send: bool,
+}
+
+impl SenderWaker {
+    fn new() -> Self {
+        SenderWaker { waker: None, permission_to_send: false }
+    }
+}
 
 /// The receiving end of a bounded mpsc channel.
 ///
@@ -126,11 +126,723 @@ pub struct Receiver<T> {
     inner: Arc<Inner<T>>,
 }
 
+#[derive(Debug)]
+struct Inner<T> {
+    // Max buffer size of the channel. If `None` then the channel is unbounded.
+    buffer: Option<usize>,
+
+    // Internal channel state. Consists of the number of messages stored in the
+    // channel as well as a flag signalling that the channel is closed.
+    state: AtomicUsize,
+
+    // Atomic, FIFO queue used to send messages to the receiver
+    message_queue: Queue<T>,
+
+    // Atomic, FIFO queue used to send wakers for blocked `Sender` tasks to the `Receiver`.
+    sender_waker_queue: Queue<Arc<Mutex<SenderWaker>>>,
+    // Lock for popping off of the sender_waker_queue
+    sender_waker_pop_lock: Mutex<()>,
+
+    // Waker for the receiver's task.
+    recv_waker: AtomicWaker,
+}
+
+// Struct representation of `Inner::state`.
+#[derive(Debug, Clone, Copy)]
+struct State {
+    // `true` when the channel is open
+    is_open: bool,
+
+    // Number of messages in the channel
+    send_reservations: usize,
+}
+
+// The `is_open` flag is stored in the left-most bit of `Inner::state`
+const OPEN_MASK: usize = usize::MAX - (usize::MAX >> 1);
+
+// When a new channel is created, it is created in the open state with no
+// pending messages.
+const INIT_STATE: usize = OPEN_MASK;
+
+// The maximum number of messages that a channel can track is `usize::MAX >> 1`
+const MAX_CAPACITY: usize = !(OPEN_MASK);
+
+// The maximum requested buffer size must be less than the maximum capacity of
+// a channel. This is because each sender gets a guaranteed slot.
+const MAX_BUFFER: usize = MAX_CAPACITY >> 1;
+
+/// Creates a bounded mpsc channel for communicating between asynchronous tasks.
+///
+/// Being bounded, this channel provides backpressure to ensure that the sender
+/// outpaces the receiver by only a limited amount. The channel's capacity is
+/// equal to `buffer + 1`. That is, there can be `buffer + 1` number of
+/// messages in-flight before the channel will start providing backpressure.
+///
+/// The [`Receiver`](Receiver) returned implements the
+/// [`Stream`](futures_core::Stream) trait, while [`Sender`](Sender) implements
+/// `Sink`.
+pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
+    // Check that the requested buffer size does not exceed the maximum buffer
+    // size permitted by the system.
+    assert!(buffer < MAX_BUFFER, "requested buffer size too large");
+    channel2(Some(buffer + 1))
+}
+
+fn channel2<T>(buffer: Option<usize>) -> (Sender<T>, Receiver<T>) {
+    let inner = Arc::new(Inner {
+        buffer: buffer,
+        state: AtomicUsize::new(INIT_STATE),
+        message_queue: Queue::new(),
+        sender_waker_queue: Queue::new(),
+        sender_waker_pop_lock: Mutex::new(()),
+        recv_waker: AtomicWaker::new(),
+    });
+
+    let tx = Sender {
+        inner: inner.clone(),
+        sender_waker: Arc::new(Mutex::new(SenderWaker::new())),
+        permission_to_send_cached: false,
+    };
+
+    let rx = Receiver {
+        inner: inner,
+    };
+
+    (tx, rx)
+}
+
+/*
+ *
+ * ===== impl Sender =====
+ *
+ */
+
+impl<T> Sender<T> {
+    /// Attempts to send a message on this `Sender`, returning the message
+    /// if there was an error.
+    pub fn try_send(&mut self, msg: T) -> Result<(), TrySendError<T>> {
+        // If the sender is currently blocked, reject the message
+        match self.poll_ready_helper(None) {
+            Ok(Async::Ready(())) => {},
+            Ok(Async::Pending) => unreachable!(),
+            Err(e) => return Err(TrySendError {
+                err: e,
+                val: msg,
+            }),
+        }
+
+        // The channel has capacity to accept the message, so send it
+        if let Err(e) = self.inner.check_open() {
+            return Err(TrySendError { err: e, val: msg });
+        }
+        self.inner.message_queue.push(msg);
+        {
+            let mut sender_waker_lock = self.sender_waker.lock().unwrap();
+            sender_waker_lock.waker = None;
+            assert!(sender_waker_lock.permission_to_send);
+            sender_waker_lock.permission_to_send = false;
+            self.permission_to_send_cached = false;
+        }
+        self.inner.recv_waker.wake();
+        Ok(())
+    }
+
+    /// Send a message on the channel.
+    ///
+    /// This function should only be called after
+    /// [`poll_ready`](Sender::poll_ready) has reported that the channel is
+    /// ready to receive a message.
+    pub fn start_send(&mut self, msg: T) -> Result<(), SendError> {
+        self.try_send(msg)
+            .map_err(|e| e.err)
+    }
+
+    // Increment the number of reservations for sending a message.
+    fn inc_send_reservations(&self) -> Result<Async<()>, SendError> {
+        let mut curr = self.inner.state.load(SeqCst);
+
+        loop {
+            let mut state = decode_state(curr);
+
+            // The receiver end closed the channel.
+            if !state.is_open {
+                return Err(SendError::disconnected());
+            }
+
+            // This probably is never hit? Odds are the process will run out of
+            // memory first. It may be worth to return something else in this
+            // case?
+            assert!(state.send_reservations < MAX_CAPACITY, "buffer space exhausted; \
+                    sending this messages would overflow the state");
+
+            // Return if the buffer is maxed out
+            if let Some(max) = self.inner.buffer {
+                debug_assert!(max >= state.send_reservations);
+                if max == state.send_reservations {
+                    return Ok(Async::Pending);
+                }
+            }
+
+            state.send_reservations += 1;
+
+            let next = encode_state(&state);
+            match self.inner.state.compare_exchange(curr, next, SeqCst, SeqCst) {
+                Ok(_) => return Ok(Async::Ready(())),
+                Err(actual) => curr = actual,
+            }
+        }
+    }
+
+    /// Polls the channel to determine if there is guaranteed capacity to send
+    /// at least one item without waiting.
+    ///
+    /// # Return value
+    ///
+    /// This method returns:
+    ///
+    /// - `Ok(Async::Ready(_))` if there is sufficient capacity;
+    /// - `Ok(Async::Pending)` if the channel may not have
+    /// capacity, in which case the current task is queued to be notified once capacity is available;
+    /// - `Err(SendError)` if the receiver has been dropped.
+    pub fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), SendError> {
+        self.poll_ready_helper(Some(cx))
+    }
+
+    /// A helper for `poll_ready` and `try_send`.
+    /// 
+    /// `cx_opt`: if `Some`, a full channel will result in the `Waker` in `Context` being
+    /// queued for a wakeup when the channel is ready to receive a message. If `None`,
+    /// an error is returned rather than queueing the task.
+    fn poll_ready_helper(&mut self, cx_opt: Option<&mut task::Context>) -> Poll<(), SendError> {
+        // Start off by checking the cached value
+        if self.permission_to_send_cached {
+            self.inner.check_open()?;
+            return Ok(Async::Ready(()));
+        }
+
+        // Check the real value behind the lock to see if it was set
+        // by the reciever.
+        let mut sender_waker_lock = self.sender_waker.lock().unwrap();
+        if sender_waker_lock.permission_to_send {
+            debug_assert!(sender_waker_lock.waker.is_none());
+            self.permission_to_send_cached = true;
+            return Ok(Async::Ready(()));
+        }
+
+        // Attempt to make a new send reservation.
+        if let Async::Ready(()) = self.inc_send_reservations()? {
+            self.permission_to_send_cached = true;
+            sender_waker_lock.permission_to_send = true;
+            sender_waker_lock.waker = None;
+            return Ok(Async::Ready(()));
+        }
+
+        let waker = if let Some(cx) = cx_opt {
+            cx.waker().clone()
+        } else {
+            return Err(SendError::full());
+        };
+
+        // Update the waker and enqueue sender_waker if necessary
+        let was_already_queued = sender_waker_lock.waker.is_some();
+        sender_waker_lock.waker = Some(waker);
+        if !was_already_queued {
+            self.inner.sender_waker_queue.push(self.sender_waker.clone());
+        }
+
+        // Now that we've queued for a wakeup, try and increment again to make sure
+        // we didn't race a decrement.
+        if let Async::Ready(()) = self.inc_send_reservations()? {
+            self.permission_to_send_cached = true;
+            sender_waker_lock.permission_to_send = true;
+            sender_waker_lock.waker = None;
+            return Ok(Async::Ready(()));
+        }
+
+        Ok(Async::Pending)
+    }
+
+    /// Returns whether this channel is closed without needing a context.
+    pub fn is_closed(&self) -> bool {
+        if let Ok(()) = self.inner.check_open() {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Closes this channel from the sender side, preventing any new messages.
+    pub fn close_channel(&mut self) {
+        self.inner.close()
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        let had_permission_to_send;
+        {
+            let mut sender_waker_lock = self.sender_waker.lock().unwrap();
+            sender_waker_lock.waker = None;
+            had_permission_to_send = sender_waker_lock.permission_to_send;
+            sender_waker_lock.permission_to_send = false;
+        }
+
+        // If we had already received permission to send a message,
+        // release that permission.
+        if had_permission_to_send {
+            self.inner.release_send_reservation();
+        }
+
+        // If the sender is the last once,
+        // close the channel and awaken the receiver
+        if Arc::strong_count(&self.inner) == 2 {
+            self.close_channel();
+        }
+    }
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Sender<T> {
+        Sender {
+            inner: self.inner.clone(),
+            sender_waker: Arc::new(Mutex::new(SenderWaker::new())),
+            permission_to_send_cached: false,
+        }
+    }
+}
+
+/*
+ *
+ * ===== impl Receiver =====
+ *
+ */
+
+impl<T> Receiver<T> {
+    /// Closes the receiving half of a channel, without dropping it.
+    ///
+    /// This prevents any further messages from being sent on the channel while
+    /// still enabling the receiver to drain messages that are buffered.
+    pub fn close(&mut self) {
+        self.inner.close()
+    }
+
+    /// Tries to receive the next message without notifying a context if empty.
+    ///
+    /// It is not recommended to call this function from inside of a future,
+    /// only when you've otherwise arranged to be notified when the channel is
+    /// no longer empty.
+    pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
+        match self.next_message() {
+            Async::Ready(msg) => {
+                Ok(msg)
+            },
+            Async::Pending => Err(TryRecvError { _inner: () }),
+        }
+    }
+
+    /// Pops off the next message.
+    /// Returns `None` if no message is present and the channel is closed.
+    fn next_message(&mut self) -> Async<Option<T>> {
+        // Pop off a message
+        loop {
+            // Safe because this is the only place the message queue is popped,
+            // and it takes `&mut self` to ensure that only the unique reciever
+            // can pop off of the message queue.
+            match unsafe { self.inner.message_queue.pop() } {
+                PopResult::Data(msg) => {
+                    self.inner.release_send_reservation();
+                    return Async::Ready(Some(msg));
+                }
+                PopResult::Empty => {
+                    if let Err(_) = self.inner.check_open() {
+                        return Async::Ready(None);
+                    }
+
+                    // The queue is empty but not closed, return Pending
+                    return Async::Pending;
+                }
+                PopResult::Inconsistent => {
+                    // Inconsistent means that there will be a message to pop
+                    // in a short time. This branch can only be reached if
+                    // values are being produced from another thread, so there
+                    // are a few ways that we can deal with this:
+                    //
+                    // 1) Spin
+                    // 2) thread::yield_now()
+                    // 3) task::current().unwrap() & return Pending
+                    //
+                    // For now, thread::yield_now() is used, but it would
+                    // probably be better to spin a few times then yield.
+                    thread::yield_now();
+                }
+            }
+        }
+    } 
+}
+
+impl<T> Stream for Receiver<T> {
+    type Item = T;
+    type Error = Never;
+
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        // Try to read a message off of the message queue.
+        let msg = match self.next_message() {
+            Async::Ready(msg) => Async::Ready(msg),
+            Async::Pending => {
+                self.inner.recv_waker.register(cx.waker());
+                // Check again for a message to make sure we didn't race.
+                self.next_message()
+            }
+        };
+
+        Ok(msg)
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        // Drain the channel of all pending messages
+        self.close();
+        while let Async::Ready(Some(_)) = self.next_message() {}
+    }
+}
+
+/*
+ *
+ * ===== impl Inner =====
+ *
+ */
+
+impl<T> Inner<T> {
+    /// Release a reservation for sending a message.
+    ///
+    /// This method must be called when messages are successfully received
+    /// and when senders holding reservations are dropped.
+    fn release_send_reservation(&self) {
+        // If there are any waiting senders, attempt to give them
+        // permission to send and awaken them before decrementing the
+        // number of send reservations.
+        if !self.wake_one(true) {
+            // If no sender was awoken and given permissions, decrement
+            // the number of send reservations.
+            self.dec_send_reservations();
+
+            // Attempt to wake a new sender (without permissions)
+            // in case a sender was added to the queue between `wake_one`
+            // and the successfull execution of `dec_send_reservations`.
+            self.wake_one(false);
+        }
+    }
+
+    fn pop_sender_waker_queue(&self) -> PopResult<Arc<Mutex<SenderWaker>>> {
+        let lock = self.sender_waker_pop_lock.lock().unwrap();
+        // Safe becuase we've used the lock above to ensure that only
+        // one user at a time can pop.
+        let res = unsafe { self.sender_waker_queue.pop() };
+        drop(lock);
+        res
+    }
+
+    /// Wake a single sender.
+    ///
+    /// `permission`: whether or not to give that task the right to send.
+    ///
+    /// Returns whether or not a sender was awoken.
+    fn wake_one(&self, permission_to_send: bool) -> bool {
+        loop {
+            match self.pop_sender_waker_queue() {
+                PopResult::Data(sender_waker) => {
+                    let mut sender_waker = sender_waker.lock().unwrap();
+                    if let Some(waker) = sender_waker.waker.take() {
+                        // If sender_waker still contains a waker to be awoken,
+                        // then it must not yet have been given permission to send.
+                        debug_assert!(sender_waker.permission_to_send == false);
+                        if permission_to_send {
+                            sender_waker.permission_to_send = true;
+                        }
+                        waker.wake();
+                        return true;
+                    }
+                    // If there was no waker, then the sender no longer
+                    // requires a wakeup. Continue on to the next waker in the queue.
+                }
+                PopResult::Empty => {
+                    // Queue empty, no task to wake up.
+                    return false;
+                }
+                PopResult::Inconsistent => {
+                    // Same as above
+                    thread::yield_now();
+                }
+            }
+        }
+    }
+
+    /// Decrease the number of active reservations for sending.
+    fn dec_send_reservations(&self) {
+        let mut curr = self.state.load(SeqCst);
+
+        loop {
+            let mut state = decode_state(curr);
+
+            state.send_reservations -= 1;
+
+            let next = encode_state(&state);
+            match self.state.compare_exchange(curr, next, SeqCst, SeqCst) {
+                Ok(_) => break,
+                Err(actual) => curr = actual,
+            }
+        }
+    }
+
+    /// Close the channel.
+    ///
+    /// All senders and the receiver will be woken up.
+    fn close(&self) {
+        let mut curr = self.state.load(SeqCst);
+
+        loop {
+            let mut state = decode_state(curr);
+
+            if !state.is_open {
+                break
+            }
+
+            state.is_open = false;
+
+            let next = encode_state(&state);
+            match self.state.compare_exchange(curr, next, SeqCst, SeqCst) {
+                Ok(_) => break,
+                Err(actual) => curr = actual,
+            }
+        }
+
+        // Wake up any senders waiting as they'll see that we've closed the
+        // channel and will continue on their merry way.
+        loop {
+            match self.pop_sender_waker_queue() {
+                PopResult::Data(sender_waker) => {
+                    if let Some(waker) = sender_waker.lock().unwrap().waker.take() {
+                        waker.wake();
+                    }
+                }
+                PopResult::Empty => break,
+                // Someone was in the middle of a `push` when we last
+                // tried to `pop`.
+                PopResult::Inconsistent => thread::yield_now(),
+            }
+        }
+
+        // Wake up the receiver
+        self.recv_waker.wake();
+    }
+
+    fn check_open(&self) -> Result<(), SendError> {
+        if decode_state(self.state.load(Relaxed)).is_open {
+            Ok(())
+        } else {
+            Err(SendError::disconnected())
+        }
+    }
+}
+
+unsafe impl<T: Send> Send for Inner<T> {}
+unsafe impl<T: Send> Sync for Inner<T> {}
+
+/*
+ *
+ * ===== Helpers =====
+ *
+ */
+
+fn decode_state(num: usize) -> State {
+    State {
+        is_open: num & OPEN_MASK == OPEN_MASK,
+        send_reservations: num & MAX_CAPACITY,
+    }
+}
+
+fn encode_state(state: &State) -> usize {
+    let mut num = state.send_reservations;
+
+    if state.is_open {
+        num |= OPEN_MASK;
+    }
+
+    num
+}
+
+/// Creates an unbounded mpsc channel for communicating between asynchronous tasks.
+///
+/// A `send` on this channel will always succeed as long as the receive half has
+/// not been closed. If the receiver falls behind, messages will be arbitrarily
+/// buffered.
+///
+/// **Note** that the amount of available system memory is an implicit bound to
+/// the channel. Using an `unbounded` channel has the ability of causing the
+/// process to run out of memory. In this case, the process will be aborted.
+pub fn unbounded<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
+    let tx = Arc::new(UnboundedInner {
+        closed: AtomicBool::new(false),
+        message_queue: Queue::new(),
+        recv_waker: AtomicWaker::new(),
+    });
+    let rx = tx.clone();
+    (UnboundedSender(tx), UnboundedReceiver(rx))
+}
+
+/// The transmission end of an unbounded mpsc channel.
+///
+/// This value is created by the [`unbounded`](unbounded) function.
+#[derive(Debug, Clone)]
+pub struct UnboundedSender<T>(Arc<UnboundedInner<T>>);
+
 /// The receiving end of an unbounded mpsc channel.
 ///
 /// This value is created by the [`unbounded`](unbounded) function.
 #[derive(Debug)]
-pub struct UnboundedReceiver<T>(Receiver<T>);
+pub struct UnboundedReceiver<T>(Arc<UnboundedInner<T>>);
+
+trait AssertKinds: Send + Sync + Clone {}
+impl AssertKinds for UnboundedSender<u32> {}
+
+#[derive(Debug)]
+struct UnboundedInner<T> {
+    closed: AtomicBool,
+    message_queue: Queue<T>,
+    recv_waker: AtomicWaker,
+}
+
+impl<T> UnboundedSender<T> {
+    /// Check if the channel is ready to receive a message.
+    pub fn poll_ready(&self, _: &mut task::Context) -> Poll<(), SendError> {
+        Ok(Async::Ready(()))
+    }
+
+    /// Returns whether this channel is closed without needing a context.
+    pub fn is_closed(&self) -> bool {
+        self.0.closed.load(SeqCst)
+    }
+
+    /// Closes this channel from the sender side, preventing any new messages.
+    pub fn close_channel(&self) {
+        self.0.closed.store(true, SeqCst);
+        self.0.recv_waker.wake();
+    }
+
+    /// Send a message on the channel.
+    ///
+    /// This method should only be called after `poll_ready` has been used to
+    /// verify that the channel is ready to receive a message.
+    pub fn start_send(&mut self, msg: T) -> Result<(), SendError> {
+        if self.0.closed.load(SeqCst) {
+            return Err(SendError::disconnected());
+        }
+        self.0.message_queue.push(msg);
+        self.0.recv_waker.wake();
+        Ok(())
+    }
+
+    /// Sends a message along this channel.
+    ///
+    /// This is an unbounded sender, so this function differs from `Sink::send`
+    /// by ensuring the return type reflects that the channel is always ready to
+    /// receive messages.
+    pub fn unbounded_send(&self, msg: T) -> Result<(), TrySendError<T>> {
+        if self.0.closed.load(SeqCst) {
+            return Err(TrySendError {
+                err: SendError::disconnected(),
+                val: msg,
+            });
+        }
+        self.0.message_queue.push(msg);
+        self.0.recv_waker.wake();
+        Ok(())
+    }
+}
+
+impl<T> Drop for UnboundedSender<T> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.0) == 2 { 
+            // If it's just us and the reciever, or us and another sender,
+            // the channel should be closed.
+            self.0.closed.store(true, SeqCst);
+            self.0.recv_waker.wake();
+        }
+    }
+}
+
+impl<T> UnboundedReceiver<T> {
+    /// Closes the receiving half of the channel, without dropping it.
+    ///
+    /// This prevents any further messages from being sent on the channel while
+    /// still enabling the receiver to drain messages that are buffered.
+    pub fn close(&mut self) {
+        self.0.closed.store(true, SeqCst);
+    }
+
+    /// Tries to receive the next message without notifying a context if empty.
+    ///
+    /// It is not recommended to call this function from inside of a future,
+    /// only when you've otherwise arranged to be notified when the channel is
+    /// no longer empty.
+    pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
+        loop {
+            // Safe because this is the only place the message queue is popped,
+            // and it takes `&mut self` to ensure that only the unique reciever
+            // can pop off of the message queue.
+            match unsafe { self.0.message_queue.pop() } {
+                PopResult::Data(msg) => {
+                    return Ok(Some(msg));
+                }
+                PopResult::Empty => {
+                    if self.0.closed.load(SeqCst) {
+                        return Ok(None);
+                    }
+                    return Err(TryRecvError { _inner: () });
+                }
+                PopResult::Inconsistent => {
+                    // Inconsistent means that there will be a message to pop
+                    // in a short time. This branch can only be reached if
+                    // values are being produced from another thread, so there
+                    // are a few ways that we can deal with this:
+                    //
+                    // 1) Spin
+                    // 2) thread::yield_now()
+                    // 3) task::current().unwrap() & return Pending
+                    //
+                    // For now, thread::yield_now() is used, but it would
+                    // probably be better to spin a few times then yield.
+                    thread::yield_now();
+                }
+            }
+        }
+    }
+}
+
+impl<T> Stream for UnboundedReceiver<T> {
+    type Item = T;
+    type Error = Never;
+
+    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
+        if let Ok(msg) = self.try_next() {
+            return Ok(Async::Ready(msg));
+        }
+        self.0.recv_waker.register(cx.waker());
+        if let Ok(msg) = self.try_next() {
+            return Ok(Async::Ready(msg));
+        }
+        Ok(Async::Pending)
+    }
+}
+
+impl<T> Drop for UnboundedReceiver<T> {
+    fn drop(&mut self) {
+        self.0.closed.store(true, SeqCst);
+    }
+}
+
+// ----- Error types -----
 
 /// The error type for [`Sender`s](Sender) used as `Sink`s.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -191,6 +903,14 @@ impl SendError {
             SendErrorKind::Disconnected => true,
             _ => false,
         }
+    }
+
+    fn full() -> Self {
+        SendError { kind: SendErrorKind::Full }
+    }
+
+    fn disconnected() -> Self {
+        SendError { kind: SendErrorKind::Disconnected }
     }
 }
 
@@ -261,796 +981,4 @@ impl Error for TryRecvError {
     fn description(&self) -> &str {
         "receiver channel is empty"
     }
-}
-
-#[derive(Debug)]
-struct Inner<T> {
-    // Max buffer size of the channel. If `None` then the channel is unbounded.
-    buffer: Option<usize>,
-
-    // Internal channel state. Consists of the number of messages stored in the
-    // channel as well as a flag signalling that the channel is closed.
-    state: AtomicUsize,
-
-    // Atomic, FIFO queue used to send messages to the receiver
-    message_queue: Queue<Option<T>>,
-
-    // Atomic, FIFO queue used to send parked task handles to the receiver.
-    parked_queue: Queue<Arc<Mutex<SenderTask>>>,
-
-    // Number of senders in existence
-    num_senders: AtomicUsize,
-
-    // Handle to the receiver's task.
-    recv_task: Mutex<ReceiverTask>,
-}
-
-// Struct representation of `Inner::state`.
-#[derive(Debug, Clone, Copy)]
-struct State {
-    // `true` when the channel is open
-    is_open: bool,
-
-    // Number of messages in the channel
-    num_messages: usize,
-}
-
-#[derive(Debug)]
-struct ReceiverTask {
-    unparked: bool,
-    task: Option<Waker>,
-}
-
-// Returned from Receiver::try_park()
-enum TryPark {
-    Parked,
-    Closed,
-    NotEmpty,
-}
-
-// The `is_open` flag is stored in the left-most bit of `Inner::state`
-const OPEN_MASK: usize = usize::MAX - (usize::MAX >> 1);
-
-// When a new channel is created, it is created in the open state with no
-// pending messages.
-const INIT_STATE: usize = OPEN_MASK;
-
-// The maximum number of messages that a channel can track is `usize::MAX >> 1`
-const MAX_CAPACITY: usize = !(OPEN_MASK);
-
-// The maximum requested buffer size must be less than the maximum capacity of
-// a channel. This is because each sender gets a guaranteed slot.
-const MAX_BUFFER: usize = MAX_CAPACITY >> 1;
-
-// Sent to the consumer to wake up blocked producers
-#[derive(Debug)]
-struct SenderTask {
-    task: Option<Waker>,
-    is_parked: bool,
-}
-
-impl SenderTask {
-    fn new() -> Self {
-        SenderTask {
-            task: None,
-            is_parked: false,
-        }
-    }
-
-    fn notify(&mut self) {
-        self.is_parked = false;
-
-        if let Some(task) = self.task.take() {
-            task.wake();
-        }
-    }
-}
-
-/// Creates a bounded mpsc channel for communicating between asynchronous tasks.
-///
-/// Being bounded, this channel provides backpressure to ensure that the sender
-/// outpaces the receiver by only a limited amount. The channel's capacity is
-/// equal to `buffer + num-senders`. In other words, each sender gets a
-/// guaranteed slot in the channel capacity, and on top of that there are
-/// `buffer` "first come, first serve" slots available to all senders.
-///
-/// The [`Receiver`](Receiver) returned implements the
-/// [`Stream`](futures_core::Stream) trait, while [`Sender`](Sender) implements
-/// `Sink`.
-pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
-    // Check that the requested buffer size does not exceed the maximum buffer
-    // size permitted by the system.
-    assert!(buffer < MAX_BUFFER, "requested buffer size too large");
-    channel2(Some(buffer))
-}
-
-/// Creates an unbounded mpsc channel for communicating between asynchronous tasks.
-///
-/// A `send` on this channel will always succeed as long as the receive half has
-/// not been closed. If the receiver falls behind, messages will be arbitrarily
-/// buffered.
-///
-/// **Note** that the amount of available system memory is an implicit bound to
-/// the channel. Using an `unbounded` channel has the ability of causing the
-/// process to run out of memory. In this case, the process will be aborted.
-pub fn unbounded<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
-    let (tx, rx) = channel2(None);
-    (UnboundedSender(tx), UnboundedReceiver(rx))
-}
-
-fn channel2<T>(buffer: Option<usize>) -> (Sender<T>, Receiver<T>) {
-    let inner = Arc::new(Inner {
-        buffer: buffer,
-        state: AtomicUsize::new(INIT_STATE),
-        message_queue: Queue::new(),
-        parked_queue: Queue::new(),
-        num_senders: AtomicUsize::new(1),
-        recv_task: Mutex::new(ReceiverTask {
-            unparked: false,
-            task: None,
-        }),
-    });
-
-    let tx = Sender {
-        inner: inner.clone(),
-        sender_task: Arc::new(Mutex::new(SenderTask::new())),
-        maybe_parked: false,
-    };
-
-    let rx = Receiver {
-        inner: inner,
-    };
-
-    (tx, rx)
-}
-
-/*
- *
- * ===== impl Sender =====
- *
- */
-
-impl<T> Sender<T> {
-    /// Attempts to send a message on this `Sender`, returning the message
-    /// if there was an error.
-    pub fn try_send(&mut self, msg: T) -> Result<(), TrySendError<T>> {
-        // If the sender is currently blocked, reject the message
-        if !self.poll_unparked(None).is_ready() {
-            return Err(TrySendError {
-                err: SendError {
-                    kind: SendErrorKind::Full,
-                },
-                val: msg,
-            });
-        }
-
-        // The channel has capacity to accept the message, so send it
-        self.do_send(None, msg)
-    }
-
-    /// Send a message on the channel.
-    ///
-    /// This function should only be called after
-    /// [`poll_ready`](Sender::poll_ready) has reported that the channel is
-    /// ready to receive a message.
-    pub fn start_send(&mut self, msg: T) -> Result<(), SendError> {
-        self.try_send(msg)
-            .map_err(|e| e.err)
-    }
-
-    // Do the send without failing
-    // None means close
-    fn do_send(&mut self, cx: Option<&mut task::Context>, msg: T)
-        -> Result<(), TrySendError<T>>
-    {
-        // Anyone callig do_send *should* make sure there is room first,
-        // but assert here for tests as a sanity check.
-        debug_assert!(self.poll_unparked(None).is_ready());
-
-        // First, increment the number of messages contained by the channel.
-        // This operation will also atomically determine if the sender task
-        // should be parked.
-        //
-        // None is returned in the case that the channel has been closed by the
-        // receiver. This happens when `Receiver::close` is called or the
-        // receiver is dropped.
-        let park_self = match self.inc_num_messages(false) {
-            Some(park_self) => park_self,
-            None => return Err(TrySendError {
-                err: SendError {
-                    kind: SendErrorKind::Disconnected,
-                },
-                val: msg,
-            }),
-        };
-
-        // If the channel has reached capacity, then the sender task needs to
-        // be parked. This will send the task handle on the parked task queue.
-        //
-        // However, when `do_send` is called while dropping the `Sender`,
-        // `task::current()` can't be called safely. In this case, in order to
-        // maintain internal consistency, a blank message is pushed onto the
-        // parked task queue.
-        if park_self {
-            self.park(cx);
-        }
-
-        self.queue_push_and_signal(Some(msg));
-
-        Ok(())
-    }
-
-    // Do the send without parking current task.
-    fn do_send_nb(&self, msg: Option<T>) -> Result<(), TrySendError<T>> {
-        match self.inc_num_messages(msg.is_none()) {
-            Some(park_self) => assert!(!park_self),
-            None => {
-                // The receiver has closed the channel. Only abort if actually
-                // sending a message. It is important that the stream
-                // termination (None) is always sent. This technically means
-                // that it is possible for the queue to contain the following
-                // number of messages:
-                //
-                //     num-senders + buffer + 1
-                //
-                if let Some(msg) = msg {
-                    return Err(TrySendError {
-                        err: SendError {
-                            kind: SendErrorKind::Disconnected,
-                        },
-                        val: msg,
-                    });
-                } else {
-                    return Ok(());
-                }
-            },
-        };
-
-        self.queue_push_and_signal(msg);
-
-        Ok(())
-    }
-
-    fn poll_ready_nb(&self) -> Poll<(), SendError> {
-        let state = decode_state(self.inner.state.load(SeqCst));
-        if state.is_open {
-            Ok(Async::Ready(()))
-        } else {
-            Err(SendError {
-                kind: SendErrorKind::Full,
-            })
-        }
-    }
-
-
-    // Push message to the queue and signal to the receiver
-    fn queue_push_and_signal(&self, msg: Option<T>) {
-        // Push the message onto the message queue
-        self.inner.message_queue.push(msg);
-
-        // Signal to the receiver that a message has been enqueued. If the
-        // receiver is parked, this will unpark the task.
-        self.signal();
-    }
-
-    // Increment the number of queued messages. Returns if the sender should
-    // block.
-    fn inc_num_messages(&self, close: bool) -> Option<bool> {
-        let mut curr = self.inner.state.load(SeqCst);
-
-        loop {
-            let mut state = decode_state(curr);
-
-            // The receiver end closed the channel.
-            if !state.is_open {
-                return None;
-            }
-
-            // This probably is never hit? Odds are the process will run out of
-            // memory first. It may be worth to return something else in this
-            // case?
-            assert!(state.num_messages < MAX_CAPACITY, "buffer space exhausted; \
-                    sending this messages would overflow the state");
-
-            state.num_messages += 1;
-
-            // The channel is closed by all sender handles being dropped.
-            if close {
-                state.is_open = false;
-            }
-
-            let next = encode_state(&state);
-            match self.inner.state.compare_exchange(curr, next, SeqCst, SeqCst) {
-                Ok(_) => {
-                    // Block if the current number of pending messages has exceeded
-                    // the configured buffer size
-                    let park_self = !close && match self.inner.buffer {
-                        Some(buffer) => state.num_messages > buffer,
-                        None => false,
-                    };
-
-                    return Some(park_self)
-                }
-                Err(actual) => curr = actual,
-            }
-        }
-    }
-
-    // Signal to the receiver task that a message has been enqueued
-    fn signal(&self) {
-        // TODO
-        // This logic can probably be improved by guarding the lock with an
-        // atomic.
-        //
-        // Do this step first so that the lock is dropped when
-        // `unpark` is called
-        let task = {
-            let mut recv_task = self.inner.recv_task.lock().unwrap();
-
-            // If the receiver has already been unparked, then there is nothing
-            // more to do
-            if recv_task.unparked {
-                return;
-            }
-
-            // Setting this flag enables the receiving end to detect that
-            // an unpark event happened in order to avoid unnecessarily
-            // parking.
-            recv_task.unparked = true;
-            recv_task.task.take()
-        };
-
-        if let Some(task) = task {
-            task.wake();
-        }
-    }
-
-    fn park(&mut self, cx: Option<&mut task::Context>) {
-        // TODO: clean up internal state if the task::current will fail
-
-        let task = cx.map(|cx| cx.waker().clone());
-
-        {
-            let mut sender = self.sender_task.lock().unwrap();
-            sender.task = task;
-            sender.is_parked = true;
-        }
-
-        // Send handle over queue
-        let t = self.sender_task.clone();
-        self.inner.parked_queue.push(t);
-
-        // Check to make sure we weren't closed after we sent our task on the
-        // queue
-        let state = decode_state(self.inner.state.load(SeqCst));
-        self.maybe_parked = state.is_open;
-    }
-
-    /// Polls the channel to determine if there is guaranteed capacity to send
-    /// at least one item without waiting.
-    ///
-    /// # Return value
-    ///
-    /// This method returns:
-    ///
-    /// - `Ok(Async::Ready(_))` if there is sufficient capacity;
-    /// - `Ok(Async::Pending)` if the channel may not have
-    /// capacity, in which case the current task is queued to be notified once capacity is available;
-    /// - `Err(SendError)` if the receiver has been dropped.
-    pub fn poll_ready(&mut self, cx: &mut task::Context) -> Poll<(), SendError> {
-        let state = decode_state(self.inner.state.load(SeqCst));
-        if !state.is_open {
-            return Err(SendError {
-                kind: SendErrorKind::Disconnected,
-            });
-        }
-
-        Ok(self.poll_unparked(Some(cx)))
-    }
-
-    /// Returns whether this channel is closed without needing a context.
-    pub fn is_closed(&self) -> bool {
-        !decode_state(self.inner.state.load(SeqCst)).is_open
-    }
-
-    /// Closes this channel from the sender side, preventing any new messages.
-    pub fn close_channel(&mut self) {
-        // There's no need to park this sender, its dropping,
-        // and we don't want to check for capacity, so skip
-        // that stuff from `do_send`.
-
-        let _ = self.do_send_nb(None);
-    }
-
-    fn poll_unparked(&mut self, cx: Option<&mut task::Context>) -> Async<()> {
-        // First check the `maybe_parked` variable. This avoids acquiring the
-        // lock in most cases
-        if self.maybe_parked {
-            // Get a lock on the task handle
-            let mut task = self.sender_task.lock().unwrap();
-
-            if !task.is_parked {
-                self.maybe_parked = false;
-                return Async::Ready(())
-            }
-
-            // At this point, an unpark request is pending, so there will be an
-            // unpark sometime in the future. We just need to make sure that
-            // the correct task will be notified.
-            //
-            // Update the task in case the `Sender` has been moved to another
-            // task
-            task.task = cx.map(|cx| cx.waker().clone());
-
-            Async::Pending
-        } else {
-            Async::Ready(())
-        }
-    }
-}
-
-impl<T> UnboundedSender<T> {
-    /// Check if the channel is ready to receive a message.
-    pub fn poll_ready(&self, _: &mut task::Context) -> Poll<(), SendError> {
-        self.0.poll_ready_nb()
-    }
-
-    /// Returns whether this channel is closed without needing a context.
-    pub fn is_closed(&self) -> bool {
-        self.0.is_closed()
-    }
-
-    /// Closes this channel from the sender side, preventing any new messages.
-    pub fn close_channel(&self) {
-        // There's no need to park this sender, its dropping,
-        // and we don't want to check for capacity, so skip
-        // that stuff from `do_send`.
-
-        let _ = self.0.do_send_nb(None);
-    }
-
-    /// Send a message on the channel.
-    ///
-    /// This method should only be called after `poll_ready` has been used to
-    /// verify that the channel is ready to receive a message.
-    pub fn start_send(&mut self, msg: T) -> Result<(), SendError> {
-        self.0.do_send_nb(Some(msg))
-            .map_err(|e| e.err)
-    }
-
-    /// Sends a message along this channel.
-    ///
-    /// This is an unbounded sender, so this function differs from `Sink::send`
-    /// by ensuring the return type reflects that the channel is always ready to
-    /// receive messages.
-    pub fn unbounded_send(&self, msg: T) -> Result<(), TrySendError<T>> {
-        self.0.do_send_nb(Some(msg))
-    }
-}
-
-impl<T> Clone for UnboundedSender<T> {
-    fn clone(&self) -> UnboundedSender<T> {
-        UnboundedSender(self.0.clone())
-    }
-}
-
-
-impl<T> Clone for Sender<T> {
-    fn clone(&self) -> Sender<T> {
-        // Since this atomic op isn't actually guarding any memory and we don't
-        // care about any orderings besides the ordering on the single atomic
-        // variable, a relaxed ordering is acceptable.
-        let mut curr = self.inner.num_senders.load(SeqCst);
-
-        loop {
-            // If the maximum number of senders has been reached, then fail
-            if curr == self.inner.max_senders() {
-                panic!("cannot clone `Sender` -- too many outstanding senders");
-            }
-
-            debug_assert!(curr < self.inner.max_senders());
-
-            let next = curr + 1;
-            let actual = self.inner.num_senders.compare_and_swap(curr, next, SeqCst);
-
-            // The ABA problem doesn't matter here. We only care that the
-            // number of senders never exceeds the maximum.
-            if actual == curr {
-                return Sender {
-                    inner: self.inner.clone(),
-                    sender_task: Arc::new(Mutex::new(SenderTask::new())),
-                    maybe_parked: false,
-                };
-            }
-
-            curr = actual;
-        }
-    }
-}
-
-impl<T> Drop for Sender<T> {
-    fn drop(&mut self) {
-        // Ordering between variables don't matter here
-        let prev = self.inner.num_senders.fetch_sub(1, SeqCst);
-
-        if prev == 1 {
-            // There's no need to park this sender, its dropping,
-            // and we don't want to check for capacity, so skip
-            // that stuff from `do_send`.
-            let _ = self.do_send_nb(None);
-        }
-    }
-}
-
-/*
- *
- * ===== impl Receiver =====
- *
- */
-
-impl<T> Receiver<T> {
-    /// Closes the receiving half of a channel, without dropping it.
-    ///
-    /// This prevents any further messages from being sent on the channel while
-    /// still enabling the receiver to drain messages that are buffered.
-    pub fn close(&mut self) {
-        let mut curr = self.inner.state.load(SeqCst);
-
-        loop {
-            let mut state = decode_state(curr);
-
-            if !state.is_open {
-                break
-            }
-
-            state.is_open = false;
-
-            let next = encode_state(&state);
-            match self.inner.state.compare_exchange(curr, next, SeqCst, SeqCst) {
-                Ok(_) => break,
-                Err(actual) => curr = actual,
-            }
-        }
-
-        // Wake up any threads waiting as they'll see that we've closed the
-        // channel and will continue on their merry way.
-        loop {
-            match unsafe { self.inner.parked_queue.pop() } {
-                PopResult::Data(task) => {
-                    task.lock().unwrap().notify();
-                }
-                PopResult::Empty => break,
-                PopResult::Inconsistent => thread::yield_now(),
-            }
-        }
-    }
-
-    /// Tries to receive the next message without notifying a context if empty.
-    ///
-    /// It is not recommended to call this function from inside of a future,
-    /// only when you've otherwise arranged to be notified when the channel is
-    /// no longer empty.
-    pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
-        match self.next_message() {
-            Async::Ready(msg) => {
-                Ok(msg)
-            },
-            Async::Pending => Err(TryRecvError { _inner: () }),
-        }
-    }
-
-    fn next_message(&mut self) -> Async<Option<T>> {
-        // Pop off a message
-        loop {
-            match unsafe { self.inner.message_queue.pop() } {
-                PopResult::Data(msg) => {
-                    // If there are any parked task handles in the parked queue, pop
-                    // one and unpark it.
-                    self.unpark_one();
-
-                    // Decrement number of messages
-                    self.dec_num_messages();
-
-                    return Async::Ready(msg);
-                }
-                PopResult::Empty => {
-                    // The queue is empty, return Pending
-                    return Async::Pending;
-                }
-                PopResult::Inconsistent => {
-                    // Inconsistent means that there will be a message to pop
-                    // in a short time. This branch can only be reached if
-                    // values are being produced from another thread, so there
-                    // are a few ways that we can deal with this:
-                    //
-                    // 1) Spin
-                    // 2) thread::yield_now()
-                    // 3) task::current().unwrap() & return Pending
-                    //
-                    // For now, thread::yield_now() is used, but it would
-                    // probably be better to spin a few times then yield.
-                    thread::yield_now();
-                }
-            }
-        }
-    }
-
-    // Unpark a single task handle if there is one pending in the parked queue
-    fn unpark_one(&mut self) {
-        loop {
-            match unsafe { self.inner.parked_queue.pop() } {
-                PopResult::Data(task) => {
-                    task.lock().unwrap().notify();
-                    return;
-                }
-                PopResult::Empty => {
-                    // Queue empty, no task to wake up.
-                    return;
-                }
-                PopResult::Inconsistent => {
-                    // Same as above
-                    thread::yield_now();
-                }
-            }
-        }
-    }
-
-    // Try to park the receiver task
-    fn try_park(&self, cx: &mut task::Context) -> TryPark {
-        let curr = self.inner.state.load(SeqCst);
-        let state = decode_state(curr);
-
-        // If the channel is closed, then there is no need to park.
-        if !state.is_open && state.num_messages == 0 {
-            return TryPark::Closed;
-        }
-
-        // First, track the task in the `recv_task` slot
-        let mut recv_task = self.inner.recv_task.lock().unwrap();
-
-        if recv_task.unparked {
-            // Consume the `unpark` signal without actually parking
-            recv_task.unparked = false;
-            return TryPark::NotEmpty;
-        }
-
-        recv_task.task = Some(cx.waker().clone());
-        TryPark::Parked
-    }
-
-    fn dec_num_messages(&self) {
-        let mut curr = self.inner.state.load(SeqCst);
-
-        loop {
-            let mut state = decode_state(curr);
-
-            state.num_messages -= 1;
-
-            let next = encode_state(&state);
-            match self.inner.state.compare_exchange(curr, next, SeqCst, SeqCst) {
-                Ok(_) => break,
-                Err(actual) => curr = actual,
-            }
-        }
-    }
-}
-
-impl<T> Stream for Receiver<T> {
-    type Item = T;
-    type Error = Never;
-
-    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
-        loop {
-            // Try to read a message off of the message queue.
-            let msg = match self.next_message() {
-                Async::Ready(msg) => msg,
-                Async::Pending => {
-                    // There are no messages to read, in this case, attempt to
-                    // park. The act of parking will verify that the channel is
-                    // still empty after the park operation has completed.
-                    match self.try_park(cx) {
-                        TryPark::Parked => {
-                            // The task was parked, and the channel is still
-                            // empty, return Pending.
-                            return Ok(Async::Pending);
-                        }
-                        TryPark::Closed => {
-                            // The channel is closed, there will be no further
-                            // messages.
-                            return Ok(Async::Ready(None));
-                        }
-                        TryPark::NotEmpty => {
-                            // A message has been sent while attempting to
-                            // park. Loop again, the next iteration is
-                            // guaranteed to get the message.
-                            continue;
-                        }
-                    }
-                }
-            };
-            // Return the message
-            return Ok(Async::Ready(msg));
-        }
-    }
-}
-
-impl<T> Drop for Receiver<T> {
-    fn drop(&mut self) {
-        // Drain the channel of all pending messages
-        self.close();
-        while self.next_message().is_ready() {
-            // ...
-        }
-    }
-}
-
-impl<T> UnboundedReceiver<T> {
-    /// Closes the receiving half of the channel, without dropping it.
-    ///
-    /// This prevents any further messages from being sent on the channel while
-    /// still enabling the receiver to drain messages that are buffered.
-    pub fn close(&mut self) {
-        self.0.close();
-    }
-
-    /// Tries to receive the next message without notifying a context if empty.
-    ///
-    /// It is not recommended to call this function from inside of a future,
-    /// only when you've otherwise arranged to be notified when the channel is
-    /// no longer empty.
-    pub fn try_next(&mut self) -> Result<Option<T>, TryRecvError> {
-        self.0.try_next()
-    }
-}
-
-impl<T> Stream for UnboundedReceiver<T> {
-    type Item = T;
-    type Error = Never;
-
-    fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
-        self.0.poll_next(cx)
-    }
-}
-
-/*
- *
- * ===== impl Inner =====
- *
- */
-
-impl<T> Inner<T> {
-    // The return value is such that the total number of messages that can be
-    // enqueued into the channel will never exceed MAX_CAPACITY
-    fn max_senders(&self) -> usize {
-        match self.buffer {
-            Some(buffer) => MAX_CAPACITY - buffer,
-            None => MAX_BUFFER,
-        }
-    }
-}
-
-unsafe impl<T: Send> Send for Inner<T> {}
-unsafe impl<T: Send> Sync for Inner<T> {}
-
-/*
- *
- * ===== Helpers =====
- *
- */
-
-fn decode_state(num: usize) -> State {
-    State {
-        is_open: num & OPEN_MASK == OPEN_MASK,
-        num_messages: num & MAX_CAPACITY,
-    }
-}
-
-fn encode_state(state: &State) -> usize {
-    let mut num = state.num_messages;
-
-    if state.is_open {
-        num |= OPEN_MASK;
-    }
-
-    num
 }

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -80,7 +80,7 @@ unsafe impl<T: Send> Send for Queue<T> { }
 unsafe impl<T: Send> Sync for Queue<T> { }
 
 impl<T> Node<T> {
-    unsafe fn new(v: Option<T>) -> *mut Node<T> {
+    fn new(v: Option<T>) -> *mut Node<T> {
         Box::into_raw(Box::new(Node {
             next: AtomicPtr::new(ptr::null_mut()),
             value: v,
@@ -92,7 +92,7 @@ impl<T> Queue<T> {
     /// Creates a new queue that is safe to share among multiple producers and
     /// one consumer.
     pub fn new() -> Queue<T> {
-        let stub = unsafe { Node::new(None) };
+        let stub = Node::new(None);
         Queue {
             head: AtomicPtr::new(stub),
             tail: UnsafeCell::new(stub),


### PR DESCRIPTION
Previously, the bounded mpsc channels wouldn't provide backpressure
in many cases because they provided a guaranteed slot for every
sender. This change refactors mpsc channels to never allow more than
buffer + 1 messages in-flight at a time.

Senders will attempt to increment the number of in-flight messages
in poll-ready. If successful, the count is incremented and a message
is sent. If the buffer was full, the sender adds itself to a queue
to be awoken. When a message is received, the receiver attempts to
awaken a Sender and grant it "sending rights". If no such channel
was found, it decreases the number of in-flight messages currently
present in the buffer. If a channel with "sending rights" is dropped,
it gives those sending rights to another waiting `Sender` or decreases
the number of in-flight messages.

There's one odd choice in this change, which was to pick buffer + 1
rather than buffer as the max number of elements. In practice, many
of the tests and a handful of real-world code relied on the ability
to have an initial element available for the first sender, and were
attempting to send into channels with a buffer size of zero. These
use-cases were all broken by this change without the change to use
buffer + 1.

Despite the buffer + 1 mitigation, this is still a breaking change
since it modifies the maximum number of elements allowed into a
channel. 0.2 has been out for a short enough time that it's probably
possible to transition without breaking existing code, but this
approach should be taken with caution. Luckily, 0.2 organized
futures-channel into a separate crate, so it could be released as
an 0.3 version of futures-channel, futures-sink, futures-util, and
the futures facade while still maintaining futures-io and futures-core
compatibility.

Fix https://github.com/rust-lang-nursery/futures-rs/issues/800
Fix https://github.com/rust-lang-nursery/net-wg/issues/11

cc @danburkert, @stjepang, @carllerche 