### PR TITLE
Channel refactor

### DIFF
--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -114,7 +114,6 @@ impl Stream for TestSender {
         try_ready!(self.tx.poll_ready(cx).map_err(|_| ()));
         self.tx.start_send(self.last + 1).unwrap();
         self.last += 1;
-        assert!(self.tx.poll_flush(cx).unwrap().is_ready());
         Ok(Async::Ready(Some(self.last)))
     }
 }

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -80,7 +80,7 @@ unsafe impl<T: Send> Send for Queue<T> { }
 unsafe impl<T: Send> Sync for Queue<T> { }
 
 impl<T> Node<T> {
-    unsafe fn new(v: Option<T>) -> *mut Node<T> {
+    fn new(v: Option<T>) -> *mut Node<T> {
         Box::into_raw(Box::new(Node {
             next: AtomicPtr::new(ptr::null_mut()),
             value: v,
@@ -92,7 +92,7 @@ impl<T> Queue<T> {
     /// Creates a new queue that is safe to share among multiple producers and
     /// one consumer.
     pub fn new() -> Queue<T> {
-        let stub = unsafe { Node::new(None) };
+        let stub = Node::new(None);
         Queue {
             head: AtomicPtr::new(stub),
             tail: UnsafeCell::new(stub),

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -413,8 +413,8 @@ fn fanout_smoke() {
 
 #[test]
 fn fanout_backpressure() {
-    let (left_send, left_recv) = mpsc::channel(0);
-    let (right_send, right_recv) = mpsc::channel(0);
+    let (left_send, left_recv) = mpsc::channel(1);
+    let (right_send, right_recv) = mpsc::channel(1);
     let sink = left_send.fanout(right_send);
 
     let sink = block_on(StartSendFut::new(sink, 0)).unwrap();


### PR DESCRIPTION
Refactors channels to use "waker" terminology rather than "parking"

Splits unbounded channels into a separate, simplified underlying type

Calls poll_ready in poll_flush impl for bounded channels in order to
provide backpressure on <Sender as Sink>::send.

Replacement for #984.

Fix #800
Fix rust-lang-nursery/net-wg#11

cc @danburkert, @seanmonstar, @carllerche