### PR TITLE
Fix async/await support for latest nightly

### DIFF
--- a/futures-macro-async/src/lib.rs
+++ b/futures-macro-async/src/lib.rs
@@ -525,8 +525,8 @@ if_nightly! {
 
     impl synom::Synom for AsyncArgs {
         named!(parse -> Self, map!(
-            option!(parens!(call!(Punctuated::<AsyncArg, syn::token::Comma>::parse_separated_nonempty))),
-            |p| AsyncArgs(p.map(|d| d.1.into_iter().collect()).unwrap_or_default())
+            call!(Punctuated::<AsyncArg, syn::token::Comma>::parse_separated),
+            |p| AsyncArgs(p.into_iter().collect())
         ));
     }
 
@@ -546,8 +546,8 @@ if_nightly! {
 
     impl synom::Synom for AsyncStreamArgs {
         named!(parse -> Self, map!(
-            option!(parens!(call!(Punctuated::<AsyncStreamArg, syn::token::Comma>::parse_separated_nonempty))),
-            |p| AsyncStreamArgs(p.map(|d| d.1.into_iter().collect()).unwrap_or_default())
+            call!(Punctuated::<AsyncStreamArg, syn::token::Comma>::parse_separated),
+            |p| AsyncStreamArgs(p.into_iter().collect())
         ));
     }
 }

--- a/futures/testcrate/ui/move-captured-variable.rs
+++ b/futures/testcrate/ui/move-captured-variable.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, generators, pin)]
+#![feature(proc_macro, proc_macro_non_items, generators, pin)]
 
 extern crate futures;
 

--- a/futures/tests/async_await_tests.rs
+++ b/futures/tests/async_await_tests.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "nightly", feature(proc_macro, generators, pin))]
+#![cfg_attr(feature = "nightly", feature(proc_macro, proc_macro_non_items, generators, pin))]
 
 extern crate futures;
 


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/50120 procedural macros do not receive the parentheses as part of their attributes TokenStream.
Also the proc_macro_non_items feature is necessary to use async_block.