### PR TITLE
Clear pending item in TakeWhile

### DIFF
--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -92,6 +92,7 @@ impl<S, R, P> Stream for TakeWhile<S, R, P>
             },
             Ok(Async::Ready(false)) => {
                 self.done_taking = true;
+                self.pending = None;
                 Ok(Async::Ready(None))
             }
             Ok(Async::Pending) => Ok(Async::Pending),


### PR DESCRIPTION
Pending item is no longer needed after termination flag has been set, so it's better to clear it earlier.

Though it's not strictly a bug, but more a surprising behavior: if pending item is not cleared, item's destructor is called after the stream's destructor. In my case it was causing a problem terminating a stream from RdKafka, cos it relies on the destruction order.