### PR TITLE
Fix a bug in stream::select_all

### DIFF
--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -67,13 +67,16 @@ impl<S: Stream> Stream for SelectAll<S> {
     type Error = S::Error;
 
     fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
-        match self.inner.poll_next(cx).map_err(|(err, _)| err)? {
-            Async::Pending => Ok(Async::Pending),
-            Async::Ready(Some((Some(item), remaining))) => {
-                self.push(remaining);
-                Ok(Async::Ready(Some(item)))
+        loop {
+            match self.inner.poll_next(cx).map_err(|(err, _)| err)? {
+                Async::Pending => return Ok(Async::Pending),
+                Async::Ready(Some((Some(item), remaining))) => {
+                    self.push(remaining);
+                    return Ok(Async::Ready(Some(item)));
+                }
+                Async::Ready(Some((None, _))) => {}
+                Async::Ready(None) => return Ok(Async::Ready(None)),
             }
-            Async::Ready(_) => Ok(Async::Ready(None)),
         }
     }
 }

--- a/futures/tests/stream_select_all.rs
+++ b/futures/tests/stream_select_all.rs
@@ -28,11 +28,13 @@ fn works_1() {
     assert_eq!(Some(Ok(33)), stream.next());
     assert_eq!(Some(Ok(99)), stream.next());
 
+    mem::drop(b_tx);
+
     c_tx.unbounded_send(42).unwrap();
     assert_eq!(Some(Ok(42)), stream.next());
     a_tx.unbounded_send(43).unwrap();
     assert_eq!(Some(Ok(43)), stream.next());
 
-    mem::drop((a_tx, b_tx, c_tx));
+    mem::drop((a_tx, c_tx));
     assert_eq!(None, stream.next());
 }


### PR DESCRIPTION
In the previous implementation, `stream::select_all` completes as soon as any of the streams it is selecting over is exhausted. The code in this PR will continue until all streams are exhausted.