### PR TITLE
Docs: make oneshot more discoverable

### DIFF
--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -76,6 +76,9 @@ struct Inner<T> {
 ///
 /// Each half can be separately owned and sent across tasks.
 ///
+/// One-shot channel is used for creating a pending future and completing it manually
+/// later. In other langauges, this functionality is also known under the name of "promise".
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
It took me a non-trivial amount of time to figure out how to complete a future "manually". `oneshot` is super neat, but it is so much different from `Promise.complete` style APIs from other libraries. Let's explain *why* you need one-short to make it hopefully easier to discover?