### PR TITLE
 Introduce LocalTaskObj

### DIFF
--- a/futures-core/src/executor.rs
+++ b/futures-core/src/executor.rs
@@ -1,4 +1,0 @@
-//! Executors.
-
-pub use core::task::{Executor, SpawnErrorKind, SpawnObjError};
-

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -83,5 +83,3 @@ pub use stream::Stream;
 
 pub mod task;
 pub use task::Poll;
-
-pub mod executor;

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -2,22 +2,23 @@
 
 use Future;
 
-pub use core::task::{UnsafeWake, Waker, LocalWaker};
+mod poll;
+pub use self::poll::Poll;
+
+pub use core::task::{
+    Context, Executor,
+    Waker, LocalWaker, UnsafeWake,
+    TaskObj, LocalTaskObj, UnsafeTask,
+    SpawnErrorKind, SpawnObjError, SpawnLocalObjError,
+};
 
 #[cfg(feature = "std")]
 pub use std::task::{Wake, local_waker, local_waker_from_nonlocal};
-
-pub use core::task::Context;
-
-mod poll;
-pub use self::poll::Poll;
 
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 mod atomic_waker;
 #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
 pub use self::atomic_waker::AtomicWaker;
-
-pub use core::task::{TaskObj, UnsafeTask};
 
 if_std! {
     use std::boxed::PinBox;

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -8,8 +8,7 @@ use std::thread;
 use std::fmt;
 
 use futures_core::*;
-use futures_core::task::{self, Wake, TaskObj};
-use futures_core::executor::{Executor, SpawnObjError};
+use futures_core::task::{self, Wake, TaskObj, Executor, SpawnObjError};
 
 use enter;
 use num_cpus;

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -605,7 +605,7 @@ pub trait FutureExt: Future {
     #[cfg(feature = "std")]
     fn with_executor<E>(self, executor: E) -> WithExecutor<Self, E>
         where Self: Sized,
-              E: ::futures_core::executor::Executor
+              E: ::futures_core::task::Executor
     {
         with_executor::new(self, executor)
     }

--- a/futures-util/src/future/with_executor.rs
+++ b/futures-util/src/future/with_executor.rs
@@ -2,8 +2,7 @@ use core::marker::Unpin;
 use core::mem::PinMut;
 
 use futures_core::{Future, Poll};
-use futures_core::task;
-use futures_core::executor::Executor;
+use futures_core::task::{self, Executor};
 
 /// Future for the `with_executor` combinator, assigning an executor
 /// to be used when spawning other futures.

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -175,7 +175,6 @@ pub mod executor {
         ThreadPool, ThreadPoolBuilder, JoinHandle,
         block_on, block_on_stream, enter, spawn, spawn_with_handle
     };
-    pub use futures_core::executor::{SpawnObjError, Executor};
 }
 
 pub mod future {
@@ -253,9 +252,6 @@ pub mod prelude {
     pub use futures_core::{
         Future, TryFuture, Stream, Poll, task
     };
-
-    #[cfg(feature = "std")]
-    pub use futures_core::executor::Executor;
 
     #[cfg(feature = "nightly")]
     pub use futures_stable::{
@@ -381,7 +377,10 @@ pub mod task {
     //! executors or dealing with synchronization issues around task wakeup.
 
     pub use futures_core::task::{
-        Context, Waker, UnsafeWake
+        Context, Waker, UnsafeWake,
+        Executor,
+        TaskObj, LocalTaskObj,
+        SpawnErrorKind, SpawnObjError, SpawnLocalObjError,
     };
 
     #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]


### PR DESCRIPTION
- Introduce `LocalTaskObj` and integrate it into `LocalPool`
- Export all the stuff form `core::task` under `futures::task` (some was previously exported under `futures::executor`) This is probably just a start. There're probably still some inconsistencies in the exports.
- This PR makes the tests in `futures-executor/tests/local_pool.rs` work