### PR TITLE
Stage futures-preview crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-futures = "0.2.1"
+futures = "0.2.2"
 ```
 
 Next, add this to your crate:
@@ -40,7 +40,7 @@ a `#[no_std]` environment, use:
 
 ```toml
 [dependencies]
-futures = { version = "0.2.1", default-features = false }
+futures = { version = "0.2.2", default-features = false }
 ```
 
 # License

--- a/futures-async-runtime/Cargo.toml
+++ b/futures-async-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-async-runtime"
-version = "0.2.1"
+name = "futures-async-runtime-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "../README.md"
@@ -13,17 +13,20 @@ description = """
 Runtime for the async/await macros in the `futures` crate.
 """
 
-[dependencies.futures-core]
-version = "0.2.1"
+[lib]
+name = "futures_async_runtime"
+
+[dependencies.futures-core-preview]
+version = "0.2.2"
 path = "../futures-core"
 default-features = false
 
-[dependencies.futures-stable]
-version = "0.2.1"
+[dependencies.futures-stable-preview]
+version = "0.2.2"
 path = "../futures-stable"
 default-features = false
 
 [features]
-nightly = ["futures-core/nightly", "futures-stable/nightly"]
-std = ["futures-core/std", "futures-stable/std"]
+nightly = ["futures-core-preview/nightly", "futures-stable-preview/nightly"]
+std = ["futures-core-preview/std", "futures-stable-preview/std"]
 default = ["std"]

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-channel"
-version = "0.2.1"
+name = "futures-channel-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -10,13 +10,16 @@ description = """
 Channels for asynchronous communication using futures-rs.
 """
 
+[lib]
+name = "futures_channel"
+
 [features]
-std = ["futures-core/std"]
+std = ["futures-core-preview/std"]
 default = ["std"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.2.1", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "0.2.2", default-features = false }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.2.1", default-features = true }
-futures-executor = { path = "../futures-executor", version = "0.2.1", default-features = true }
+futures-preview = { path = "../futures", version = "0.2.2", default-features = true }
+futures-executor-preview = { path = "../futures-executor", version = "0.2.2", default-features = true }

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -4,7 +4,7 @@
 //! asynchronous tasks.
 
 #![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/futures-channel/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/futures-channel/0.2.2")]
 #![no_std]
 
 #[cfg(feature = "std")]

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-core"
-version = "0.2.1"
+name = "futures-core-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -9,6 +9,9 @@ documentation = "https://docs.rs/futures-core"
 description = """
 The core traits and types in for the `futures` library.
 """
+
+[lib]
+name = "futures_core"
 
 [features]
 default = ["std"]

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/futures-core/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/futures-core/0.2.2")]
 
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "nightly", feature(pin))]

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-executor"
-version = "0.2.1"
+name = "futures-executor-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -10,17 +10,20 @@ description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """
 
+[lib]
+name = "futures_executor"
+
 [features]
-std = ["num_cpus", "futures-core/std", "futures-util/std", "futures-channel/std", "lazy_static"]
+std = ["num_cpus", "futures-core-preview/std", "futures-util-preview/std", "futures-channel-preview/std", "lazy_static"]
 default = ["std"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.2.1", default-features = false}
-futures-util = { path = "../futures-util", version = "0.2.1", default-features = false}
-futures-channel = { path = "../futures-channel", version = "0.2.1", default-features = false}
+futures-core-preview = { path = "../futures-core", version = "0.2.2", default-features = false}
+futures-util-preview = { path = "../futures-util", version = "0.2.2", default-features = false}
+futures-channel-preview = { path = "../futures-channel", version = "0.2.2", default-features = false}
 num_cpus = { version = "1.0", optional = true }
 lazy_static = { version = "1.0", optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.2.1" }
-futures-channel = { path = "../futures-channel", version = "0.2.1" }
+futures-preview = { path = "../futures", version = "0.2.2" }
+futures-channel-preview = { path = "../futures-channel", version = "0.2.2" }

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![no_std]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/futures-executor/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/futures-executor/0.2.2")]
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-io"
-version = "0.2.1"
+name = "futures-io-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -10,13 +10,16 @@ description = """
 The `AsyncRead` and `AsyncWrite` traits for the futures-rs library.
 """
 
+[lib]
+name = "futures_io"
+
 [features]
-std = ["futures-core/std", "iovec"]
+std = ["futures-core-preview/std", "iovec"]
 default = ["std"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.2.1", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "0.2.2", default-features = false }
 iovec = { version = "0.1", optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.2.1" }
+futures-preview = { path = "../futures", version = "0.2.2" }

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_rnoot_url = "https://docs.rs/futures-io/0.2.1")]
+#![doc(html_rnoot_url = "https://docs.rs/futures-io/0.2.2")]
 
 macro_rules! if_std {
     ($($i:item)*) => ($(

--- a/futures-macro-async/Cargo.toml
+++ b/futures-macro-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-macro-async"
-version = "0.2.1"
+name = "futures-macro-async-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -10,6 +10,7 @@ few other assorted macros.
 """
 
 [lib]
+name = "futures_macro_async"
 proc-macro = true
 
 [dependencies]

--- a/futures-macro-await/Cargo.toml
+++ b/futures-macro-await/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-macro-await"
-version = "0.2.1"
+name = "futures-macro-await-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -8,8 +8,11 @@ description = """
 Definition of the `await!` macro for the `futures` crate.
 """
 
+[lib]
+name = "futures_macro_await"
+
 [dev-dependencies]
-futures = { path = "../futures" }
+futures-preview = { path = "../futures" }
 
 [features]
-nightly = ["futures/nightly"]
+nightly = ["futures-preview/nightly"]

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-sink"
-version = "0.2.1"
+name = "futures-sink-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -10,11 +10,14 @@ description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """
 
+[lib]
+name = "futures_sink"
+
 [features]
-std = ["either/use_std", "futures-core/std", "futures-channel/std"]
+std = ["either/use_std", "futures-core-preview/std", "futures-channel-preview/std"]
 default = ["std"]
 
 [dependencies]
 either = { version = "1.4", default-features = false, optional = true }
-futures-core = { path = "../futures-core", version = "0.2.1", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.2.1", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "0.2.2", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "0.2.2", default-features = false }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/futures-sink/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/futures-sink/0.2.2")]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/futures-stable/Cargo.toml
+++ b/futures-stable/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
-name = "futures-stable"
+name = "futures-stable-preview"
 description = "futures which support internal references"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["boats <boats@mozilla.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 
-[dependencies.futures-core]
+[lib]
+name = "futures_stable"
+
+[dependencies.futures-core-preview]
 path = "../futures-core"
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
-[dependencies.futures-executor]
+[dependencies.futures-executor-preview]
 path = "../futures-executor"
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [features]
-nightly = ["futures-core/nightly"]
-std = ["futures-core/std", "futures-executor/std"]
+nightly = ["futures-core-preview/nightly"]
+std = ["futures-core-preview/std", "futures-executor-preview/std"]
 default = ["std"]

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures-util"
-version = "0.2.1"
+name = "futures-util-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -10,19 +10,22 @@ description = """
 Common utilities and extension traits for the futures-rs library.
 """
 
+[lib]
+name = "futures_util"
+
 [features]
-std = ["futures-core/std", "futures-io/std", "futures-sink/std", "either/use_std"]
-default = ["std", "futures-core/either", "futures-sink/either"]
+std = ["futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "either/use_std"]
+default = ["std", "futures-core-preview/either", "futures-sink-preview/either"]
 bench = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.2.1", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.2.1", default-features = false }
-futures-io = { path = "../futures-io", version = "0.2.1", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.2.1", default-features = false}
+futures-core-preview = { path = "../futures-core", version = "0.2.2", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "0.2.2", default-features = false }
+futures-io-preview = { path = "../futures-io", version = "0.2.2", default-features = false }
+futures-sink-preview = { path = "../futures-sink", version = "0.2.2", default-features = false}
 either = { version = "1.4", default-features = false }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.2.1" }
-futures-executor = { path = "../futures-executor", version = "0.2.1" }
-futures-channel = { path = "../futures-channel", version = "0.2.1" }
+futures-preview = { path = "../futures", version = "0.2.2" }
+futures-executor-preview = { path = "../futures-executor", version = "0.2.2" }
+futures-channel-preview = { path = "../futures-channel", version = "0.2.2" }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "futures"
-version = "0.2.1"
+name = "futures-preview"
+version = "0.2.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "../README.md"
@@ -14,23 +14,26 @@ composability, and iterator-like interfaces.
 """
 categories = ["asynchronous"]
 
+[lib]
+name = "futures"
+
 [badges]
 travis-ci = { repository = "rust-lang-nursery/futures-rs" }
 appveyor = { repository = "rust-lang-nursery/futures-rs" }
 
 [dependencies]
-futures-async-runtime = { path = "../futures-async-runtime", version = "0.2.1", default-features = false }
-futures-core = { path = "../futures-core", version = "0.2.1", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.2.1", default-features = false }
-futures-executor = { path = "../futures-executor", version = "0.2.1", default-features = false }
-futures-io = { path = "../futures-io", version = "0.2.1", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.2.1", default-features = false }
-futures-stable = { path = "../futures-stable", version = "0.2.1", default-features = false }
-futures-util = { path = "../futures-util", version = "0.2.1", default-features = false }
-futures-macro-async = { path = "../futures-macro-async", version = "0.2.1", optional = true }
-futures-macro-await = { path = "../futures-macro-await", version = "0.2.1", optional = true }
+futures-async-runtime-preview = { path = "../futures-async-runtime", version = "0.2.2", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "0.2.2", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "0.2.2", default-features = false }
+futures-executor-preview = { path = "../futures-executor", version = "0.2.2", default-features = false }
+futures-io-preview = { path = "../futures-io", version = "0.2.2", default-features = false }
+futures-sink-preview = { path = "../futures-sink", version = "0.2.2", default-features = false }
+futures-stable-preview = { path = "../futures-stable", version = "0.2.2", default-features = false }
+futures-util-preview = { path = "../futures-util", version = "0.2.2", default-features = false }
+futures-macro-async-preview = { path = "../futures-macro-async", version = "0.2.2", optional = true }
+futures-macro-await-preview = { path = "../futures-macro-await", version = "0.2.2", optional = true }
 
 [features]
-nightly = ["futures-core/nightly", "futures-stable/nightly", "futures-async-runtime/nightly", "futures-macro-async", "futures-macro-await", "futures-macro-async/nightly"]
-std = ["futures-core/std", "futures-executor/std", "futures-io/std", "futures-sink/std", "futures-stable/std", "futures-util/std", "futures-async-runtime/std"]
+nightly = ["futures-core-preview/nightly", "futures-stable-preview/nightly", "futures-async-runtime-preview/nightly", "futures-macro-async-preview", "futures-macro-await-preview", "futures-macro-async-preview/nightly"]
+std = ["futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-stable-preview/std", "futures-util-preview/std", "futures-async-runtime-preview/std"]
 default = ["std"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -20,7 +20,7 @@
 //! completion, but *do not block* the thread running them.
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/futures/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/futures/0.2.2")]
 
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "nightly", feature(use_extern_macros))]

--- a/futures/testcrate/Cargo.toml
+++ b/futures/testcrate/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 [lib]
 path = "lib.rs"
 
-[dependencies.futures]
+[dependencies.futures-preview]
 features = ["std", "nightly"]
 path = ".."
 


### PR DESCRIPTION
This moves the current 0.2 crates into "*-preview" packages to denote that they're not releases that are expected to be stable long-term. Following this release, 0.2.0 and 0.2.1 of each crate will be yanked, leaving 0.1 as the current long-term release, with 0.3 as the next upcoming "preview" release. 0.2 will never see a long-term release.

Once released under "*-preview", 0.3 will receive regular updates, but will not be expected to be backwards-compatible, and will be nightly-only. Once futures-in-std have stabilized, 0.3 will move to the non-preview channel and no longer introduce breaking changes.

Apologies for all the confusion throughout this process-- hopefully this plan clarifies things. If you have any questions about the plan, feel free to comment here or message me on the rust-lang discord.

Fix https://github.com/rust-lang-nursery/futures-rs/issues/1039

cc @seanmonstar, @carllerche 