### PR TITLE
`PinMut::get_mut_unchecked`, Add `Sized` bound to `poll_unpin`

### DIFF
--- a/futures-core/src/future/either.rs
+++ b/futures-core/src/future/either.rs
@@ -28,7 +28,7 @@ impl<A, B> Stream for Either<A, B>
 
     fn poll_next(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Option<A::Item>> {
         unsafe {
-            match PinMut::get_mut(self) {
+            match PinMut::get_mut_unchecked(self) {
                 Either::Left(a) => PinMut::new_unchecked(a).poll_next(cx),
                 Either::Right(b) => PinMut::new_unchecked(b).poll_next(cx),
             }

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -18,14 +18,14 @@ pub use core::future::Future;
 pub trait CoreFutureExt: Future {
     /// A convenience for calling `Future::poll` on `Unpin` future types.
     fn poll_unpin(&mut self, cx: &mut task::Context) -> Poll<Self::Output>
-        where Self: Unpin
+        where Self: Unpin + Sized
     {
         PinMut::new(self).poll(cx)
     }
 }
 
 impl<T: ?Sized> CoreFutureExt for T where T: Future {}
- 
+
 /// A convenience for futures that return `Result` values that includes
 /// a variety of adapters tailored to such futures.
 pub trait TryFuture {

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -27,7 +27,7 @@ macro_rules! if_std {
 macro_rules! pinned_deref {
     ($e:expr) => (
         ::core::mem::PinMut::new_unchecked(
-            &mut **::core::mem::PinMut::get_mut($e.reborrow())
+            &mut **::core::mem::PinMut::get_mut_unchecked($e.reborrow())
         )
     )
 }
@@ -36,7 +36,7 @@ macro_rules! pinned_deref {
 macro_rules! pinned_field {
     ($e:expr, $f:tt) => (
         ::core::mem::PinMut::new_unchecked(
-            &mut ::core::mem::PinMut::get_mut($e.reborrow()).$f
+            &mut ::core::mem::PinMut::get_mut_unchecked($e.reborrow()).$f
         )
     )
 }
@@ -57,7 +57,7 @@ macro_rules! unsafe_unpinned {
     ($f:tt -> $t:ty) => (
         fn $f<'a>(self: &'a mut PinMut<Self>) -> &'a mut $t {
             unsafe {
-                &mut ::core::mem::PinMut::get_mut(self.reborrow()).$f
+                &mut ::core::mem::PinMut::get_mut_unchecked(self.reborrow()).$f
             }
         }
     )

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -49,7 +49,7 @@ pub trait Stream {
 
     /// A convenience for calling `Stream::poll_next` on `Unpin` stream types.
     fn poll_next_unpin(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>>
-        where Self: Unpin
+        where Self: Unpin + Sized
     {
         PinMut::new(self).poll_next(cx)
     }
@@ -79,7 +79,7 @@ if_std! {
         type Item = S::Item;
 
         fn poll_next(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
-            (**self).poll_next_unpin(cx)
+            PinMut::new(&mut **self).poll_next(cx)
         }
     }
 

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -184,7 +184,7 @@ if_std! {
 
         fn start_send(self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
             // TODO: impl<T> Unpin for Vec<T> {}
-            unsafe { PinMut::get_mut(self) }.push(item);
+            unsafe { PinMut::get_mut_unchecked(self) }.push(item);
             Ok(())
         }
 
@@ -207,7 +207,7 @@ if_std! {
 
         fn start_send(self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
             // TODO: impl<T> Unpin for Vec<T> {}
-            unsafe { PinMut::get_mut(self) }.push_back(item);
+            unsafe { PinMut::get_mut_unchecked(self) }.push_back(item);
             Ok(())
         }
 
@@ -257,7 +257,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn poll_ready(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match PinMut::get_mut(self) {
+            match PinMut::get_mut_unchecked(self) {
                 Either::Left(x) => PinMut::new_unchecked(x).poll_ready(cx),
                 Either::Right(x) => PinMut::new_unchecked(x).poll_ready(cx),
             }
@@ -266,7 +266,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn start_send(self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
         unsafe {
-            match PinMut::get_mut(self) {
+            match PinMut::get_mut_unchecked(self) {
                 Either::Left(x) => PinMut::new_unchecked(x).start_send(item),
                 Either::Right(x) => PinMut::new_unchecked(x).start_send(item),
             }
@@ -275,7 +275,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn poll_flush(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match PinMut::get_mut(self) {
+            match PinMut::get_mut_unchecked(self) {
                 Either::Left(x) => PinMut::new_unchecked(x).poll_flush(cx),
                 Either::Right(x) => PinMut::new_unchecked(x).poll_flush(cx),
             }
@@ -284,7 +284,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn poll_close(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match PinMut::get_mut(self) {
+            match PinMut::get_mut_unchecked(self) {
                 Either::Left(x) => PinMut::new_unchecked(x).poll_close(cx),
                 Either::Right(x) => PinMut::new_unchecked(x).poll_close(cx),
             }

--- a/futures-util/src/future/chain.rs
+++ b/futures-util/src/future/chain.rs
@@ -24,8 +24,8 @@ impl<Fut1, Fut2, Data> Chain<Fut1, Fut2, Data>
         let mut f = Some(f);
 
         loop {
-            // safe to `get_mut` here because we don't move out
-            let fut2 = match unsafe { PinMut::get_mut(self.reborrow()) } {
+            // Safe to use `get_mut_unchecked` here because we don't move out
+            let fut2 = match unsafe { PinMut::get_mut_unchecked(self.reborrow()) } {
                 Chain::First(fut1, data) => {
                     // safe to create a new `PinMut` because `fut1` will never move
                     // before it's dropped.
@@ -37,17 +37,17 @@ impl<Fut1, Fut2, Data> Chain<Fut1, Fut2, Data>
                     }
                 }
                 Chain::Second(fut2) => {
-                    // safe to create a new `PinMut` because `fut2` will never move
+                    // Safe to create a new `PinMut` because `fut2` will never move
                     // before it's dropped; once we're in `Chain::Second` we stay
                     // there forever.
                     return unsafe { PinMut::new_unchecked(fut2) }.poll(cx)
                 }
             };
 
-            // safe because we're using the `&mut` to do an assignment, not for moving out
+            // Safe because we're using the `&mut` to do an assignment, not for moving out
             unsafe {
-                // note: it's safe to move the `fut2` here because we haven't yet polled it
-                *PinMut::get_mut(self.reborrow()) = Chain::Second(fut2);
+                // Note: It's safe to move the `fut2` here because we haven't yet polled it
+                *PinMut::get_mut_unchecked(self.reborrow()) = Chain::Second(fut2);
             }
         }
     }

--- a/futures-util/src/future/flatten_stream.rs
+++ b/futures-util/src/future/flatten_stream.rs
@@ -47,7 +47,7 @@ impl<F> Stream for FlattenStream<F>
     fn poll_next(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
         loop {
             // safety: data is never moved via the resulting &mut reference
-            let stream = match &mut unsafe { PinMut::get_mut(self.reborrow()) }.state {
+            let stream = match &mut unsafe { PinMut::get_mut_unchecked(self.reborrow()) }.state {
                 State::Future(f) => {
                     // safety: the future we're re-pinning here will never be moved;
                     // it will just be polled, then dropped in place
@@ -74,7 +74,7 @@ impl<F> Stream for FlattenStream<F>
             unsafe {
                 // safety: we use the &mut only for an assignment, which causes
                 // only an in-place drop
-                PinMut::get_mut(self.reborrow()).state = State::Stream(stream);
+                PinMut::get_mut_unchecked(self.reborrow()).state = State::Stream(stream);
             }
         }
     }

--- a/futures-util/src/future/with_executor.rs
+++ b/futures-util/src/future/with_executor.rs
@@ -32,7 +32,7 @@ impl<F, E> Future for WithExecutor<F, E>
     type Output = F::Output;
 
     fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<F::Output> {
-        let this = unsafe { PinMut::get_mut(self) };
+        let this = unsafe { PinMut::get_mut_unchecked(self) };
         let fut = unsafe { PinMut::new_unchecked(&mut this.future) };
         let exec = &mut this.executor;
         fut.poll(&mut cx.with_executor(exec))

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -24,7 +24,7 @@ fn lock_and_then<T, U, E, F>(lock: &BiLock<T>, cx: &mut task::Context, f: F) -> 
     match lock.poll_lock(cx) {
         // Safety: the value behind the bilock used by `ReadHalf` and `WriteHalf` is never exposed
         // as a `PinMut` anywhere other than here as a way to get to `&mut`.
-        Poll::Ready(mut l) => f(unsafe { PinMut::get_mut(l.as_pin_mut()) }, cx),
+        Poll::Ready(mut l) => f(unsafe { PinMut::get_mut_unchecked(l.as_pin_mut()) }, cx),
         Poll::Pending => Poll::Pending,
     }
 }

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -35,7 +35,7 @@ impl<S, F> SinkMapErr<S, F> {
 
     /// Get a pinned reference to the inner sink.
     pub fn get_pinned_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, S> {
-        unsafe { PinMut::new_unchecked(&mut PinMut::get_mut(self).sink) }
+        unsafe { PinMut::new_unchecked(&mut PinMut::get_mut_unchecked(self).sink) }
     }
 
     /// Consumes this combinator, returning the underlying sink.

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -47,7 +47,7 @@ enum State<Fut, T> {
 impl<Fut, T> State<Fut, T> {
     fn as_pin_mut<'a>(self: PinMut<'a, Self>) -> State<PinMut<'a, Fut>, PinMut<'a, T>> {
         unsafe {
-            match PinMut::get_mut(self) {
+            match PinMut::get_mut_unchecked(self) {
                 State::Empty => State::Empty,
                 State::Process(fut) => State::Process(PinMut::new_unchecked(fut)),
                 State::Buffered(x) => State::Buffered(PinMut::new_unchecked(x)),
@@ -116,7 +116,7 @@ impl<S, U, Fut, F, E> With<S, U, Fut, F>
         if let Some(buffered) = buffered {
             PinMut::set(self.state(), State::Buffered(buffered));
         }
-        if let State::Buffered(item) = unsafe { mem::replace(PinMut::get_mut(self.state()), State::Empty) } {
+        if let State::Buffered(item) = unsafe { mem::replace(PinMut::get_mut_unchecked(self.state()), State::Empty) } {
             Poll::Ready(self.sink().start_send(item).map_err(Into::into))
         } else {
             unreachable!()

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -65,7 +65,7 @@ impl<S> Fuse<S> {
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, S> {
-        unsafe { PinMut::new_unchecked(&mut PinMut::get_mut(self).stream) }
+        unsafe { PinMut::new_unchecked(&mut PinMut::get_mut_unchecked(self).stream) }
     }
 
     /// Consumes this combinator, returning the underlying stream.

--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -43,7 +43,7 @@ impl<'a, F: Unpin> Iterator for IterMut<'a, F> {
     type Item = &'a mut F;
 
     fn next(&mut self) -> Option<&'a mut F> {
-        self.0.next().map(|f| unsafe { PinMut::get_mut(f) })
+        self.0.next().map(|f| PinMut::get_mut(f))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -33,7 +33,7 @@ impl<S1, S2> Select<S1, S2> {
 
     fn project<'a>(self: PinMut<'a, Self>) -> (&'a mut bool, PinMut<'a, Fuse<S1>>, PinMut<'a, Fuse<S2>>) {
         unsafe {
-            let Select { stream1, stream2, flag } = PinMut::get_mut(self);
+            let Select { stream1, stream2, flag } = PinMut::get_mut_unchecked(self);
             (flag, PinMut::new_unchecked(stream1), PinMut::new_unchecked(stream2))
         }
     }

--- a/futures-util/src/try_future/and_then.rs
+++ b/futures-util/src/try_future/and_then.rs
@@ -34,8 +34,8 @@ impl<A, B, F> Future for AndThen<A, B, F>
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         loop {
-            // safe to `get_mut` here because we don't move out
-            let fut2 = match &mut unsafe { PinMut::get_mut(self.reborrow()) }.state {
+            // Safe to use `get_mut_unchecked` here because we don't move out
+            let fut2 = match &mut unsafe { PinMut::get_mut_unchecked(self.reborrow()) }.state {
                 State::First(fut1, data) => {
                     // safe to create a new `PinMut` because `fut1` will never move
                     // before it's dropped.
@@ -48,17 +48,17 @@ impl<A, B, F> Future for AndThen<A, B, F>
                     }
                 }
                 State::Second(fut2) => {
-                    // safe to create a new `PinMut` because `fut2` will never move
+                    // Safe to create a new `PinMut` because `fut2` will never move
                     // before it's dropped; once we're in `Chain::Second` we stay
                     // there forever.
                     return unsafe { PinMut::new_unchecked(fut2) }.try_poll(cx)
                 }
             };
 
-            // safe because we're using the `&mut` to do an assignment, not for moving out
+            // Safe because we're using the `&mut` to do an assignment, not for moving out
             unsafe {
-                // note: it's safe to move the `fut2` here because we haven't yet polled it
-                PinMut::get_mut(self.reborrow()).state = State::Second(fut2);
+                // Note: it's safe to move the `fut2` here because we haven't yet polled it
+                PinMut::get_mut_unchecked(self.reborrow()).state = State::Second(fut2);
             }
         }
     }

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -26,7 +26,7 @@ impl<F, S> FlattenSink<F, S> {
         -> State<PinMut<'a, F>, PinMut<'a, S>>
     {
         unsafe {
-            match &mut PinMut::get_mut(self).0 {
+            match &mut PinMut::get_mut_unchecked(self).0 {
                 Waiting(f) => Waiting(PinMut::new_unchecked(f)),
                 Ready(s) => Ready(PinMut::new_unchecked(s)),
                 Closed => Closed,

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -31,7 +31,7 @@ impl<U, A, F> Future for MapErr<A, F>
             Poll::Pending => return Poll::Pending,
             Poll::Ready(e) => {
                 let f = unsafe {
-                    PinMut::get_mut(self).f.take().expect("cannot poll MapErr twice")
+                    PinMut::get_mut_unchecked(self).f.take().expect("cannot poll MapErr twice")
                 };
                 Poll::Ready(e.map_err(f))
             }

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -31,7 +31,7 @@ impl<U, A, F> Future for MapOk<A, F>
             Poll::Pending => return Poll::Pending,
             Poll::Ready(e) => {
                 let f = unsafe {
-                    PinMut::get_mut(self).f.take().expect("cannot poll MapOk twice")
+                    PinMut::get_mut_unchecked(self).f.take().expect("cannot poll MapOk twice")
                 };
                 Poll::Ready(e.map(f))
             }

--- a/futures-util/src/try_future/recover.rs
+++ b/futures-util/src/try_future/recover.rs
@@ -26,7 +26,7 @@ impl<A, F> Future for Recover<A, F>
         unsafe { pinned_field!(self.reborrow(), inner) }.try_poll(cx)
             .map(|res| res.unwrap_or_else(|e| {
                 let f = unsafe {
-                    PinMut::get_mut(self).f.take()
+                    PinMut::get_mut_unchecked(self).f.take()
                         .expect("Polled future::Recover after completion")
                 };
                 f(e)


### PR DESCRIPTION
The new nightly (84804c387 2018-06-26) includes `PinMut::get_mut` & `get_mut_unchecked`!

- Replace `PinMut::get_mut` with `get_mut_unchecked` (this was renamed)
- Remove workaround that was used because the safe `PinMut::get_mut` didn't exist
- Use `unsafe_pinned!` macro in `FutureOption`
- Add `Sized` bound to `poll_unpin` methods. See error log below. I'm not sure how best to resolve this

<details>
<summary>Error log: The trait cannot be made into an object</summary>

```
error: the trait `stream::Stream` cannot be made into an object
  --> futures-core/src/stream/mod.rs:51:5
   |
51 | /     fn poll_next_unpin(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>>
52 | |         where Self: Unpin
53 | |     {
54 | |         PinMut::new(self).poll_next(cx)
55 | |     }
   | |_____^
   |
note: lint level defined here
  --> futures-core/src/lib.rs:7:54
   |
7  | #![deny(missing_docs, missing_debug_implementations, warnings)]
   |                                                      ^^^^^^^^
   = note: #[deny(where_clauses_object_safety)] implied by #[deny(warnings)]
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
   = note: method `poll_next_unpin` references the `Self` type in where clauses

error: the trait `future::CoreFutureExt` cannot be made into an object
  --> futures-core/src/future/mod.rs:20:5
   |
20 | /     fn poll_unpin(&mut self, cx: &mut task::Context) -> Poll<Self::Output>
21 | |         where Self: Unpin
22 | |     {
23 | |         PinMut::new(self).poll(cx)
24 | |     }
   | |_____^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
   = note: method `poll_unpin` references the `Self` type in where clauses

error: the trait `stream::Stream` cannot be made into an object
  --> futures-core/src/stream/mod.rs:51:5
   |
51 | /     fn poll_next_unpin(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>>
52 | |         where Self: Unpin
53 | |     {
54 | |         PinMut::new(self).poll_next(cx)
55 | |     }
   | |_____^
   |
note: lint level defined here
  --> futures-core/src/lib.rs:7:54
   |
7  | #![deny(missing_docs, missing_debug_implementations, warnings)]
   |                                                      ^^^^^^^^
   = note: #[deny(where_clauses_object_safety)] implied by #[deny(warnings)]
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
   = note: method `poll_next_unpin` references the `Self` type in where clauses

error: the trait `future::CoreFutureExt` cannot be made into an object
  --> futures-core/src/future/mod.rs:20:5
   |
20 | /     fn poll_unpin(&mut self, cx: &mut task::Context) -> Poll<Self::Output>
21 | |         where Self: Unpin
22 | |     {
23 | |         PinMut::new(self).poll(cx)
24 | |     }
   | |_____^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #51443 <https://github.com/rust-lang/rust/issues/51443>
   = note: method `poll_unpin` references the `Self` type in where clauses
```
</details>