### PR TITLE
Rust 2018

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures-channel"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://github.com/rust-lang-nursery/futures-rs"
 documentation = "https://docs.rs/futures-core"

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -4,10 +4,14 @@
 //! asynchronous tasks.
 
 #![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(rust_2018_preview)]
 
-#![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/futures-channel/0.2.0")]
 #![no_std]
+
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
+#![doc(html_root_url = "https://docs.rs/futures-channel/0.2.0")]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -88,7 +88,7 @@ use std::usize;
 use futures_core::task::{self, Waker};
 use futures_core::{Poll, Stream};
 
-use mpsc::queue::{Queue, PopResult};
+use crate::mpsc::queue::{Queue, PopResult};
 
 mod queue;
 

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use futures_core::{Future, Poll};
 use futures_core::task::{self, Waker};
 
-use lock::Lock;
+use crate::lock::Lock;
 
 /// A future for a value that will be provided by another asynchronous task.
 ///

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures-core"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://github.com/rust-lang-nursery/futures-rs"
 documentation = "https://docs.rs/futures-core"

--- a/futures-core/src/future/either.rs
+++ b/futures-core/src/future/either.rs
@@ -1,4 +1,4 @@
-use {task, Stream, Poll};
+use crate::{task, Stream, Poll};
 
 use core::mem::PinMut;
 

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -3,8 +3,8 @@
 use core::mem::PinMut;
 use core::marker::Unpin;
 
-use Poll;
-use task;
+use crate::Poll;
+use crate::task;
 
 mod option;
 pub use self::option::FutureOption;

--- a/futures-core/src/future/option.rs
+++ b/futures-core/src/future/option.rs
@@ -1,7 +1,7 @@
 //! Definition of the `Option` (optional step) combinator
 
-use {Future, Poll};
-use task;
+use crate::{Future, Poll};
+use crate::task;
 use core::mem::PinMut;
 
 /// A future representing a value which may or may not be present.

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,10 +1,13 @@
 //! Core traits and types for asynchronous operations in Rust.
 
-#![feature(pin, arbitrary_self_types)]
-#![feature(futures_api)]
+#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(rust_2018_preview)]
 
 #![no_std]
+
 #![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
 #![doc(html_root_url = "https://docs.rs/futures-core/0.3.0")]
 
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
@@ -76,10 +79,10 @@ macro_rules! pin_mut {
 }
 
 pub mod future;
-pub use future::{Future, CoreFutureExt, TryFuture};
+pub use crate::future::{Future, CoreFutureExt, TryFuture};
 
 pub mod stream;
-pub use stream::Stream;
+pub use crate::stream::Stream;
 
 pub mod task;
-pub use task::Poll;
+pub use crate::task::Poll;

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -2,8 +2,8 @@
 
 use core::mem::PinMut;
 
-use Poll;
-use task;
+use crate::Poll;
+use crate::task;
 
 /// A stream of values produced asynchronously.
 ///

--- a/futures-core/src/task/atomic_waker.rs
+++ b/futures-core/src/task/atomic_waker.rs
@@ -3,7 +3,7 @@ use core::cell::UnsafeCell;
 use core::sync::atomic::AtomicUsize;
 use core::sync::atomic::Ordering::{Acquire, Release, AcqRel};
 
-use task::Waker;
+use crate::task::Waker;
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -1,6 +1,6 @@
 //! Task notification.
 
-use Future;
+use crate::Future;
 
 mod poll;
 pub use self::poll::Poll;

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures-executor"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://github.com/rust-lang-nursery/futures-rs"
 documentation = "https://docs.rs/futures-core"

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -1,9 +1,13 @@
 //! Built-in executors and related tools.
 
 #![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(rust_2018_preview)]
 
 #![no_std]
-#![deny(missing_docs)]
+
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
 #![doc(html_root_url = "https://docs.rs/futures-executor/0.2.0")]
 
 #[cfg(feature = "std")]
@@ -29,15 +33,15 @@ if_std! {
     extern crate num_cpus;
 
     mod local_pool;
-    pub use local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalExecutor};
+    pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalExecutor};
 
     mod unpark_mutex;
     mod thread_pool;
-    pub use thread_pool::{ThreadPool, ThreadPoolBuilder};
+    pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 
     mod enter;
-    pub use enter::{enter, Enter, EnterError};
+    pub use crate::enter::{enter, Enter, EnterError};
 
     mod spawn;
-    pub use spawn::{spawn, Spawn, spawn_with_handle, SpawnWithHandle, JoinHandle};
+    pub use crate::spawn::{spawn, Spawn, spawn_with_handle, SpawnWithHandle, JoinHandle};
 }

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -13,8 +13,8 @@ use futures_core::task::{
 use futures_util::stream::FuturesUnordered;
 use futures_util::stream::StreamExt;
 
-use enter;
-use ThreadPool;
+use crate::enter;
+use crate::ThreadPool;
 
 /// A single-threaded task pool.
 ///
@@ -27,6 +27,7 @@ use ThreadPool;
 /// [`executor()`](LocalPool::executor) method. Because the executor is
 /// single-threaded, it supports a special form of task spawning for non-`Send`
 /// futures, via [`spawn_local`](LocalExecutor::spawn_local).
+#[derive(Debug)]
 pub struct LocalPool {
     pool: FuturesUnordered<LocalTaskObj>,
     incoming: Rc<Incoming>,
@@ -34,7 +35,7 @@ pub struct LocalPool {
 
 /// A handle to a [`LocalPool`](LocalPool) that implements
 /// [`Executor`](::futures_core::executor::Executor).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LocalExecutor {
     incoming: Weak<Incoming>,
 }
@@ -232,6 +233,7 @@ pub fn block_on_stream<S: Stream>(s: S) -> BlockingStream<S> {
 }
 
 /// An iterator which blocks on values from a stream until they become available.
+#[derive(Debug)]
 pub struct BlockingStream<S: Stream> { stream: Option<S> }
 
 impl<S: Stream> BlockingStream<S> {

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -10,9 +10,9 @@ use std::fmt;
 use futures_core::*;
 use futures_core::task::{self, Wake, TaskObj, Executor, SpawnObjError};
 
-use enter;
+use crate::enter;
 use num_cpus;
-use unpark_mutex::UnparkMutex;
+use crate::unpark_mutex::UnparkMutex;
 
 /// A general-purpose thread pool for scheduling asynchronous tasks.
 ///
@@ -30,8 +30,8 @@ pub struct ThreadPoolBuilder {
     pool_size: usize,
     stack_size: usize,
     name_prefix: Option<String>,
-    after_start: Option<Arc<Fn(usize) + Send + Sync>>,
-    before_stop: Option<Arc<Fn(usize) + Send + Sync>>,
+    after_start: Option<Arc<dyn Fn(usize) + Send + Sync>>,
+    before_stop: Option<Arc<dyn Fn(usize) + Send + Sync>>,
 }
 
 trait AssertSendSync: Send + Sync {}
@@ -95,7 +95,7 @@ impl ThreadPool {
     /// Note that the function will return when the provided future completes,
     /// even if some of the tasks it spawned are still running.
     pub fn run<F: Future>(&mut self, f: F) -> F::Output {
-        ::LocalPool::new().run_until(f, self)
+        crate::LocalPool::new().run_until(f, self)
     }
 }
 
@@ -121,8 +121,8 @@ impl PoolState {
 
     fn work(&self,
             idx: usize,
-            after_start: Option<Arc<Fn(usize) + Send + Sync>>,
-            before_stop: Option<Arc<Fn(usize) + Send + Sync>>) {
+            after_start: Option<Arc<dyn Fn(usize) + Send + Sync>>,
+            before_stop: Option<Arc<dyn Fn(usize) + Send + Sync>>) {
         let _scope = enter().unwrap();
         after_start.map(|fun| fun(idx));
         loop {

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures-io"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://github.com/rust-lang-nursery/futures-rs"
 documentation = "https://docs.rs/futures-io"

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -4,11 +4,15 @@
 //! asynchronous analogs to `std::io::{Read, Write}`. The primary difference is
 //! that these traits integrate with the asynchronous task system.
 
-#![no_std]
-#![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_rnoot_url = "https://docs.rs/futures-io/0.2.0")]
-
 #![feature(futures_api)]
+#![feature(rust_2018_preview)]
+
+#![no_std]
+
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
+#![doc(html_rnoot_url = "https://docs.rs/futures-io/0.2.0")]
 
 macro_rules! if_std {
     ($($i:item)*) => ($(
@@ -33,9 +37,9 @@ if_std! {
 
     // Re-export io::Error so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
-    pub use StdIo::Error as Error;
-    pub use StdIo::ErrorKind as ErrorKind;
-    pub use StdIo::Result as Result;
+    pub use crate::StdIo::Error as Error;
+    pub use crate::StdIo::ErrorKind as ErrorKind;
+    pub use crate::StdIo::Result as Result;
 
     /// A type used to conditionally initialize buffers passed to `AsyncRead`
     /// methods, modeled after `std`.

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures-sink"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = "2018"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://github.com/rust-lang-nursery/futures-rs"
 documentation = "https://docs.rs/futures-core"

--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -1,4 +1,4 @@
-use {Sink, Poll};
+use crate::{Sink, Poll};
 use futures_core::task;
 use futures_channel::mpsc::{Sender, SendError, UnboundedSender};
 use std::mem::PinMut;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -3,11 +3,15 @@
 //! This crate contains the `Sink` trait which allows values to be sent
 //! asynchronously.
 
-#![no_std]
-#![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/futures-sink/0.2.0")]
-
 #![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(rust_2018_preview)]
+
+#![no_std]
+
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
+#![doc(html_root_url = "https://docs.rs/futures-sink/0.2.0")]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures-util"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = '2018'
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://github.com/rust-lang-nursery/futures-rs"
 documentation = "https://docs.rs/futures-core"

--- a/futures-util/src/future/catch_unwind.rs
+++ b/futures-util/src/future/catch_unwind.rs
@@ -28,7 +28,7 @@ impl<F> CatchUnwind<F> where F: Future {
 impl<F> Future for CatchUnwind<F>
     where F: Future + UnwindSafe,
 {
-    type Output = Result<F::Output, Box<Any + Send>>;
+    type Output = Result<F::Output, Box<dyn Any + Send>>;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         match catch_unwind(AssertUnwindSafe(|| self.future().poll(cx))) {

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::marker::Unpin;
 use std::mem::PinMut;
 
-use {Poll, Future, task};
+use crate::{Poll, Future, task};
 
 use futures_io::AsyncWrite;
 

--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -3,7 +3,7 @@ use std::boxed::Box;
 use std::marker::Unpin;
 use std::mem::PinMut;
 
-use {Future, Poll, task};
+use crate::{Future, Poll, task};
 
 use futures_io::{AsyncRead, AsyncWrite};
 

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::marker::Unpin;
 use std::mem::PinMut;
 
-use {Poll, Future, task};
+use crate::{Poll, Future, task};
 
 use futures_io::AsyncWrite;
 

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -2,9 +2,9 @@ use std::io;
 use std::marker::Unpin;
 use std::mem::PinMut;
 
-use {Future, Poll, task};
+use crate::{Future, Poll, task};
 
-use io::AsyncRead;
+use crate::io::AsyncRead;
 
 /// A future which can be used to easily read available number of bytes to fill
 /// a buffer.

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -2,9 +2,9 @@ use std::io;
 use std::marker::Unpin;
 use std::mem::{self, PinMut};
 
-use {Poll, Future, task};
+use crate::{Poll, Future, task};
 
-use io::AsyncRead;
+use crate::io::AsyncRead;
 
 /// A future which can be used to easily read exactly enough bytes to fill
 /// a buffer.

--- a/futures-util/src/io/read_to_end.rs
+++ b/futures-util/src/io/read_to_end.rs
@@ -3,9 +3,9 @@ use std::marker::Unpin;
 use std::mem::PinMut;
 use std::vec::Vec;
 
-use {Poll, Future, task};
+use crate::{Poll, Future, task};
 
-use io::AsyncRead;
+use crate::io::AsyncRead;
 
 /// A future which can be used to easily read the entire contents of a stream
 /// into a vector.

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::mem::PinMut;
 
-use {Poll, task};
-use lock::BiLock;
+use crate::{Poll, task};
+use crate::lock::BiLock;
 
 use futures_io::{AsyncRead, AsyncWrite, IoVec};
 

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::marker::Unpin;
 use std::mem::{self, PinMut};
 
-use {Poll, Future, task};
+use crate::{Poll, Future, task};
 
 use futures_io::AsyncWrite;
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -2,9 +2,13 @@
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
 #![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(rust_2018_preview)]
 
 #![no_std]
+
 #![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
 #![doc(html_root_url = "https://docs.rs/futures/0.1")]
 
 #[cfg(test)]
@@ -60,18 +64,18 @@ pub mod lock;
 mod lock;
 
 pub mod future;
-pub use future::FutureExt;
+pub use crate::future::FutureExt;
 
 pub mod try_future;
-pub use try_future::TryFutureExt;
+pub use crate::try_future::TryFutureExt;
 
 #[cfg(feature = "std")]
 pub mod io;
 #[cfg(feature = "std")]
-pub use io::{AsyncReadExt, AsyncWriteExt};
+pub use crate::io::{AsyncReadExt, AsyncWriteExt};
 
 pub mod stream;
-pub use stream::StreamExt;
+pub use crate::stream::StreamExt;
 
 pub mod sink;
-pub use sink::SinkExt;
+pub use crate::sink::SinkExt;

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -1,7 +1,7 @@
 use futures_core::{Stream, Poll};
 use futures_core::task;
 use futures_sink::{Sink};
-use sink::{SinkExt, SinkMapErr};
+use crate::sink::{SinkExt, SinkMapErr};
 
 use std::mem::PinMut;
 

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -2,7 +2,7 @@ use futures_core::{Poll, Future, Stream};
 use futures_core::task;
 use futures_sink::{Sink};
 
-use stream::{StreamExt, Fuse};
+use crate::stream::{StreamExt, Fuse};
 
 use core::marker::Unpin;
 use core::mem::PinMut;

--- a/futures-util/src/stream/catch_unwind.rs
+++ b/futures-util/src/stream/catch_unwind.rs
@@ -30,7 +30,7 @@ impl<S: Stream> CatchUnwind<S> {
 impl<S> Stream for CatchUnwind<S>
     where S: Stream + UnwindSafe,
 {
-    type Item = Result<S::Item, Box<Any + Send>>;
+    type Item = Result<S::Item, Box<dyn Any + Send>>;
 
     fn poll_next(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
         if *self.caught_unwind() {

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -5,7 +5,7 @@ use std::prelude::v1::*;
 use futures_core::{Poll, Stream};
 use futures_core::task;
 
-use stream::Fuse;
+use crate::stream::Fuse;
 
 /// An adaptor that chunks up elements in a vector.
 ///

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -4,7 +4,7 @@ use core::mem::PinMut;
 use futures_core::{task, Future, Poll, Stream};
 use futures_sink::Sink;
 
-use stream::{StreamExt, Fuse};
+use crate::stream::{StreamExt, Fuse};
 
 const INVALID_POLL: &str = "polled `Forward` after completion";
 

--- a/futures-util/src/stream/futures_unordered/node.rs
+++ b/futures-util/src/stream/futures_unordered/node.rs
@@ -62,7 +62,7 @@ impl<T> Node<T> {
     // Saftey: The returned `NonNull<Unsafe>` needs to be put into a `Waker`
     // or `LocalWaker`
     unsafe fn clone_as_unsafe_wake_without_lifetime(self: &Arc<Node<T>>)
-        -> NonNull<UnsafeWake>
+        -> NonNull<dyn UnsafeWake>
     {
         let clone = self.clone();
 
@@ -70,12 +70,12 @@ impl<T> Node<T> {
         // a single field that is a pointer.
         let ptr = mem::transmute::<Arc<Node<T>>, NonNull<ArcNode<T>>>(clone);
 
-        let ptr = ptr as NonNull<UnsafeWake>;
+        let ptr = ptr as NonNull<dyn UnsafeWake>;
 
         // Hide lifetime of `T`
         // Safety: This is safe because `UnsafeWake` is guaranteed not to
         // touch `T`
-        mem::transmute::<NonNull<UnsafeWake>, NonNull<UnsafeWake>>(ptr)
+        mem::transmute::<NonNull<dyn UnsafeWake>, NonNull<dyn UnsafeWake>>(ptr)
     }
 
     pub(super) fn local_waker(self: &Arc<Node<T>>) -> LocalWaker {

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -4,7 +4,7 @@ use core::marker::Unpin;
 use futures_core::{Poll, Stream};
 use futures_core::task;
 
-use stream::{StreamExt, Fuse};
+use crate::stream::{StreamExt, Fuse};
 
 /// A `Stream` that implements a `peek` method.
 ///

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -3,7 +3,7 @@ use core::mem::PinMut;
 use futures_core::{Poll, Stream};
 use futures_core::task;
 
-use stream::{StreamExt, Fuse};
+use crate::stream::{StreamExt, Fuse};
 
 /// An adapter for merging the output of two streams.
 ///

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -7,7 +7,7 @@ use std::mem::PinMut;
 use futures_core::{task, Stream, Poll};
 use futures_sink::Sink;
 
-use lock::BiLock;
+use crate::lock::BiLock;
 
 /// A `Stream` part of the split pair
 #[must_use = "streams do nothing unless polled"]

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -4,7 +4,7 @@ use core::marker::Unpin;
 use futures_core::{Poll, Stream};
 use futures_core::task;
 
-use stream::{StreamExt, Fuse};
+use crate::stream::{StreamExt, Fuse};
 
 /// An adapter for merging the output of two streams.
 ///

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,8 +1,11 @@
+cargo-features = ["edition"]
+
 [package]
 name = "futures"
 version = "0.3.0-alpha"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
+edition = '2018'
 readme = "README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang-nursery/futures-rs"

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -20,8 +20,13 @@
 //! completion, but *do not block* the thread running them.
 
 #![feature(futures_api)]
+#![feature(rust_2018_preview)]
 
 #![no_std]
+
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(bare_trait_objects)]
+
 #![doc(html_root_url = "https://docs.rs/futures/0.2.0")]
 
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -35,9 +35,6 @@ extern crate futures_io;
 extern crate futures_sink;
 extern crate futures_util;
 
-#[cfg(feature = "nightly")] extern crate futures_macro_async;
-#[cfg(feature = "nightly")] extern crate futures_macro_await;
-
 pub use futures_core::future::Future;
 pub use futures_util::future::FutureExt;
 pub use futures_core::stream::Stream;
@@ -253,15 +250,6 @@ pub mod prelude {
         Future, TryFuture, Stream, Poll, task
     };
 
-    #[cfg(feature = "nightly")]
-    pub use futures_stable::{
-        StableFuture,
-        StableStream
-    };
-
-    #[cfg(all(feature = "nightly", feature = "std"))]
-    pub use futures_stable::StableExecutor;
-
     pub use futures_sink::Sink;
 
     #[cfg(feature = "std")]
@@ -281,21 +269,6 @@ pub mod prelude {
     pub use futures_util::{
         AsyncReadExt,
         AsyncWriteExt,
-    };
-
-    #[cfg(feature = "nightly")]
-    pub use futures_macro_async::{
-        async,
-        async_stream,
-        async_block,
-        async_stream_block,
-    };
-
-    #[cfg(feature = "nightly")]
-    pub use futures_macro_await::{
-        await,
-        stream_yield,
-        await_item
     };
 }
 
@@ -388,20 +361,4 @@ pub mod task {
 
     #[cfg(feature = "std")]
     pub use futures_core::task::Wake;
-}
-
-#[cfg(feature = "nightly")]
-pub mod stable {
-    pub use futures_stable::{StableFuture, StableStream};
-
-    #[cfg(feature = "std")]
-    pub use futures_stable::{StableExecutor, block_on_stable};
-}
-
-#[cfg(feature = "nightly")]
-#[doc(hidden)]
-pub mod __rt {
-    #[cfg(feature = "std")]
-    pub extern crate std;
-    pub use futures_async_runtime::*;
 }

--- a/futures/testcrate/Cargo.toml
+++ b/futures/testcrate/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["edition"]
+
 [package]
 name = "testcrate"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Since we're on nightly already, we might as well use Rust 2018. This gives Rust 2018 some usage and it costs us nothing because futures wont stabilize before Rust 2018.

I especially like `dyn Trait`. It makes it much clearer where trait objects are used.

This PR includes https://github.com/rust-lang-nursery/futures-rs/pull/1053