### PR TITLE
0.2: Fix compilation when "nightly" feature is enabled

### DIFF
--- a/futures-async-runtime/src/future.rs
+++ b/futures-async-runtime/src/future.rs
@@ -28,7 +28,7 @@ impl<T> StableFuture for GenStableFuture<T>
     fn poll(self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
         CTX.with(|cell| {
             let _r = Reset::new(ctx, cell);
-            let this: &mut Self = unsafe { PinMut::get_mut(self) };
+            let this: &mut Self = unsafe { PinMut::get_mut_unchecked(self) };
             // This is an immovable generator, but since we're only accessing
             // it via a PinMut this is safe.
             match unsafe { this.0.resume() } {

--- a/futures-async-runtime/src/stream.rs
+++ b/futures-async-runtime/src/stream.rs
@@ -40,7 +40,7 @@ impl<U, T> StableStream for GenStableStream<U, T>
     fn poll_next(self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
         CTX.with(|cell| {
             let _r = Reset::new(ctx, cell);
-            let this: &mut Self = unsafe { PinMut::get_mut(self) };
+            let this: &mut Self = unsafe { PinMut::get_mut_unchecked(self) };
             if this.done { return Ok(Async::Ready(None)) }
             // This is an immovable generator, but since we're only accessing
             // it via a PinMut this is safe.

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -147,7 +147,7 @@ if_std! {
         type Error = F::Error;
 
         fn poll(&mut self, cx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
-            unsafe { ::core::mem::PinMut::get_mut(self.as_pin_mut()).poll(cx) }
+            unsafe { ::core::mem::PinMut::get_mut_unchecked(self.as_pin_mut()).poll(cx) }
         }
     }
 

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -89,7 +89,7 @@ if_std! {
         type Error = S::Error;
 
         fn poll_next(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
-            unsafe { ::core::mem::PinMut::get_mut(self.as_pin_mut()).poll_next(cx) }
+            unsafe { ::core::mem::PinMut::get_mut_unchecked(self.as_pin_mut()).poll_next(cx) }
         }
     }
 

--- a/futures-stable/src/lib.rs
+++ b/futures-stable/src/lib.rs
@@ -86,7 +86,7 @@ if_nightly! {
         type Error = F::Error;
 
         fn poll(self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Self::Item, Self::Error> {
-            F::poll(unsafe { PinMut::get_mut(self) }, ctx)
+            F::poll(unsafe { PinMut::get_mut_unchecked(self) }, ctx)
         }
     }
 
@@ -140,7 +140,7 @@ if_nightly! {
         type Error = S::Error;
 
         fn poll_next(self: PinMut<Self>, ctx: &mut task::Context) -> Poll<Option<Self::Item>, Self::Error> {
-            S::poll_next(unsafe { PinMut::get_mut(self) }, ctx)
+            S::poll_next(unsafe { PinMut::get_mut_unchecked(self) }, ctx)
         }
     }
 }

--- a/futures/tests/async_await/pinned.rs
+++ b/futures/tests/async_await/pinned.rs
@@ -1,6 +1,7 @@
 use futures::stable::block_on_stable;
 use futures::executor::{block_on, ThreadPool};
 use futures::prelude::*;
+use futures::prelude::await;
 
 #[async]
 fn foo() -> Result<i32, i32> {

--- a/futures/tests/async_await/smoke.rs
+++ b/futures/tests/async_await/smoke.rs
@@ -12,6 +12,7 @@ use std::io;
 use futures::Never;
 use futures::future::poll_fn;
 use futures::prelude::*;
+use futures::prelude::await;
 
 #[async]
 fn foo() -> Result<i32, i32> {


### PR DESCRIPTION
Some of the crates are not compiling with the latest nightly compiler when "nightly" feature is enabled (because of https://github.com/rust-lang/rust/pull/51730).
Please release a new version of the "futures-core-preview", "futures-stable-preview" and "futures-async-runtime-preview" after merging this.