### PR TITLE
shared: fix unsound Send and Sync impl for Shared

### DIFF
--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -235,8 +235,20 @@ impl Notify for Notifier {
     }
 }
 
-unsafe impl<F: Future> Sync for Inner<F> {}
-unsafe impl<F: Future> Send for Inner<F> {}
+// The `F` is synchronized by a lock, so `F` doesn't need
+// to be `Sync`. However, its `Item` or `Error` are exposed
+// through an `Arc` but not lock, so they must be `Send + Sync`.
+unsafe impl<F> Send for Inner<F>
+    where F: Future + Send,
+          F::Item: Send + Sync,
+          F::Error: Send + Sync,
+{}
+
+unsafe impl<F> Sync for Inner<F>
+    where F: Future + Send,
+          F::Item: Send + Sync,
+          F::Error: Send + Sync,
+{}
 
 impl<F> fmt::Debug for Inner<F>
     where F: Future + fmt::Debug,


### PR DESCRIPTION
The `Future::shared` combinator wrongly allowed both `!Send` futures, and futures with `!Send + !Sync` items or errors, to be sent across threads. Here's an example that compiles with 0.1.21, allowing the sending and cloning of an `Rc` across threads: https://gist.github.com/rust-play/1b25c790a21d34e653a8cbf3e528ae08