### PR TITLE
Support non-atomic targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,10 @@ matrix:
         - cargo build --manifest-path futures-executor/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features
-    # - rust: nightly
-    #   script:
-    #     - rustup component add rust-src
-    #     - cargo install xargo
-    #     - xargo build --manifest-path futures/Cargo.toml --target thumbv6m-none-eabi --no-default-features
+    - rust: nightly
+      script:
+        - rustup target add thumbv6m-none-eabi
+        - cargo build --manifest-path futures/Cargo.toml --target thumbv6m-none-eabi --no-default-features --features nightly
     # - rust: 1.20.0
     #   script: cargo test --all
     # - rust: nightly

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -9,8 +9,6 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-core/0.3.0-alpha")]
 
-#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
-
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -2,6 +2,7 @@
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
 #![feature(async_await, await_macro, pin, arbitrary_self_types, futures_api)]
+#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs, missing_debug_implementations, warnings)]

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -3,7 +3,13 @@
 mod context;
 pub use self::context::ContextExt;
 
-#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
+#[cfg_attr(
+    feature = "nightly",
+    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
+)]
 mod atomic_waker;
-#[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
+#[cfg_attr(
+    feature = "nightly",
+    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
+)]
 pub use self::atomic_waker::AtomicWaker;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -339,7 +339,10 @@ pub mod task {
 
     pub use futures_util::task::ContextExt;
 
-    #[cfg_attr(feature = "nightly", cfg(target_has_atomic = "ptr"))]
+    #[cfg_attr(
+        feature = "nightly",
+        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
+    )]
     pub use futures_util::task::AtomicWaker;
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
As of https://github.com/rust-lang/rust/pull/51953 `cfg(target_has_atomic)` has been updated to separately enable compare-and-swap (CAS) operations from the different supported sizes. Because `AtomicWaker` uses these CAS operations we need to also gate its inclusion on `cfg(target_has_atomic = "cas")`. `thumv6m` is one of the architectures that supports atomic read-write operations on its pointer sized integers, but doesn't support CAS operations.