### PR TITLE
Allow ownership of the output of Shared to be reclaimed

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -578,10 +578,6 @@ pub trait FutureExt: Future {
     /// The shared() method provides a method to convert any future into a
     /// cloneable future. It enables a future to be polled by multiple threads.
     ///
-    /// The returned `Shared` future resolves with `Arc<Self::Output>`,
-    /// which implements `Deref` to allow shared access to the underlying
-    /// result. Ownership of the underlying value cannot currently be reclaimed.
-    ///
     /// This method is only available when the `std` feature of this
     /// library is activated, and it is activated by default.
     ///
@@ -596,8 +592,8 @@ pub trait FutureExt: Future {
     /// let shared1 = future.shared();
     /// let shared2 = shared1.clone();
     ///
-    /// assert_eq!(6, *await!(shared1));
-    /// assert_eq!(6, *await!(shared2));
+    /// assert_eq!(6, await!(shared1));
+    /// assert_eq!(6, await!(shared2));
     /// # });
     /// ```
     ///
@@ -614,14 +610,15 @@ pub trait FutureExt: Future {
     /// let shared1 = future.shared();
     /// let shared2 = shared1.clone();
     /// let join_handle = thread::spawn(move || {
-    ///     assert_eq!(6, *block_on(shared2));
+    ///     assert_eq!(6, block_on(shared2));
     /// });
-    /// assert_eq!(6, *block_on(shared1));
+    /// assert_eq!(6, block_on(shared1));
     /// join_handle.join().unwrap();
     /// ```
     #[cfg(feature = "std")]
     fn shared(self) -> Shared<Self>
-        where Self: Sized
+    where
+        Self: Sized,
     {
         Shared::new(self)
     }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -50,7 +50,7 @@ impl<Fut: Future> fmt::Debug for Inner<Fut> {
 
 enum FutureOrOutput<Fut: Future> {
     Future(Fut),
-    Output(Arc<Fut::Output>),
+    Output(Fut::Output),
 }
 
 unsafe impl<Fut> Send for Inner<Fut>
@@ -88,15 +88,17 @@ impl<Fut: Future> Shared<Fut> {
     }
 }
 
-impl<Fut> Shared<Fut> where Fut: Future {
+impl<Fut> Shared<Fut>
+where
+    Fut: Future,
+    Fut::Output: Clone,
+{
     /// If any clone of this `Shared` has completed execution, returns its result immediately
     /// without blocking. Otherwise, returns None without triggering the work represented by
     /// this `Shared`.
-    pub fn peek(&self) -> Option<Arc<Fut::Output>> {
+    pub fn peek(&self) -> Option<Fut::Output> {
         match self.inner.notifier.state.load(SeqCst) {
-            COMPLETE => {
-                Some(unsafe { self.clone_output() })
-            }
+            COMPLETE => Some(unsafe { self.clone_output() }),
             POISONED => panic!("inner future panicked during poll"),
             _ => None,
         }
@@ -133,7 +135,7 @@ impl<Fut> Shared<Fut> where Fut: Future {
 
     /// Safety: callers must first ensure that `self.inner.state`
     /// is `COMPLETE`
-    unsafe fn clone_output(&self) -> Arc<Fut::Output> {
+    unsafe fn clone_output(&self) -> Fut::Output {
         if let FutureOrOutput::Output(item) = &*self.inner.future_or_output.get() {
             item.clone()
         } else {
@@ -142,8 +144,11 @@ impl<Fut> Shared<Fut> where Fut: Future {
     }
 }
 
-impl<Fut: Future> Future for Shared<Fut> {
-    type Output = Arc<Fut::Output>;
+impl<Fut: Future> Future for Shared<Fut>
+where
+    Fut::Output: Clone,
+{
+    type Output = Fut::Output;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let this = &mut *self;
@@ -210,7 +215,6 @@ impl<Fut: Future> Future for Shared<Fut> {
                     }
                 }
                 Poll::Ready(output) => {
-                    let output = Arc::new(output);
                     unsafe {
                         *this.inner.future_or_output.get() =
                             FutureOrOutput::Output(output.clone());
@@ -232,7 +236,10 @@ impl<Fut: Future> Future for Shared<Fut> {
     }
 }
 
-impl<Fut> Clone for Shared<Fut> where Fut: Future {
+impl<Fut> Clone for Shared<Fut>
+where
+    Fut: Future,
+{
     fn clone(&self) -> Self {
         Shared {
             inner: self.inner.clone(),
@@ -241,7 +248,10 @@ impl<Fut> Clone for Shared<Fut> where Fut: Future {
     }
 }
 
-impl<Fut> Drop for Shared<Fut> where Fut: Future {
+impl<Fut> Drop for Shared<Fut>
+where
+    Fut: Future,
+{
     fn drop(&mut self) {
         if self.waker_key != NULL_WAKER_KEY {
             if let Ok(mut wakers) = self.inner.notifier.wakers.lock() {

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -82,7 +82,7 @@ fn drop_in_poll() {
     let future2 = LocalFutureObj::new(Box::new(future1.clone()));
     slot1.replace(Some(future2));
 
-    assert_eq!(*block_on(future1), 1);
+    assert_eq!(block_on(future1), 1);
 }
 
 #[test]
@@ -111,6 +111,6 @@ fn peek() {
     spawn.spawn_local_obj(LocalFutureObj::new(Box::new(f1.map(|_| ())))).unwrap();
     local_pool.run(spawn);
     for _ in 0..2 {
-        assert_eq!(*f2.peek().unwrap(), Ok(42));
+        assert_eq!(f2.peek().unwrap(), Ok(42));
     }
 }


### PR DESCRIPTION
This implements the ideas in #1091. Namely that `Shared` now returns the value as is, without wrapping in `Arc` (first commit) and that the `Shared` instance now gets invalidated if, when it is polled, it is the last instance left which allows `Shared` to avoid cloning the output if only one instance of it remains.

I'd like to document this behavior but I have so far struggled to come up with succinct wording. So instead I figured I'd post a PR to see if it is desirable in the first place 

Closes #1091