### PR TITLE
Associated types of TryStream and TryFuture

### DIFF
--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -9,7 +9,7 @@ pub use core::future::{Future, FutureObj, LocalFutureObj, UnsafeFutureObj};
 /// a variety of adapters tailored to such futures.
 pub trait TryFuture {
     /// The type of successful values yielded by this future
-    type Item;
+    type Ok;
 
     /// The type of failures yielded by this future
     type Error;
@@ -22,13 +22,13 @@ pub trait TryFuture {
     fn try_poll(
         self: PinMut<Self>,
         cx: &mut task::Context,
-    ) -> Poll<Result<Self::Item, Self::Error>>;
+    ) -> Poll<Result<Self::Ok, Self::Error>>;
 }
 
 impl<F, T, E> TryFuture for F
     where F: Future<Output = Result<T, E>>
 {
-    type Item = T;
+    type Ok = T;
     type Error = E;
 
     #[inline]

--- a/futures-core/src/stream.rs
+++ b/futures-core/src/stream.rs
@@ -52,13 +52,6 @@ pub trait Stream {
         self: PinMut<Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>>;
-
-    /// A convenience for calling `Stream::poll_next` on `Unpin` stream types.
-    fn poll_next_unpin(&mut self, cx: &mut task::Context) -> Poll<Option<Self::Item>>
-        where Self: Unpin + Sized
-    {
-        PinMut::new(self).poll_next(cx)
-    }
 }
 
 impl<'a, S: ?Sized + Stream + Unpin> Stream for &'a mut S {

--- a/futures-core/src/stream.rs
+++ b/futures-core/src/stream.rs
@@ -97,10 +97,10 @@ impl<A, B> Stream for Either<A, B>
 /// a variety of adapters tailored to such futures.
 pub trait TryStream {
     /// The type of successful values yielded by this future
-    type TryItem;
+    type Ok;
 
     /// The type of failures yielded by this future
-    type TryError;
+    type Error;
 
     /// Poll this `TryStream` as if it were a `Stream`.
     ///
@@ -108,17 +108,17 @@ pub trait TryStream {
     /// directly inheriting from the `Stream` trait; in the future it won't be
     /// needed.
     fn try_poll_next(self: PinMut<Self>, cx: &mut task::Context)
-        -> Poll<Option<Result<Self::TryItem, Self::TryError>>>;
+        -> Poll<Option<Result<Self::Ok, Self::Error>>>;
 }
 
 impl<S, T, E> TryStream for S
     where S: Stream<Item = Result<T, E>>
 {
-    type TryItem = T;
-    type TryError = E;
+    type Ok = T;
+    type Error = E;
 
     fn try_poll_next(self: PinMut<Self>, cx: &mut task::Context)
-        -> Poll<Option<Result<Self::TryItem, Self::TryError>>>
+        -> Poll<Option<Result<Self::Ok, Self::Error>>>
     {
         self.poll_next(cx)
     }

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -4,9 +4,11 @@
 //! including the `StreamExt` trait which adds methods to `Stream` types.
 
 use core::marker::Unpin;
+use core::mem::PinMut;
 use either::Either;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
+use futures_core::task::{self, Poll};
 use futures_sink::Sink;
 
 mod iter;
@@ -920,5 +922,16 @@ pub trait StreamExt: Stream {
               Self: Sized
     {
         Either::Right(self)
+    }
+
+    /// A convenience for calling [`Stream::poll_next`] on [`Unpin`] stream
+    /// types.
+    fn poll_next_unpin(
+        &mut self,
+        cx: &mut task::Context
+    ) -> Poll<Option<Self::Item>>
+    where Self: Unpin + Sized
+    {
+        PinMut::new(self).poll_next(cx)
     }
 }

--- a/futures-util/src/try_future/and_then.rs
+++ b/futures-util/src/try_future/and_then.rs
@@ -30,14 +30,14 @@ impl<Fut1, Fut2, F> AndThen<Fut1, Fut2, F>
 impl<Fut1, Fut2, F> Future for AndThen<Fut1, Fut2, F>
     where Fut1: TryFuture,
           Fut2: TryFuture<Error = Fut1::Error>,
-          F: FnOnce(Fut1::Item) -> Fut2,
+          F: FnOnce(Fut1::Ok) -> Fut2,
 {
-    type Output = Result<Fut2::Item, Fut2::Error>;
+    type Output = Result<Fut2::Ok, Fut2::Error>;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.try_chain().poll(cx, |result, async_op| {
             match result {
-                Ok(item) => TryChainAction::Future(async_op(item)),
+                Ok(ok) => TryChainAction::Future(async_op(ok)),
                 Err(err) => TryChainAction::Output(Err(err)),
             }
         })

--- a/futures-util/src/try_future/err_into.rs
+++ b/futures-util/src/try_future/err_into.rs
@@ -28,13 +28,13 @@ impl<A, E> Future for ErrInto<A, E>
     where A: TryFuture,
           A::Error: Into<E>,
 {
-    type Output = Result<A::Item, E>;
+    type Output = Result<A::Ok, E>;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         match self.future().try_poll(cx) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(e) => {
-                Poll::Ready(e.map_err(Into::into))
+            Poll::Ready(output) => {
+                Poll::Ready(output.map_err(Into::into))
             }
         }
     }

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -37,7 +37,7 @@ impl<F, S> FlattenSink<F, S> {
 
 impl<F, S> Sink for FlattenSink<F, S>
 where
-    F: TryFuture<Item = S>,
+    F: TryFuture<Ok = S>,
     S: Sink<SinkError = F::Error>,
 {
     type SinkItem = S::SinkItem;
@@ -96,7 +96,7 @@ where
 
 pub fn new<F, S>(fut: F) -> FlattenSink<F, S>
 where
-    F: TryFuture<Item = S>,
+    F: TryFuture<Ok = S>,
     S: Sink<SinkError = F::Error>,
 {
     FlattenSink(Waiting(fut))

--- a/futures-util/src/try_future/into_future.rs
+++ b/futures-util/src/try_future/into_future.rs
@@ -19,7 +19,7 @@ impl<Fut> IntoFuture<Fut> {
 }
 
 impl<Fut: TryFuture> Future for IntoFuture<Fut> {
-    type Output = Result<Fut::Item, Fut::Error>;
+    type Output = Result<Fut::Ok, Fut::Error>;
 
     #[inline]
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -29,7 +29,7 @@ impl<Fut, F, E> Future for MapErr<Fut, F>
     where Fut: TryFuture,
           F: FnOnce(Fut::Error) -> E,
 {
-    type Output = Result<Fut::Item, E>;
+    type Output = Result<Fut::Ok, E>;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         match self.future().try_poll(cx) {

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -27,7 +27,7 @@ impl<Fut: Unpin, F> Unpin for MapOk<Fut, F> {}
 
 impl<Fut, F, T> Future for MapOk<Fut, F>
     where Fut: TryFuture,
-          F: FnOnce(Fut::Item) -> T,
+          F: FnOnce(Fut::Ok) -> T,
 {
     type Output = Result<T, Fut::Error>;
 

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -64,9 +64,9 @@ pub trait TryFutureExt: TryFuture {
     ///
     /// Note that this function consumes this future and returns a wrapped
     /// version of it.
-    fn flatten_sink(self) -> FlattenSink<Self, Self::Item>
+    fn flatten_sink(self) -> FlattenSink<Self, Self::Ok>
     where
-        Self::Item: Sink<SinkError=Self::Error>,
+        Self::Ok: Sink<SinkError=Self::Error>,
         Self: Sized,
     {
         flatten_sink::new(self)
@@ -113,7 +113,7 @@ pub trait TryFutureExt: TryFuture {
     /// assert_eq!(block_on(new_future), Err(1));
     /// ```
     fn map_ok<T, F>(self, op: F) -> MapOk<Self, F>
-        where F: FnOnce(Self::Item) -> T,
+        where F: FnOnce(Self::Ok) -> T,
               Self: Sized,
     {
         MapOk::new(self, op)
@@ -228,7 +228,7 @@ pub trait TryFutureExt: TryFuture {
     /// });
     /// ```
     fn and_then<Fut, F>(self, async_op: F) -> AndThen<Self, Fut, F>
-        where F: FnOnce(Self::Item) -> Fut,
+        where F: FnOnce(Self::Ok) -> Fut,
               Fut: TryFuture<Error = Self::Error>,
               Self: Sized,
     {
@@ -271,7 +271,7 @@ pub trait TryFutureExt: TryFuture {
     /// ```
     fn or_else<Fut, F>(self, async_op: F) -> OrElse<Self, Fut, F>
         where F: FnOnce(Self::Error) -> Fut,
-              Fut: TryFuture<Item = Self::Item>,
+              Fut: TryFuture<Ok = Self::Ok>,
               Self: Sized,
     {
         OrElse::new(self, async_op)
@@ -429,7 +429,7 @@ pub trait TryFutureExt: TryFuture {
     /// ```
     fn unwrap_or_else<F>(self, op: F) -> UnwrapOrElse<Self, F>
         where Self: Sized,
-              F: FnOnce(Self::Error) -> Self::Item
+              F: FnOnce(Self::Error) -> Self::Ok
     {
         UnwrapOrElse::new(self, op)
     }

--- a/futures-util/src/try_future/or_else.rs
+++ b/futures-util/src/try_future/or_else.rs
@@ -29,15 +29,15 @@ impl<Fut1, Fut2, F> OrElse<Fut1, Fut2, F>
 
 impl<Fut1, Fut2, F> Future for OrElse<Fut1, Fut2, F>
     where Fut1: TryFuture,
-          Fut2: TryFuture<Item = Fut1::Item>,
+          Fut2: TryFuture<Ok = Fut1::Ok>,
           F: FnOnce(Fut1::Error) -> Fut2,
 {
-    type Output = Result<Fut2::Item, Fut2::Error>;
+    type Output = Result<Fut2::Ok, Fut2::Error>;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.try_chain().poll(cx, |result, async_op| {
             match result {
-                Ok(item) => TryChainAction::Output(Ok(item)),
+                Ok(ok) => TryChainAction::Output(Ok(ok)),
                 Err(err) => TryChainAction::Future(async_op(err)),
             }
         })

--- a/futures-util/src/try_future/try_chain.rs
+++ b/futures-util/src/try_future/try_chain.rs
@@ -14,7 +14,7 @@ crate enum TryChainAction<Fut2>
     where Fut2: TryFuture,
 {
     Future(Fut2),
-    Output(Result<Fut2::Item, Fut2::Error>),
+    Output(Result<Fut2::Ok, Fut2::Error>),
 }
 
 impl<Fut1, Fut2, Data> TryChain<Fut1, Fut2, Data>
@@ -29,8 +29,8 @@ impl<Fut1, Fut2, Data> TryChain<Fut1, Fut2, Data>
         self: PinMut<Self>,
         cx: &mut task::Context,
         op: F,
-    ) -> Poll<Result<Fut2::Item, Fut2::Error>>
-        where F: FnOnce(Result<Fut1::Item, Fut1::Error>, Data) -> TryChainAction<Fut2>,
+    ) -> Poll<Result<Fut2::Ok, Fut2::Error>>
+        where F: FnOnce(Result<Fut1::Ok, Fut1::Error>, Data) -> TryChainAction<Fut2>,
     {
         let mut op = Some(op);
 

--- a/futures-util/src/try_future/unwrap_or_else.rs
+++ b/futures-util/src/try_future/unwrap_or_else.rs
@@ -27,9 +27,9 @@ impl<Fut: Unpin, F> Unpin for UnwrapOrElse<Fut, F> {}
 
 impl<Fut, F> Future for UnwrapOrElse<Fut, F>
     where Fut: TryFuture,
-          F: FnOnce(Fut::Error) -> Fut::Item,
+          F: FnOnce(Fut::Error) -> Fut::Ok,
 {
-    type Output = Fut::Item;
+    type Output = Fut::Ok;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         match self.future().try_poll(cx) {

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -50,7 +50,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(output, Err(6));
     /// ```
     #[cfg(feature = "std")]
-    fn try_collect<C: Default + Extend<Self::TryItem>>(self) -> TryCollect<Self, C>
+    fn try_collect<C: Default + Extend<Self::Ok>>(self) -> TryCollect<Self, C>
         where Self: Sized
     {
         try_collect::new(self)

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -36,11 +36,14 @@ impl<S: TryStream, C: Default> TryCollect<S, C> {
 impl<S: Unpin + TryStream, C> Unpin for TryCollect<S, C> {}
 
 impl<S, C> Future for TryCollect<S, C>
-    where S: TryStream, C: Default + Extend<S::TryItem>
+    where S: TryStream, C: Default + Extend<S::Ok>
 {
-    type Output = Result<C, S::TryError>;
+    type Output = Result<C, S::Error>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(
+        mut self: PinMut<Self>,
+        cx: &mut task::Context
+    ) -> Poll<Self::Output> {
         loop {
             match ready!(self.stream().try_poll_next(cx)) {
                 Some(Ok(x)) => self.items().extend(Some(x)),


### PR DESCRIPTION
Implements https://github.com/rust-lang-nursery/futures-rs/issues/1090

To minimize churn I recommend merging this before the release of the alpha. I think users will appreciate the similarity to the `Result` type and `Try` trait. Consistency with the standard library is great.