### PR TITLE
Fix crate name in import

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ futures-preview = "0.3.0-alpha"
 Next, add this to your crate:
 
 ```rust
-extern crate futures-preview as futures;
+extern crate futures_preview as futures;
 
 use futures::Future;
 ```


### PR DESCRIPTION
If you don't override the lib name then Cargo will automatically convert the `-` in the package name to an `_` for the lib.