### PR TITLE
Implement AsyncWrite for the generic Cursor<T: AsMut<[u8]>>

### DIFF
--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -24,5 +24,6 @@ default = ["std"]
 futures-core-preview = { path = "../futures-core", version = "0.3.0-alpha.1", default-features = false }
 iovec = { version = "0.1", optional = true }
 
-# [dev-dependencies]
-# futures = { path = "../futures", version = "0.2.0" }
+[dev-dependencies]
+futures-preview = { path = "../futures", version = "0.3.0-alpha.1" }
+assert_matches = "1.3.0"

--- a/futures-io/tests/cursor.rs
+++ b/futures-io/tests/cursor.rs
@@ -1,0 +1,19 @@
+#![feature(use_extern_macros, futures_api)]
+
+use assert_matches::assert_matches;
+use futures::Poll;
+use futures::future::lazy;
+use futures::io::AsyncWrite;
+use std::io::Cursor;
+
+#[test]
+fn cursor_asyncwrite_asmut() {
+    let mut cursor = Cursor::new([0; 5]);
+    futures::executor::block_on(lazy(|ctx| {
+        assert_matches!(cursor.poll_write(ctx, &[1, 2]), Poll::Ready(Ok(2)));
+        assert_matches!(cursor.poll_write(ctx, &[3, 4]), Poll::Ready(Ok(2)));
+        assert_matches!(cursor.poll_write(ctx, &[5, 6]), Poll::Ready(Ok(1)));
+        assert_matches!(cursor.poll_write(ctx, &[6, 7]), Poll::Ready(Ok(0)));
+    }));
+    assert_eq!(cursor.into_inner(), [1, 2, 3, 4, 5]);
+}


### PR DESCRIPTION
This introduces an unfortunate point of difference between `futures::io::AsyncWrite` and `std::io::Write`, but I think the increased ergonomics around writing to statically sized in memory buffers (presumably just for test purposes) is useful.

`impl<T: AsRef<[u8]>> Read for Cursor<T>` was added in rust-lang/rust#27197, I'm not sure why `impl<T: AsMut<[u8]>> Write for Cursor<T>` wasn't added at the same time; I would propose doing this change in `std` and just piggybacking off it here, but the breakage is almost certainly not worth it by this point.

(This PR is based off #1108 in order to have some "real" code changes to evaluate the ergonomics on)