### PR TITLE
Add names to the CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: rust
 rust:
-    - nightly
+  - nightly
 sudo: false
 
 matrix:
   include:
     - os: osx
-    - rust: nightly
+    - name: cargo bench
+      rust: nightly
       script: cargo bench --all && cd futures-util && cargo bench --features=bench
-    - rust: nightly
+    - name: cargo build --no-default-features
+      rust: nightly
       script:
         - cargo build --manifest-path futures/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-channel/Cargo.toml --no-default-features
@@ -16,11 +18,13 @@ matrix:
         - cargo build --manifest-path futures-executor/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features
-    - rust: nightly
+    - name: cargo build --target=thumbv6m-none-eabi
+      rust: nightly
       script:
         - rustup target add thumbv6m-none-eabi
         - cargo build --manifest-path futures/Cargo.toml --target thumbv6m-none-eabi --no-default-features --features nightly
-    - rust: nightly
+    - name: cargo doc
+      rust: nightly
       script:
         - cargo doc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ sudo: false
 matrix:
   include:
     - os: osx
+    - os: linux
     - name: cargo bench
       rust: nightly
       script: cargo bench --all && cd futures-util && cargo bench --features=bench


### PR DESCRIPTION
Travis.CI shows environment variables in the build jobs list to allow easily identifying which job is which.