### PR TITLE
Only deny warnings in CI to improve dev experience

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,49 @@ sudo: false
 
 matrix:
   include:
-    - os: osx
-    - os: linux
+    - name: cargo test
+      os: osx
+
+    - name: cargo test
+      os: linux
+
+    - name: cargo rustc -- -D warnings
+      rust: nightly
+      script:
+        - cargo rustc --manifest-path futures/Cargo.toml -- -Dwarnings
+        - cargo rustc --manifest-path futures-core/Cargo.toml -- -Dwarnings
+        - cargo rustc --manifest-path futures-channel/Cargo.toml -- -Dwarnings
+        - cargo rustc --manifest-path futures-executor/Cargo.toml -- -Dwarnings
+        - cargo rustc --manifest-path futures-io/Cargo.toml -- -Dwarnings
+        - cargo rustc --manifest-path futures-sink/Cargo.toml -- -Dwarnings
+        - cargo rustc --manifest-path futures-util/Cargo.toml -- -Dwarnings
+
     - name: cargo bench
       rust: nightly
-      script: cargo bench --all && cd futures-util && cargo bench --features=bench
+      script:
+        - cargo bench --all
+        - cargo bench -p futures-util-preview --features=bench
+
     - name: cargo build --no-default-features
       rust: nightly
       script:
         - cargo build --manifest-path futures/Cargo.toml --no-default-features
-        - cargo build --manifest-path futures-channel/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-core/Cargo.toml --no-default-features
+        - cargo build --manifest-path futures-channel/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-executor/Cargo.toml --no-default-features
+        - cargo build --manifest-path futures-io/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features
+
     - name: cargo build --target=thumbv6m-none-eabi
       rust: nightly
       script:
         - rustup target add thumbv6m-none-eabi
-        - cargo build --manifest-path futures/Cargo.toml --target thumbv6m-none-eabi --no-default-features --features nightly
+        - cargo build --manifest-path futures/Cargo.toml
+            --target thumbv6m-none-eabi
+            --no-default-features
+            --features nightly
+
     - name: cargo doc
       rust: nightly
       script:

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![no_std]
 
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://docs.rs/futures-channel-preview/0.3.0-alpha.1")]

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![no_std]
 
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://docs.rs/futures-core-preview/0.3.0-alpha.1")]

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://docs.rs/futures-executor-preview/0.3.0-alpha.1")]

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![no_std]
 
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://docs.rs/futures-io-preview/0.3.0-alpha.1")]

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -4,7 +4,7 @@
 //! asynchronously.
 
 #![no_std]
-#![deny(missing_docs, missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/futures-sink-preview/0.3.0-alpha.1")]
 
 #![feature(pin, arbitrary_self_types, futures_api)]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://docs.rs/futures-util-preview/0.3.0-alpha.1")]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -25,7 +25,7 @@
 
 #![no_std]
 
-#![deny(missing_docs, missing_debug_implementations)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://docs.rs/futures-preview/0.3.0-alpha.1")]


### PR DESCRIPTION
Having the build break because of missing docs when developing locally can get really annoying. I'm also trying to fixup clippy noted issues which trigger the current `deny(warnings)`. Instead it seems better to allow developers to temporarily have warnings while developing, but deny them in CI so that PRs are gated on the code being warning free.

I also tidied the CI config a little bit, a bit of extra whitespace around the jobs, split the benchmarks up to multiple separate commands and used a multiline string for the `thumbv6m` build (yaml will merge multiline indented strings into a single line).