### PR TITLE
100% Clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ matrix:
     - name: cargo test
       os: linux
 
-    - name: Deny warnings
+    - name: cargo clippy
       rust: nightly
+      install:
+        - rustup component add clippy-preview
       script:
-        - RUSTFLAGS=-Dwarnings cargo check
+        - cargo clippy --all -- -Dwarnings
 
     - name: cargo bench
       rust: nightly
@@ -35,8 +37,9 @@ matrix:
 
     - name: cargo build --target=thumbv6m-none-eabi
       rust: nightly
-      script:
+      install:
         - rustup target add thumbv6m-none-eabi
+      script:
         - cargo build --manifest-path futures/Cargo.toml
             --target thumbv6m-none-eabi
             --no-default-features

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -160,9 +160,9 @@ impl LocalPool {
                 let mut main_cx = Context::new(local_waker, exec);
 
                 // if our main task is done, so are we
-                match future.reborrow().poll(&mut main_cx) {
-                    Poll::Ready(output) => return Poll::Ready(output),
-                    _ => {}
+                let result = future.reborrow().poll(&mut main_cx);
+                if let Poll::Ready(output) = result {
+                    return Poll::Ready(output);
                 }
             }
 
@@ -202,6 +202,12 @@ impl LocalPool {
                 _ => {}
             }
         }
+    }
+}
+
+impl Default for LocalPool {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -43,7 +43,7 @@ impl<Fut> Abortable<Fut> where Fut: Future {
     /// ```
     pub fn new(future: Fut, reg: AbortRegistration) -> Self {
         Abortable {
-            future: future,
+            future,
             inner: reg.inner,
         }
     }
@@ -94,7 +94,7 @@ impl AbortHandle {
                 inner: inner.clone(),
             },
             AbortRegistration {
-                inner: inner,
+                inner,
             },
         )
     }

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -48,6 +48,7 @@ macro_rules! generate {
         impl<$($Fut: Future),*> Future for $Join<$($Fut),*> {
             type Output = ($($Fut::Output),*);
 
+            #[allow(useless_let_if_seq)]
             fn poll(
                 mut self: PinMut<Self>, cx: &mut task::Context
             ) -> Poll<Self::Output> {

--- a/futures-util/src/io/allow_std.rs
+++ b/futures-util/src/io/allow_std.rs
@@ -80,7 +80,8 @@ impl<T> AsyncWrite for AllowStdIo<T> where T: io::Write {
     }
 
     fn poll_flush(&mut self, _: &mut task::Context) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(try_with_interrupt!(io::Write::flush(self))))
+        try_with_interrupt!(io::Write::flush(self));
+        Poll::Ready(Ok(()))
     }
 
     fn poll_close(&mut self, cx: &mut task::Context) -> Poll<io::Result<()>> {

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -250,12 +250,12 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// assert_eq!(output, [1, 2, 3, 4, 0]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
     /// ```
-    fn flush<'a>(&'a mut self) -> Flush<'a, Self> {
+    fn flush(&mut self) -> Flush<'_, Self> {
         Flush::new(self)
     }
 
     /// Creates a future which will entirely close this `AsyncWrite`.
-    fn close<'a>(&'a mut self) -> Close<'a, Self> {
+    fn close(&mut self) -> Close<'_, Self> {
         Close::new(self)
     }
 
@@ -281,7 +281,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
     /// ```
-    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> WriteAll<'a, Self> {
+    fn write_all(&'a mut self, buf: &'a [u8]) -> WriteAll<'a, Self> {
         WriteAll::new(self, buf)
     }
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
+#![allow(unknown_lints)]
 
 #![doc(html_root_url = "https://docs.rs/futures-util-preview/0.3.0-alpha.1")]
 

--- a/futures-util/src/lock.rs
+++ b/futures-util/src/lock.rs
@@ -241,7 +241,7 @@ impl<'a, T: Unpin> DerefMut for BiLockGuard<'a, T> {
 
 impl<'a, T> BiLockGuard<'a, T> {
     /// Get a mutable pinned reference to the locked value.
-    pub fn as_pin_mut<'b>(&'b mut self) -> PinMut<'b, T> {
+    pub fn as_pin_mut(&mut self) -> PinMut<'_, T> {
         // Safety: we never allow moving a !Unpin value out of a bilock, nor
         // allow mutable access to it
         unsafe { PinMut::new_unchecked(&mut *self.bilock.arc.value.as_ref().unwrap().get()) }

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -33,6 +33,7 @@ impl<Si, F> SinkMapErr<Si, F> {
     }
 
     /// Get a pinned reference to the inner sink.
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pinned_mut(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
         unsafe { PinMut::map_unchecked(self, |x| &mut x.sink) }
     }
@@ -61,6 +62,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
         mut self: PinMut<Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
+        #[allow(redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
         self.sink().poll_ready(cx).map_err(|e| self.take_f()(e))
     }
 
@@ -68,6 +70,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
         mut self: PinMut<Self>,
         item: Self::SinkItem,
     ) -> Result<(), Self::SinkError> {
+        #[allow(redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
         self.sink().start_send(item).map_err(|e| self.take_f()(e))
     }
 
@@ -75,6 +78,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
         mut self: PinMut<Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
+        #[allow(redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
         self.sink().poll_flush(cx).map_err(|e| self.take_f()(e))
     }
 
@@ -82,6 +86,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
         mut self: PinMut<Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
+        #[allow(redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
         self.sink().poll_close(cx).map_err(|e| self.take_f()(e))
     }
 }

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -33,7 +33,7 @@ impl<Si, F> SinkMapErr<Si, F> {
     }
 
     /// Get a pinned reference to the inner sink.
-    pub fn get_pinned_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
+    pub fn get_pinned_mut(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
         unsafe { PinMut::map_unchecked(self, |x| &mut x.sink) }
     }
 

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -161,7 +161,7 @@ pub trait SinkExt: Sink {
     }
 
     /// Close the sink.
-    fn close<'a>(&'a mut self) -> Close<'a, Self>
+    fn close(&mut self) -> Close<'_, Self>
         where Self: Unpin,
     {
         Close::new(self)
@@ -183,7 +183,7 @@ pub trait SinkExt: Sink {
     ///
     /// This adapter is intended to be used when you want to stop sending to the sink
     /// until all current requests are processed.
-    fn flush<'a>(&'a mut self) -> Flush<'a, Self>
+    fn flush(&mut self) -> Flush<'_, Self>
         where Self: Unpin,
     {
         Flush::new(self)
@@ -195,7 +195,7 @@ pub trait SinkExt: Sink {
     /// Note that, **because of the flushing requirement, it is usually better
     /// to batch together items to send via `send_all`, rather than flushing
     /// between each item.**
-    fn send<'a>(&'a mut self, item: Self::SinkItem) -> Send<'a, Self>
+    fn send(&mut self, item: Self::SinkItem) -> Send<'_, Self>
         where Self: Unpin,
     {
         Send::new(self, item)
@@ -212,7 +212,7 @@ pub trait SinkExt: Sink {
     /// Doing `sink.send_all(stream)` is roughly equivalent to
     /// `stream.forward(sink)`. The returned future will exhaust all items from
     /// `stream` and send them to `self`.
-    fn send_all<'a, St>(
+    fn send_all<St>(
         &'a mut self,
         stream: &'a mut St
     ) -> SendAll<'a, Self, St>

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -58,8 +58,8 @@ enum State<Fut, T> {
 }
 
 impl<Fut, T> State<Fut, T> {
-    fn as_pin_mut<'a>(
-        self: PinMut<'a, Self>
+    fn as_pin_mut(
+        self: PinMut<'a, Self>,
     ) -> State<PinMut<'a, Fut>, PinMut<'a, T>> {
         unsafe {
             match PinMut::get_mut_unchecked(self) {

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -58,6 +58,7 @@ enum State<Fut, T> {
 }
 
 impl<Fut, T> State<Fut, T> {
+    #[allow(needless_lifetimes, wrong_self_convention)] // https://github.com/rust-lang/rust/issues/52675
     fn as_pin_mut(
         self: PinMut<'a, Self>,
     ) -> State<PinMut<'a, Fut>, PinMut<'a, T>> {

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -60,7 +60,7 @@ where
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
+    pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
         unsafe { PinMut::map_unchecked(self, |x| &mut x.sink) }
     }
 

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -60,6 +60,7 @@ where
     }
 
     /// Get a pinned mutable reference to the inner sink.
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
         unsafe { PinMut::map_unchecked(self, |x| &mut x.sink) }
     }

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -84,7 +84,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, St> {
+    pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, St> {
         unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
     }
 

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -84,6 +84,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, St> {
         unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
     }

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -80,7 +80,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, St> {
+    pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, St> {
         unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
     }
 

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -80,6 +80,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, St> {
         unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
     }

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -55,7 +55,7 @@ impl<St: Stream> Fuse<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, St> {
+    pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, St> {
         unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
     }
 

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -55,6 +55,7 @@ impl<St: Stream> Fuse<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut(self: PinMut<'a, Self>) -> PinMut<'a, St> {
         unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
     }

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -159,6 +159,7 @@ impl<Fut> FuturesUnordered<Fut> {
     }
 
     /// Returns an iterator that allows modifying each future in the set.
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn iter_pin_mut(self: PinMut<'a, Self>) -> IterPinMut<'a, Fut> {
         IterPinMut {
             node: self.head_all,

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -159,7 +159,7 @@ impl<Fut> FuturesUnordered<Fut> {
     }
 
     /// Returns an iterator that allows modifying each future in the set.
-    pub fn iter_pin_mut<'a>(self: PinMut<'a, Self>) -> IterPinMut<'a, Fut> {
+    pub fn iter_pin_mut(self: PinMut<'a, Self>) -> IterPinMut<'a, Fut> {
         IterPinMut {
             node: self.head_all,
             len: self.len,

--- a/futures-util/src/stream/futures_unordered/node.rs
+++ b/futures-util/src/stream/futures_unordered/node.rs
@@ -99,13 +99,11 @@ impl<Fut> Node<Fut> {
 
     /// Returns a local waker for this node without cloning the Arc.
     pub(super) fn local_waker(self: &'a Arc<Node<Fut>>) -> LocalWakerRef<'a> {
-        // Safety: This is save because an `Arc` is a struct which contains
+        // Safety: This is safe because an `Arc` is a struct which contains
         // a single field that is a pointer.
         let ptr = unsafe {
-            *mem::transmute::<*const Arc<Node<Fut>>,
-                              *const NonNull<ArcNodeUnowned<Fut>>>(self)
+            *(self as *const _ as *const NonNull<ArcNodeUnowned<Fut>>)
         };
-
 
         let ptr = ptr as NonNull<dyn UnsafeWake>;
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -153,7 +153,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(block_on(stream.next()), Some(3));
     /// assert_eq!(block_on(stream.next()), None);
     /// ```
-    fn next<'a>(&'a mut self) -> Next<'a, Self>
+    fn next(&mut self) -> Next<'_, Self>
         where Self: Sized + Unpin,
     {
         Next::new(self)

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -30,6 +30,7 @@ where
         FlattenSink(Waiting(future))
     }
 
+    #[allow(needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     fn project_pin(
         self: PinMut<'a, Self>
     ) -> State<PinMut<'a, Fut>, PinMut<'a, Si>> {

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -30,7 +30,7 @@ where
         FlattenSink(Waiting(future))
     }
 
-    fn project_pin<'a>(
+    fn project_pin(
         self: PinMut<'a, Self>
     ) -> State<PinMut<'a, Fut>, PinMut<'a, Si>> {
         unsafe {


### PR DESCRIPTION
I think merging all these changes is only worth it if we start gating CI on Clippy, otherwise the buggy allows should be dropped (just means dropping the last 2 commits). ~~With this and #1111 the deny warnings job could be changed to `cargo clippy -- -D warnings` and hit all builtin + Clippy warnings on all the crates at once.~~ (EDIT: Done since #1111 is merged)

I think the `needless_lifetimes` one could be fixed in Clippy relatively easily, presumably it just doesn't support `arbitrary_self_types` properly. The `redundant_closures` one seems like it won't be able to get a fix soon, it would need Clippy to somehow detect side-effect producing code.

I'm opening this mostly for discussion on whether gating CI on Clippy is of interest to the team. If it is then I might take a look at doing the upstream fixes to reduce the bad parts of this.