### PR TITLE
Revert "Local waker reference optimization"

### DIFF
--- a/futures-util/src/stream/futures_unordered/node.rs
+++ b/futures-util/src/stream/futures_unordered/node.rs
@@ -1,7 +1,6 @@
 use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 use std::mem;
-use std::ops::Deref;
 use std::ptr::{self, NonNull};
 use std::sync::{Arc, Weak};
 use std::sync::atomic::{AtomicPtr, AtomicBool};
@@ -32,19 +31,6 @@ pub(super) struct Node<Fut> {
     pub(super) queued: AtomicBool,
 }
 
-pub(super) struct LocalWakerRef<'a> {
-    local_waker: LocalWaker,
-    _marker: PhantomData<&'a ()>,
-}
-
-impl<'a> Deref for LocalWakerRef<'a> {
-    type Target = LocalWaker;
-
-    fn deref(&self) -> &LocalWaker {
-        &self.local_waker
-    }
-}
-
 impl<Fut> Node<Fut> {
     pub(super) fn wake(self: &Arc<Node<Fut>>) {
         let inner = match self.ready_to_run_queue.upgrade() {
@@ -73,56 +59,32 @@ impl<Fut> Node<Fut> {
         }
     }
 
-    /// Returns a waker.
-    pub(super) fn waker(self: &Arc<Node<Fut>>) -> Waker {
+    // Saftey: The returned `NonNull<Unsafe>` needs to be put into a `Waker`
+    // or `LocalWaker`
+    unsafe fn clone_as_unsafe_wake_without_lifetime(self: &Arc<Node<Fut>>)
+        -> NonNull<dyn UnsafeWake>
+    {
         let clone = self.clone();
 
         // Safety: This is save because an `Arc` is a struct which contains
         // a single field that is a pointer.
-        let ptr = unsafe {
-            mem::transmute::<Arc<Node<Fut>>,
-                             NonNull<ArcNode<Fut>>>(clone)
-        };
+        let ptr = mem::transmute::<Arc<Node<Fut>>,
+                                   NonNull<ArcNode<Fut>>>(clone);
 
         let ptr = ptr as NonNull<dyn UnsafeWake>;
 
         // Hide lifetime of `Fut`
-        // Safety: The waker can safely outlive the future because the
-        // `UnsafeWake` impl is guaranteed to not touch `Fut`.
-        let ptr = unsafe {
-            mem::transmute::<NonNull<dyn UnsafeWake>,
-                             NonNull<dyn UnsafeWake>>(ptr)
-        };
-
-        unsafe { Waker::new(ptr) }
+        // Safety: This is safe because `UnsafeWake` is guaranteed not to
+        // touch `Fut`
+        mem::transmute::<NonNull<dyn UnsafeWake>, NonNull<dyn UnsafeWake>>(ptr)
     }
 
-    /// Returns a local waker for this node without cloning the Arc.
-    pub(super) fn local_waker(self: &'a Arc<Node<Fut>>) -> LocalWakerRef<'a> {
-        // Safety: This is save because an `Arc` is a struct which contains
-        // a single field that is a pointer.
-        let ptr = unsafe {
-            *mem::transmute::<*const Arc<Node<Fut>>,
-                              *const NonNull<ArcNodeUnowned<Fut>>>(self)
-        };
+    pub(super) fn local_waker(self: &Arc<Node<Fut>>) -> LocalWaker {
+        unsafe { LocalWaker::new(self.clone_as_unsafe_wake_without_lifetime()) }
+    }
 
-
-        let ptr = ptr as NonNull<dyn UnsafeWake>;
-
-        // Hide lifetime of `self`
-        // Safety:
-        // - Since the `Arc` has not been cloned, the local waker must
-        //   not outlive it. This is ensured by the lifetime of `LocalWakerRef`.
-        // - The local waker can safely outlive the future because the
-        //   `UnsafeWake` impl is guaranteed to not touch `Fut`.
-        unsafe {
-            let ptr = mem::transmute::<NonNull<dyn UnsafeWake>,
-                                       NonNull<dyn UnsafeWake>>(ptr);
-            LocalWakerRef {
-                local_waker: LocalWaker::new(ptr),
-                _marker: PhantomData,
-            }
-        }
+    pub(super) fn waker(self: &Arc<Node<Fut>>) -> Waker {
+        unsafe { Waker::new(self.clone_as_unsafe_wake_without_lifetime()) }
     }
 }
 
@@ -130,8 +92,8 @@ impl<Fut> Drop for Node<Fut> {
     fn drop(&mut self) {
         // Currently a `Node<Fut>` is sent across all threads for any lifetime,
         // regardless of `Fut`. This means that for memory safety we can't
-        // actually touch `Fut` at any time except when we have a reference to
-        // the `FuturesUnordered` itself.
+        // actually touch `Fut` at any time except when we have a reference to the
+        // `FuturesUnordered` itself.
         //
         // Consequently it *should* be the case that we always drop futures from
         // the `FuturesUnordered` instance, but this is a bomb in place to catch
@@ -151,15 +113,10 @@ impl<Fut> Drop for Node<Fut> {
 // `{ strong, weak, data }`.
 struct ArcNode<Fut>(PhantomData<Fut>);
 
-struct ArcNodeUnowned<Fut>(PhantomData<Fut>); // Doesn't drop the `Arc`'s data
-
-// We should never touch the future `Fut` on any thread other than the one
-// owning `FuturesUnordered`, so this should be a safe operation.
+// We should never touch the future `Fut` on any thread other than the one owning
+// `FuturesUnordered`, so this should be a safe operation.
 unsafe impl<Fut> Send for ArcNode<Fut> {}
 unsafe impl<Fut> Sync for ArcNode<Fut> {}
-
-unsafe impl<Fut> Send for ArcNodeUnowned<Fut> {}
-unsafe impl<Fut> Sync for ArcNodeUnowned<Fut> {}
 
 // We need to implement `UnsafeWake` trait directly and can't implement `Wake`
 // for `Node<Fut>` because `Fut`, the future, isn't required to have a static
@@ -167,14 +124,14 @@ unsafe impl<Fut> Sync for ArcNodeUnowned<Fut> {}
 // safe because neither `drop_raw` nor `wake` touch `Fut`. This is the case even
 // though `drop_raw` runs the destructor for `Node<Fut>` because its destructor
 // is guaranteed to not touch `Fut`. `Fut` must already have been dropped by the
-// time it runs. See `Drop` impl for `Node<Fut>` for more details.
+// time it runs. See `Drop` impl for `Node<T>` for more details.
 unsafe impl<Fut> UnsafeWake for ArcNode<Fut> {
     #[inline]
     unsafe fn clone_raw(&self) -> Waker {
         let me: *const ArcNode<Fut> = self;
         let node = &*(&me as *const *const ArcNode<Fut>
                           as *const Arc<Node<Fut>>);
-        node.waker()
+        Node::waker(node)
     }
 
     #[inline]
@@ -190,28 +147,6 @@ unsafe impl<Fut> UnsafeWake for ArcNode<Fut> {
         let me: *const ArcNode<Fut> = self;
         let node = &*(&me as *const *const ArcNode<Fut>
                           as *const Arc<Node<Fut>>);
-        node.wake();
-    }
-}
-
-unsafe impl<Fut> UnsafeWake for ArcNodeUnowned<Fut> {
-    #[inline]
-    unsafe fn clone_raw(&self) -> Waker {
-        let me: *const ArcNodeUnowned<Fut> = self;
-        let node = &*(&me as *const *const ArcNodeUnowned<Fut>
-                          as *const Arc<Node<Fut>>);
-        node.waker() // Clones the `Arc` and the returned waker owns the
-                     // clone. (`ArcNode<Fut>` not `ArcNodeUnowned<Fut>`)
-    }
-
-    #[inline]
-    unsafe fn drop_raw(&self) {} // Does nothing
-
-    #[inline]
-    unsafe fn wake(&self) {
-        let me: *const ArcNodeUnowned<Fut> = self;
-        let node = &*(&me as *const *const ArcNodeUnowned<Fut>
-                          as *const Arc<Node<Fut>>);
-       node.wake();
+        Node::wake(node)
     }
 }


### PR DESCRIPTION
Reverts rust-lang-nursery/futures-rs#1045

I just did some benchmarking and the old way seems faster

Without reference optimization:
```
test oneshots ... bench:   3,917,664 ns/iter (+/- 364,682)
test oneshots ... bench:   3,853,601 ns/iter (+/- 572,603)
test oneshots ... bench:   3,849,870 ns/iter (+/- 531,131)
```

With reference optimization:
```
test oneshots ... bench:   4,529,390 ns/iter (+/- 949,579)
test oneshots ... bench:   4,454,850 ns/iter (+/- 444,460)
test oneshots ... bench:   4,462,664 ns/iter (+/- 528,435)
```

0.1 (for comparison):
```
test oneshots ... bench:   5,201,813 ns/iter (+/- 824,011)
test oneshots ... bench:   5,433,348 ns/iter (+/- 1,320,998)
test oneshots ... bench:   5,197,584 ns/iter (+/- 1,232,213)
```

Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz, rustc 1.29.0-nightly (6a1c0637c 2018-07-23)

I don't know how representative our benchmark for futures_unordered is, but it consistently shows better numbers for the old approach.