### PR TITLE
`Compat` implementation

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -19,6 +19,7 @@ name = "futures_util"
 [features]
 std = ["futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "either/use_std", "slab"]
 default = ["std", "futures-core-preview/either", "futures-sink-preview/either"]
+compat = ["std", "futures"]
 bench = []
 nightly = []
 
@@ -29,6 +30,7 @@ futures-io-preview = { path = "../futures-io", version = "0.3.0-alpha.2", defaul
 futures-sink-preview = { path = "../futures-sink", version = "0.3.0-alpha.2", default-features = false}
 either = { version = "1.4", default-features = false }
 slab = { version = "0.4", optional = true }
+futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "0.3.0-alpha.2" }

--- a/futures-util/src/compat/compat.rs
+++ b/futures-util/src/compat/compat.rs
@@ -1,0 +1,20 @@
+/// Converts a futures 0.3 `TryFuture` into a futures 0.1 `Future`
+/// and vice versa.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct Compat<Fut, Ex> {
+    crate future: Fut,
+    crate executor: Option<Ex>,
+}
+
+impl<Fut, Ex> Compat<Fut, Ex> {
+    /// Returns the inner future.
+    pub fn into_inner(self) -> Fut {
+        self.future
+    }
+
+    /// Creates a new `Compat`.
+    crate fn new(future: Fut, executor: Option<Ex>) -> Compat<Fut, Ex> {
+        Compat { future, executor }
+    }
+}

--- a/futures-util/src/compat/compat01to03.rs
+++ b/futures-util/src/compat/compat01to03.rs
@@ -1,0 +1,61 @@
+use super::Compat;
+use futures::Async as Async01;
+use futures::Future as Future01;
+use futures::executor::{self as executor01, NotifyHandle as NotifyHandle01,
+                        Notify as Notify01, UnsafeNotify as UnsafeNotify01};
+use futures_core::Future as Future03;
+use futures_core::task as task03;
+use std::mem::PinMut;
+
+impl<Fut: Future01> Future03 for Compat<Fut, ()> {
+    type Output = Result<Fut::Item, Fut::Error>;
+
+    fn poll(
+        self: PinMut<Self>,
+        cx: &mut task03::Context
+    ) -> task03::Poll<Self::Output> {
+        let notify = &WakerToHandle(cx.waker());
+
+        executor01::with_notify(notify, 0, move || {
+            unsafe {
+                match PinMut::get_mut_unchecked(self).future.poll() {
+                    Ok(Async01::Ready(t)) => task03::Poll::Ready(Ok(t)),
+                    Ok(Async01::NotReady) => task03::Poll::Pending,
+                    Err(e) => task03::Poll::Ready(Err(e)),
+                }
+            }
+        })
+    }
+}
+
+struct NotifyWaker(task03::Waker);
+
+#[derive(Clone)]
+struct WakerToHandle<'a>(&'a task03::Waker);
+
+impl<'a> From<WakerToHandle<'a>> for NotifyHandle01 {
+    fn from(handle: WakerToHandle<'a>) -> NotifyHandle01 {
+        let ptr = Box::new(NotifyWaker(handle.0.clone()));
+
+        unsafe {
+            NotifyHandle01::new(Box::into_raw(ptr))
+        }
+    }
+}
+
+impl Notify01 for NotifyWaker {
+    fn notify(&self, _: usize) {
+        self.0.wake();
+    }
+}
+
+unsafe impl UnsafeNotify01 for NotifyWaker {
+    unsafe fn clone_raw(&self) -> NotifyHandle01 {
+        WakerToHandle(&self.0).into()
+    }
+
+    unsafe fn drop_raw(&self) {
+        let ptr: *const dyn UnsafeNotify01 = self;
+        drop(Box::from_raw(ptr as *mut dyn UnsafeNotify01));
+    }
+}

--- a/futures-util/src/compat/compat03to01.rs
+++ b/futures-util/src/compat/compat03to01.rs
@@ -1,0 +1,41 @@
+use super::Compat;
+use futures::Future as Future01;
+use futures::Poll as Poll01;
+use futures::task as task01;
+use futures::Async as Async01;
+use futures_core::TryFuture as TryFuture03;
+use futures_core::task as task03;
+use std::marker::Unpin;
+use std::mem::PinMut;
+use std::sync::Arc;
+
+impl<Fut, Ex> Future01 for Compat<Fut, Ex>
+where Fut: TryFuture03 + Unpin,
+      Ex: task03::Executor
+{
+    type Item = Fut::Ok;
+    type Error = Fut::Error;
+
+    fn poll(&mut self) -> Poll01<Self::Item, Self::Error> {
+        let waker = current_as_waker();
+        let mut cx = task03::Context::new(&waker, self.executor.as_mut().unwrap());
+        match PinMut::new(&mut self.future).try_poll(&mut cx) {
+            task03::Poll::Ready(Ok(t)) => Ok(Async01::Ready(t)),
+            task03::Poll::Pending => Ok(Async01::NotReady),
+            task03::Poll::Ready(Err(e)) => Err(e),
+        }
+    }
+}
+
+fn current_as_waker() -> task03::LocalWaker {
+    let arc_waker = Arc::new(Current(task01::current()));
+    task03::local_waker_from_nonlocal(arc_waker)
+}
+
+struct Current(task01::Task);
+
+impl task03::Wake for Current {
+    fn wake(arc_self: &Arc<Self>) {
+        arc_self.0.notify();
+    }
+}

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -1,0 +1,47 @@
+
+pub trait ExecCompat: Executor01<
+        Compat<FutureObj<'static, ()>, BoxedExecutor>
+    > + Clone + Send + 'static
+{
+    fn compat(self) -> ExecutorCompat<Self> 
+        where Self: Sized;
+}
+
+impl<E> ExecCompat for E
+where E: Executor01<
+        Compat<FutureObj<'static, ()>, BoxedExecutor>
+      >,
+      E: Clone + Send + 'static
+{
+    fn compat(self) -> ExecutorCompat<Self> {
+        ExecutorCompat {
+            exec: self,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ExecutorCompat<E> {
+    exec: E
+}
+
+impl<E> Executor03 for ExecutorCompat<E> 
+    where E: Executor01<
+        Compat<FutureObj<'static, ()>, Box<Executor03>>
+    >,
+    E: Clone + Send + 'static,
+{
+    fn spawn_obj(&mut self, obj: FutureObj<'static, ()>) -> Result<(), task::SpawnObjError> {
+        
+        self.exec.execute(obj.compat(Box::new(self.clone())))
+                 .map_err(|exec_err| {
+                     use futures_core::task::{SpawnObjError, SpawnErrorKind};
+                     
+                     let fut = exec_err.into_future().compat().map(|_| ());
+                     SpawnObjError {
+                         kind: SpawnErrorKind::shutdown(),
+                         task: Box::new(fut).into(),   
+                     }
+                 })
+    }
+}

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -23,7 +23,7 @@ pub type ExecutorFuture01 = Compat<NeverError<FutureObj<'static, ()>>, BoxedExec
 pub trait Executor01CompatExt: Executor01<ExecutorFuture01> 
     + Clone + Send + 'static
 {
-    /// Creates an exector compatable with futures 0.3.
+    /// Creates an `Executor` compatable with futures 0.3.
     fn compat(self) -> CompatExecutor<Self> 
         where Self: Sized;
 }
@@ -39,7 +39,7 @@ where E: Executor01<ExecutorFuture01>,
     }
 }
 
-/// Converts `futures 0.1` Executors into `futures 0.3` Executors
+/// Converts a futures 0.1 `Executor` into a futures 0.3 `Executor`.
 #[derive(Clone)]
 pub struct CompatExecutor<E> {
     exec: E

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -1,70 +1,71 @@
 
+use super::Compat;
+use crate::{TryFutureExt, FutureExt, future::NeverError};
 use futures::future::Executor as Executor01;
-
 use futures_core::task::Executor as Executor03;
 use futures_core::task as task03;
 use futures_core::future::FutureObj;
 
-use super::Compat;
-use crate::{TryFutureExt, FutureExt, future::NeverError};
+pub struct BoxedExecutor03(Box<dyn Executor03 + Send>);
 
-pub struct BoxedExecutor(Box<dyn Executor03 + Send>);
-
-impl Executor03 for BoxedExecutor {
-    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), task03::SpawnObjError> {
+impl Executor03 for BoxedExecutor03 {
+    fn spawn_obj(
+        &mut self,
+        future: FutureObj<'static, ()>,
+    ) -> Result<(), task03::SpawnObjError> {
         (&mut *self.0).spawn_obj(future)
     }
 }
 
 /// A future that can run on a futures 0.1 executor.
-pub type ExecutorFuture01 = Compat<NeverError<FutureObj<'static, ()>>, BoxedExecutor>;
+pub type Executor01Future = Compat<NeverError<FutureObj<'static, ()>>, BoxedExecutor03>;
 
 /// Extension trait for futures 0.1 Executors.
-pub trait Executor01CompatExt: Executor01<ExecutorFuture01> 
-    + Clone + Send + 'static
+pub trait Executor01CompatExt: Executor01<Executor01Future> +
+                               Clone + Send + 'static
 {
     /// Creates an `Executor` compatable with futures 0.3.
-    fn compat(self) -> CompatExecutor<Self> 
+    fn compat(self) -> Executor01As03<Self>
         where Self: Sized;
 }
 
-impl<E> Executor01CompatExt for E
-where E: Executor01<ExecutorFuture01>,
-      E: Clone + Send + 'static
+impl<Ex> Executor01CompatExt for Ex
+where Ex: Executor01<Executor01Future> + Clone + Send + 'static
 {
-    fn compat(self) -> CompatExecutor<Self> {
-        CompatExecutor {
-            exec: self,
+    fn compat(self) -> Executor01As03<Self> {
+        Executor01As03 {
+            executor01: self,
         }
     }
 }
 
 /// Converts a futures 0.1 `Executor` into a futures 0.3 `Executor`.
 #[derive(Clone)]
-pub struct CompatExecutor<E> {
-    exec: E
+pub struct Executor01As03<Ex> {
+    executor01: Ex
 }
 
-impl<E> Executor03 for CompatExecutor<E> 
-    where E: Executor01<ExecutorFuture01>,
-    E: Clone + Send + 'static,
+impl<Ex> Executor03 for Executor01As03<Ex>
+where Ex: Executor01<Executor01Future>,
+      Ex: Clone + Send + 'static,
 {
     fn spawn_obj(
-        &mut self, 
+        &mut self,
         future: FutureObj<'static, ()>,
     ) -> Result<(), task03::SpawnObjError> {
-        
-        let fut = future.never_error().compat(BoxedExecutor(Box::new(self.clone())));
+        let future = future.never_error().compat(BoxedExecutor03(Box::new(self.clone())));
 
-        self.exec.execute(fut)
-            .map_err(|exec_err| {
+        match self.executor01.execute(future) {
+            Ok(()) => Ok(()),
+            Err(err) => {
                 use futures_core::task::{SpawnObjError, SpawnErrorKind};
-                     
-                let fut = exec_err.into_future().into_inner().unwrap_or_else(|_| ());
-                SpawnObjError {
+
+                let fut = err.into_future().into_inner().unwrap_or_else(|_| ());
+                Err(SpawnObjError {
                     kind: SpawnErrorKind::shutdown(),
-                    task: Box::new(fut).into(),   
-                }
-            })
+                    future: Box::new(fut).into(),
+                })
+            }
+        }
     }
 }

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -1,6 +1,6 @@
 
 use super::Compat;
-use crate::{TryFutureExt, FutureExt, future::NeverError};
+use crate::{TryFutureExt, FutureExt, future::UnitError};
 use futures::future::Executor as Executor01;
 use futures_core::task::Executor as Executor03;
 use futures_core::task as task03;
@@ -18,7 +18,7 @@ impl Executor03 for BoxedExecutor03 {
 }
 
 /// A future that can run on a futures 0.1 executor.
-pub type Executor01Future = Compat<NeverError<FutureObj<'static, ()>>, BoxedExecutor03>;
+pub type Executor01Future = Compat<UnitError<FutureObj<'static, ()>>, BoxedExecutor03>;
 
 /// Extension trait for futures 0.1 Executors.
 pub trait Executor01CompatExt: Executor01<Executor01Future> +
@@ -53,7 +53,7 @@ where Ex: Executor01<Executor01Future>,
         &mut self,
         future: FutureObj<'static, ()>,
     ) -> Result<(), task03::SpawnObjError> {
-        let future = future.never_error().compat(BoxedExecutor03(Box::new(self.clone())));
+        let future = future.unit_error().compat(BoxedExecutor03(Box::new(self.clone())));
 
         match self.executor01.execute(future) {
             Ok(()) => Ok(()),

--- a/futures-util/src/compat/future01ext.rs
+++ b/futures-util/src/compat/future01ext.rs
@@ -1,0 +1,18 @@
+use super::Compat;
+use futures::Future as Future01;
+
+impl<Fut: Future01> Future01CompatExt for Fut {}
+
+/// Extension trait for futures 0.1 Futures.
+pub trait Future01CompatExt: Future01 {
+    /// Converts a futures 0.1 `Future<Item = T, Error = E>` into a
+    /// futures 0.3 `Future<Output = Result<T, E>>`.
+    fn compat(self) -> Compat<Self, ()> where Self: Sized {
+        Compat {
+            future: self,
+            executor: None,
+        }
+    }
+}
+
+

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -1,149 +1,15 @@
 //! Futures 0.1 / 0.3 shims
-//! 
 
 #![allow(missing_debug_implementations)]
 
-use futures::Future as Future01;
-use futures::Poll as Poll01;
-use futures::task as task01;
-use futures::task::Task as Task01;
-use futures::executor::{with_notify, NotifyHandle, Notify, UnsafeNotify};
-
-use futures_core::Future as Future03;
-use futures_core::TryFuture as TryFuture03;
-use futures_core::Poll as Poll03;
-use futures_core::task as task03;
-use futures_core::task::Executor as Executor03;
-use futures_core::task::{Wake, Waker, LocalWaker, local_waker_from_nonlocal};
-
-use std::mem::PinMut;
-use std::marker::Unpin;
-use std::sync::Arc;
-
 mod executor;
-pub use self::executor::{Executor01CompatExt, ExecutorFuture01, CompatExecutor};
+pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 
-/// Converts a futures 0.3 `TryFuture` into a futures 0.1 `Future`
-/// and vice versa.
-#[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
-pub struct Compat<Fut, E> {
-    crate inner: Fut, 
-    crate executor: Option<E>,
-}
+mod compat;
+pub use self::compat::Compat;
 
-impl<Fut, E> Compat<Fut, E> {
-    /// Returns the inner future.
-    pub fn into_inner(self) -> Fut {
-        self.inner
-    }
+mod compat01to03;
+mod compat03to01;
 
-    /// Creates a new `Compat`.
-    crate fn new(inner: Fut, executor: Option<E>) -> Compat<Fut, E> {
-        Compat {
-            inner,
-            executor
-        }
-    }
-}
-
-impl<T> Future03 for Compat<T, ()> where T: Future01 {
-    type Output = Result<T::Item, T::Error>;
-
-    fn poll(self: PinMut<Self>, cx: &mut task03::Context) -> Poll03<Self::Output> {
-        use futures::Async;
-
-        let notify = &WakerToHandle(cx.waker());
-
-        with_notify(notify, 0, move || { 
-            unsafe {
-                match PinMut::get_mut_unchecked(self).inner.poll() {
-                    Ok(Async::Ready(t)) => Poll03::Ready(Ok(t)),
-                    Ok(Async::NotReady) => Poll03::Pending,
-                    Err(e) => Poll03::Ready(Err(e)),
-                }
-            }
-        })
-    }
-}
-
-struct NotifyWaker(Waker);
-
-#[derive(Clone)]
-struct WakerToHandle<'a>(&'a Waker);
-
-impl<'a> From<WakerToHandle<'a>> for NotifyHandle {
-    fn from(handle: WakerToHandle<'a>) -> NotifyHandle {
-        let ptr = Box::new(NotifyWaker(handle.0.clone()));
-
-        unsafe {
-            NotifyHandle::new(Box::into_raw(ptr))
-        }
-    }
-}
-
-impl Notify for NotifyWaker {
-    fn notify(&self, _: usize) {
-        self.0.wake();
-    }
-}
-
-unsafe impl UnsafeNotify for NotifyWaker {
-    unsafe fn clone_raw(&self) -> NotifyHandle {
-        WakerToHandle(&self.0).into()
-    }
-
-    unsafe fn drop_raw(&self) {
-        let ptr: *const dyn UnsafeNotify = self;
-        drop(Box::from_raw(ptr as *mut dyn UnsafeNotify));
-    }
-}
-
-
-
-
-impl<T, E> Future01 for Compat<T, E> where T: TryFuture03 + Unpin,
-    E: Executor03
-{
-    type Item = T::Ok;
-    type Error = T::Error;
-
-    fn poll(&mut self) -> Poll01<Self::Item, Self::Error> {
-        use futures::Async;
-
-        let waker = current_as_waker();
-        let mut cx = task03::Context::new(&waker, self.executor.as_mut().unwrap());
-        match PinMut::new(&mut self.inner).try_poll(&mut cx) {
-            Poll03::Ready(Ok(t)) => Ok(Async::Ready(t)),
-            Poll03::Pending => Ok(Async::NotReady),
-            Poll03::Ready(Err(e)) => Err(e),
-        }
-    }
-}
-
-fn current_as_waker() -> LocalWaker {
-    let arc_waker = Arc::new(Current(task01::current()));
-    local_waker_from_nonlocal(arc_waker)
-}
-
-struct Current(Task01);
-
-impl Wake for Current {
-    fn wake(arc_self: &Arc<Self>) {
-        arc_self.0.notify();
-    }
-}
-
-/// Extension trait for futures 0.1 Futures.
-pub trait Future01Ext: Future01 {
-    /// Converts a futures 0.1 `Future<Item = T, Error = E>` into a 
-    /// futures 0.3 `Future<Output = Result<T, E>>`.
-    fn compat(self) -> Compat<Self, ()> where Self: Sized {
-        Compat {
-            inner: self,
-            executor: None,
-        }
-    }
-}
-
-impl<T: Future01> Future01Ext for T {}
+mod future01ext;
+pub use self::future01ext::Future01CompatExt;

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -1,0 +1,132 @@
+//! Futures 0.1 / 0.3 shims
+//! 
+
+#![allow(missing_debug_implementations)]
+
+use futures::Future as Future01;
+use futures::Poll as Poll01;
+use futures::task as task01;
+use futures::task::Task as Task01;
+use futures::executor::{with_notify, NotifyHandle, Notify, UnsafeNotify};
+
+use futures_core::Future as Future03;
+use futures_core::TryFuture as TryFuture03;
+use futures_core::Poll as Poll03;
+use futures_core::task;
+use futures_core::task::Executor as Executor03;
+use futures_core::task::{Wake, Waker, LocalWaker, local_waker_from_nonlocal};
+
+use core::mem::PinMut;
+use core::marker::Unpin;
+use std::sync::Arc;
+
+/// Converts a futures 0.3 `TryFuture` into a futures 0.1 `Future`
+/// and vice versa.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct Compat<Fut, E> {
+    crate inner: Fut, 
+    crate executor: Option<E>,
+}
+
+impl<Fut, E> Compat<Fut, E> {
+    /// Returns the inner future.
+    pub fn into_inner(self) -> Fut {
+        self.inner
+    }
+
+    /// Creates a new `Compat`.
+    crate fn new(inner: Fut, executor: Option<E>) -> Compat<Fut, E> {
+        Compat {
+            inner,
+            executor
+        }
+    }
+}
+
+impl<T> Future03 for Compat<T, ()> where T: Future01 {
+    type Output = Result<T::Item, T::Error>;
+
+    fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll03<Self::Output> {
+        use futures::Async;
+
+        let notify = &WakerToHandle(cx.waker());
+
+        with_notify(notify, 0, move || { 
+            unsafe {
+                match PinMut::get_mut_unchecked(self).inner.poll() {
+                    Ok(Async::Ready(t)) => Poll03::Ready(Ok(t)),
+                    Ok(Async::NotReady) => Poll03::Pending,
+                    Err(e) => Poll03::Ready(Err(e)),
+                }
+            }
+        })
+    }
+}
+
+struct NotifyWaker(Waker);
+
+#[derive(Clone)]
+struct WakerToHandle<'a>(&'a Waker);
+
+impl<'a> From<WakerToHandle<'a>> for NotifyHandle {
+    fn from(handle: WakerToHandle<'a>) -> NotifyHandle {
+        let ptr = Box::new(NotifyWaker(handle.0.clone()));
+
+        unsafe {
+            NotifyHandle::new(Box::into_raw(ptr))
+        }
+    }
+}
+
+impl Notify for NotifyWaker {
+    fn notify(&self, _: usize) {
+        self.0.wake();
+    }
+}
+
+unsafe impl UnsafeNotify for NotifyWaker {
+    unsafe fn clone_raw(&self) -> NotifyHandle {
+        WakerToHandle(&self.0).into()
+    }
+
+    unsafe fn drop_raw(&self) {
+        let ptr: *const dyn UnsafeNotify = self;
+        drop(Box::from_raw(ptr as *mut dyn UnsafeNotify));
+    }
+}
+
+
+
+
+impl<T, E> Future01 for Compat<T, E> where T: TryFuture03 + Unpin,
+    E: Executor03
+{
+    type Item = T::Ok;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll01<Self::Item, Self::Error> {
+        use futures::Async;
+
+        let waker = current_as_waker();
+        let mut cx = task::Context::new(&waker, self.executor.as_mut().unwrap());
+        match PinMut::new(&mut self.inner).try_poll(&mut cx) {
+            Poll03::Ready(Ok(t)) => Ok(Async::Ready(t)),
+            Poll03::Pending => Ok(Async::NotReady),
+            Poll03::Ready(Err(e)) => Err(e),
+        }
+    }
+}
+
+fn current_as_waker() -> LocalWaker {
+    let arc_waker = Arc::new(Current(task01::current()));
+    local_waker_from_nonlocal(arc_waker)
+}
+
+struct Current(Task01);
+
+impl Wake for Current {
+    fn wake(arc_self: &Arc<Self>) {
+        arc_self.0.notify();
+    }
+}

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -133,3 +133,16 @@ impl Wake for Current {
         arc_self.0.notify();
     }
 }
+
+/// Extension trait for futures 0.1.
+pub trait Future01Ext: Future01 {
+    /// Converts the future into a futures 0.3 future.
+    fn compat(self) -> Compat<Self, ()> where Self: Sized {
+        Compat {
+            inner: self,
+            executor: None,
+        }
+    }
+}
+
+impl<T: Future01> Future01Ext for T {}

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -134,9 +134,10 @@ impl Wake for Current {
     }
 }
 
-/// Extension trait for futures 0.1.
+/// Extension trait for futures 0.1 Futures.
 pub trait Future01Ext: Future01 {
-    /// Converts the future into a futures 0.3 future.
+    /// Converts a futures 0.1 `Future<Item = T, Error = E>` into a 
+    /// futures 0.3 `Future<Output = Result<T, E>>`.
     fn compat(self) -> Compat<Self, ()> where Self: Sized {
         Compat {
             inner: self,

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -57,8 +57,8 @@ pub use self::then::Then;
 mod inspect;
 pub use self::inspect::Inspect;
 
-mod never_error;
-pub use self::never_error::NeverError;
+mod unit_error;
+pub use self::unit_error::UnitError;
 
 mod with_executor;
 pub use self::with_executor::WithExecutor;
@@ -645,11 +645,11 @@ pub trait FutureExt: Future {
         PinBox::new(self)
     }
 
-    /// Turns a `Future` into a `TryFuture` that never errors
-    fn never_error(self) -> NeverError<Self>
+    /// Turns a `Future` into a `TryFuture` with `Error = ()`.
+    fn unit_error(self) -> UnitError<Self>
         where Self: Sized
     {
-        NeverError::new(self)
+        UnitError::new(self)
     }
 
     /// Assigns the provided `Executor` to be used when spawning tasks

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -68,6 +68,8 @@ mod chain;
 crate use self::chain::Chain;
 
 if_std! {
+    use std::boxed::PinBox;
+
     mod abortable;
     pub use self::abortable::{abortable, Abortable, AbortHandle, AbortRegistration, Aborted};
 
@@ -86,8 +88,6 @@ if_std! {
 
     mod shared;
     pub use self::shared::Shared;
-
-    use std::boxed::PinBox;
 }
 
 impl<T: ?Sized> FutureExt for T where T: Future {}

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -57,6 +57,9 @@ pub use self::then::Then;
 mod inspect;
 pub use self::inspect::Inspect;
 
+mod never_error;
+pub use self::never_error::NeverError;
+
 mod with_executor;
 pub use self::with_executor::WithExecutor;
 
@@ -83,6 +86,8 @@ if_std! {
 
     mod shared;
     pub use self::shared::Shared;
+
+    use std::boxed::PinBox;
 }
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
@@ -630,6 +635,21 @@ pub trait FutureExt: Future {
         where Self: Sized
     {
         Shared::new(self)
+    }
+
+    /// Wrap the future in a Box, pinning it.
+    #[cfg(feature = "std")]
+    fn boxed(self) -> PinBox<Self>
+        where Self: Sized
+    {
+        PinBox::new(self)
+    }
+
+    /// Turns a `Future` into a `TryFuture` that never errors
+    fn never_error(self) -> NeverError<Self>
+        where Self: Sized
+    {
+        NeverError::new(self)
     }
 
     /// Assigns the provided `Executor` to be used when spawning tasks

--- a/futures-util/src/future/never_error.rs
+++ b/futures-util/src/future/never_error.rs
@@ -1,0 +1,39 @@
+use core::marker::Unpin;
+use core::mem::PinMut;
+use futures_core::future::Future;
+use futures_core::task::{self, Poll};
+
+/// Future for the `never_error` combinator, turning a `Future` into a `TryFuture`.
+///
+/// This is created by the `FutureExt::never_error` method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
+pub struct NeverError<Fut> {
+    future: Fut,
+}
+
+impl<Fut> NeverError<Fut> {
+    unsafe_pinned!(future: Fut);
+
+    /// Creates a new NeverError.
+    pub(super) fn new(future: Fut) -> NeverError<Fut> {
+        NeverError { future }
+    }
+}
+
+impl<Fut: Unpin> Unpin for NeverError<Fut> {}
+
+impl<Fut, T> Future for NeverError<Fut>
+    where Fut: Future<Output = T>,
+{
+    type Output = Result<T, ()>;
+
+    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<T, ()>> {
+        match self.future().poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(output) => {
+                Poll::Ready(Ok(output))
+            }
+        }
+    }
+}

--- a/futures-util/src/future/never_error.rs
+++ b/futures-util/src/future/never_error.rs
@@ -29,11 +29,6 @@ impl<Fut, T> Future for NeverError<Fut>
     type Output = Result<T, ()>;
 
     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<T, ()>> {
-        match self.future().poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(output) => {
-                Poll::Ready(Ok(output))
-            }
-        }
+        self.future().poll(cx).map(Ok)
     }
 }

--- a/futures-util/src/future/unit_error.rs
+++ b/futures-util/src/future/unit_error.rs
@@ -3,27 +3,27 @@ use core::mem::PinMut;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
-/// Future for the `never_error` combinator, turning a `Future` into a `TryFuture`.
+/// Future for the `unit_error` combinator, turning a `Future` into a `TryFuture`.
 ///
-/// This is created by the `FutureExt::never_error` method.
+/// This is created by the `FutureExt::unit_error` method.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
-pub struct NeverError<Fut> {
+pub struct UnitError<Fut> {
     future: Fut,
 }
 
-impl<Fut> NeverError<Fut> {
+impl<Fut> UnitError<Fut> {
     unsafe_pinned!(future: Fut);
 
-    /// Creates a new NeverError.
-    pub(super) fn new(future: Fut) -> NeverError<Fut> {
-        NeverError { future }
+    /// Creates a new UnitError.
+    pub(super) fn new(future: Fut) -> UnitError<Fut> {
+        UnitError { future }
     }
 }
 
-impl<Fut: Unpin> Unpin for NeverError<Fut> {}
+impl<Fut: Unpin> Unpin for UnitError<Fut> {}
 
-impl<Fut, T> Future for NeverError<Fut>
+impl<Fut, T> Future for UnitError<Fut>
     where Fut: Future<Output = T>,
 {
     type Output = Result<T, ()>;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -75,6 +75,9 @@ pub mod sink;
 
 pub mod task;
 
+#[cfg(feature = "compat")]
+pub mod compat;
+
 if_std! {
     // FIXME: currently async/await is only available with std
     pub mod async_await;

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -36,3 +36,4 @@ futures-util-preview = { path = "../futures-util", version = "0.3.0-alpha.2", de
 nightly = ["futures-util-preview/nightly"]
 std = ["futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std"]
 default = ["std"]
+compat = ["std", "futures-util-preview/compat"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -85,11 +85,12 @@ pub mod compat {
     //!
 
     pub use futures_util::compat::{
-        Compat, CompatExecutor,
-        ExecutorFuture01,
+        Compat,
+        Executor01Future,
+        Executor01As03,
         Executor01CompatExt,
-        Future01Ext,
-    }; 
+        Future01CompatExt,
+    };
 }
 
 #[cfg(feature = "std")]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -79,6 +79,19 @@ pub mod channel {
     pub use futures_channel::{oneshot, mpsc};
 }
 
+#[cfg(feature = "compat")]
+pub mod compat {
+    //! Interop between `futures` 0.1 and 0.3.
+    //!
+
+    pub use futures_util::compat::{
+        Compat, CompatExecutor,
+        ExecutorFuture01,
+        Executor01CompatExt,
+        Future01Ext,
+    }; 
+}
+
 #[cfg(feature = "std")]
 pub mod executor {
     //! Task execution.


### PR DESCRIPTION
based on @MajorBreakfast's approach here https://github.com/rust-lang-nursery/net-wg/issues/26#issuecomment-407577152

issues: 
* executors are blocked on https://github.com/rust-lang/rust/pull/52674
* more tests / examples
* ~where should 0.1 -> 0.3 combinators live?~
* renaming blocked on https://github.com/rust-lang/cargo/pull/5794
* name of NeverError type