### PR TITLE
Fail CI if rustdoc can't resolve an item

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,13 @@ matrix:
     - name: cargo doc
       rust: nightly
       script:
+        - RUSTDOCFLAGS=-Dwarnings cargo doc
+            -p futures-core-preview
+            -p futures-channel-preview
+            -p futures-sink-preview
+            -p futures-io-preview
+            -p futures-util-preview
+            -p futures-executor-preview
         - cargo doc
 
 script:


### PR DESCRIPTION
All our crates except the facade should build their docs without warnings. Now that we removed `#![deny(warnings)]` our CI doesn't fail properly anymore if there is such a warning. This PR makes it fail again.

We don't deny warnings for the facade because rustdoc seems to have problems with reexports and produces a lot of warnings. Luckily the doc links seem to work after all. Very strange. That's another issue though, this PR just restores the behavior we had before we removed the `#![deny(warnings)]` annotations.