### PR TITLE
Stop borrowing uncompleted futures in select macro

### DIFF
--- a/futures-util/src/async_await/select.rs
+++ b/futures-util/src/async_await/select.rs
@@ -1,23 +1,23 @@
 //! The `select` macro.
 
-/// Polls multiple futures simultaneously, executing the branch for the future 
+/// Polls multiple futures simultaneously, executing the branch for the future
 /// that finishes first.
-/// 
-/// `select!` can select over futures with different output types, but each 
-/// branch has to have the same return type. Inside each branch, the respective 
+///
+/// `select!` can select over futures with different output types, but each
+/// branch has to have the same return type. Inside each branch, the respective
 /// future's output is available via a variable with the same name as the future.
-/// 
+///
 /// This macro is only usable inside of async functions, closures, and blocks.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// #![feature(pin, async_await, await_macro, futures_api)]
 /// # futures::executor::block_on(async {
 /// use futures::{select, future};
 /// let mut a = future::ready(4);
 /// let mut b: future::Empty<()> = future::empty();
-/// 
+///
 /// let res = select! {
 ///     a => a + 1,
 ///     b => 0,
@@ -33,44 +33,37 @@ macro_rules! select {
     ($(
         $name:ident => $body:expr,
     )*) => { {
+        // Require all arguments to be `Unpin` so that we don't have to pin them,
+        // allowing uncompleted futures to be reused by the caller after the
+        // `select!` resolves.
         $(
             $crate::async_await::assert_unpin(&$name);
         )*
+
         #[allow(bad_style)]
-        struct __priv<$($name,)*> {
+        enum __PrivResult<$($name,)*> {
             $(
-                $name: $name,
+                $name($name),
             )*
         }
-        let mut __priv_futures = __priv {
+
+        let __priv_res = loop {
             $(
-                $name: $crate::future::maybe_done(&mut $name),
-            )*
-        };
-        loop {
-            $(
-                if let $crate::core_reexport::task::Poll::Ready(()) =
-                    $crate::poll!($crate::core_reexport::mem::PinMut::new(
-                        &mut __priv_futures.$name))
-                {
-                    break;
+                let poll_res = $crate::poll!($crate::core_reexport::mem::PinMut::new(
+                        &mut $name));
+                if let $crate::core_reexport::task::Poll::Ready(x) = poll_res {
+                    break __PrivResult::$name(x);
                 }
             )*
             $crate::pending!();
-        }
-        if false {
-            unreachable!()
-        }
-        $(
-            else if let Some($name) =
-                $crate::core_reexport::mem::PinMut::new(&mut __priv_futures.$name).take_output()
-            {
-                let _ = $name; // suppress "unused" warning for binding name
-                $body
-            }
-        )*
-        else {
-            unreachable!()
+        };
+        match __priv_res {
+            $(
+                __PrivResult::$name($name) => {
+                    let _ = $name; // Suppress "unused" warning for binding name
+                    $body
+                }
+            )*
         }
     } };
 }

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -51,3 +51,27 @@ fn select() {
     });
     assert!(ran);
 }
+
+#[test]
+fn select_can_move_uncompleted_futures() {
+    let (tx1, mut rx1) = oneshot::channel::<i32>();
+    let (tx2, mut rx2) = oneshot::channel::<i32>();
+    tx1.send(1).unwrap();
+    tx2.send(2).unwrap();
+    let mut ran = false;
+    block_on(async {
+        select! {
+            rx1 => {
+                assert_eq!(Ok(1), rx1);
+                assert_eq!(Ok(2), await!(rx2));
+                ran = true;
+            },
+            rx2 => {
+                assert_eq!(Ok(2), rx2);
+                assert_eq!(Ok(1), await!(rx1));
+                ran = true;
+            },
+        }
+    });
+    assert!(ran);
+}


### PR DESCRIPTION
This removes the temporary `__priv` struct from the `select!` impl, allowing for a more optimized representation as well as allowing uncompleted futures to be moved inside the branches of other completed futures. The name shadowing behavior conveniently prevents accidental use of completed futures (at least in common cases).