### PR TITLE
Add job to publish docs on tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ rust:
 sudo: false
 cache: cargo
 
+stages:
+  - name: test
+  - name: release
+    if: tag IS present
+
 matrix:
   include:
     - name: cargo test
@@ -68,7 +73,28 @@ matrix:
     - name: cargo doc
       rust: nightly
       script:
-        - cargo doc --all
+        - cargo doc --all --no-deps --all-features
+
+    - name: publish docs
+      stage: release
+      rust: nightly
+      before_script:
+        - echo "machine github.com login $GH_TOKEN password x-oauth-basic" >> ~/.netrc
+        - chmod 0600 ~/.netrc
+        - git clone https://github.com/rust-lang-nursery/futures-api-docs
+      script:
+        - cargo doc --all --no-deps --all-features
+        - mv target/doc "futures-api-docs/$TRAVIS_TAG"
+        - cd futures-api-docs
+        - |
+          sed -i'' -e '/<main id="doc-links">/a\
+          \        <a href="https://rust-lang-nursery.github.io/futures-api-docs/'"$TRAVIS_TAG"'/futures/">\
+          \          <span>'"$TRAVIS_TAG"'</span>\
+          \        </a>\
+          ' index.html
+        - git add "docs/$TRAVIS_TAG" index.html
+        - git commit -m "Add API docs for $TRAVIS_TAG"
+        - git push origin master
 
 script:
   - cargo test --all


### PR DESCRIPTION
r? @MajorBreakfast 

This reuses the existing `GH_TOKEN` variable (at least, I assume that's what the encrypted environment variable is from looking back at the history) which I believe is from @alexcrichton's account. We may want to change that (especially if that doesn't give it access to push to https://github.com/rust-lang-nursery/futures-doc)?