### PR TITLE
Add an IntoStream wrapper around TryStream

### DIFF
--- a/futures-util/src/try_stream/into_stream.rs
+++ b/futures-util/src/try_stream/into_stream.rs
@@ -1,0 +1,48 @@
+use core::mem::PinMut;
+use futures_core::stream::{Stream, TryStream};
+use futures_core::task::{self, Poll};
+
+/// Stream for the [`into_stream`](super::TryStreamExt::into_stream) combinator.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct IntoStream<St> {
+    stream: St,
+}
+
+impl<St> IntoStream<St> {
+    unsafe_pinned!(stream: St);
+
+    #[inline]
+    pub(super) fn new(stream: St) -> Self {
+        IntoStream { stream }
+    }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    pub fn get_mut(&mut self) -> &mut St {
+        &mut self.stream
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    pub fn into_inner(self) -> St {
+        self.stream
+    }
+}
+
+impl<St: TryStream> Stream for IntoStream<St> {
+    type Item = Result<St::Ok, St::Error>;
+
+    #[inline]
+    fn poll_next(
+        mut self: PinMut<Self>,
+        cx: &mut task::Context,
+    ) -> Poll<Option<Self::Item>> {
+        self.stream().try_poll_next(cx)
+    }
+}

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -292,5 +292,4 @@ pub trait TryStreamExt: TryStream {
     {
         TryFilterMap::new(self, f)
     }
-
 }


### PR DESCRIPTION
Similar idea to IntoFuture.
Will use this in the implementation of try_buffer_unordered to wrap a TryStream in a Fuse