### PR TITLE
Alpha 3 blog post

### DIFF
--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -25,13 +25,13 @@ The `std::task::Executor` trait is now called `std::task::Spawn`. The purpose of
 As a consequence of this renaming, some functions on `Context` were adjusted:
 ```rust
 impl<'a> Context<'a> {
-    pub fn new(local_waker: &'a LocalWaker, spawner: &'a mut dyn Spawn) -> Context<'a> { /* --snip-- */ }
+    pub fn new(local_waker: &'a LocalWaker, spawner: &'a mut dyn Spawn) -> Context<'a> { ... }
 
-    pub fn spawner(&mut self) -> &mut dyn Spawn { /* --snip-- */ }
+    pub fn spawner(&mut self) -> &mut dyn Spawn { ... }
 
-    pub fn with_spawner<'b, Sp: Spawn>(&'b mut self, spawner: &'b mut Sp) -> Context<'b> { /* --snip-- */ }
+    pub fn with_spawner<'b, Sp: Spawn>(&'b mut self, spawner: &'b mut Sp) -> Context<'b> { ... }
 
-    // --snip--
+    // ...
 }
 ```
 
@@ -113,7 +113,7 @@ The pin macros now live in their own crate, the `pin-utils` crate. The macros ar
 The crate includes the macros for (un)pin projections `unsafe_pinned!` and `unsafe_unpinned!` and the macro for stack pinning `pin_mut!`:
 
 ```rust
-let foo = Foo { /* ... */ };
+let foo = Foo { ... };
 pin_mut!(foo); // PinMut<Foo>
 ```
 

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -14,13 +14,13 @@ $ rustup update
 
 ## Compatibility layer
 
-A compatibility layer between 0.3 an 0.1 was developped. It is now possible to convert an 0.3 future into an 0.1 future and vice versa. Similar conversions for streams and sinks are also supported. Additionally it is now possible to run 0.3 futures and async functions on Tokio's executor. We have a dedicated blog post coming up that explains this in more detail.
+A compatibility layer between 0.3 an 0.1 was developed. It is now possible to convert an 0.3 future into an 0.1 future and vice versa. Similar conversions for streams and sinks are also supported. Additionally, it is now possible to run 0.3 futures and async functions on Tokio's executor. We have a dedicated blog post coming up that explains this in more detail.
 
 ## Spawning
 
 ### `Spawn` trait
 
-The `std::task::Executor` trait is now called `std::task::Spawn`. The purpose of the trait remains unchanged - it is to provide a mechanism for spawning tasks. We noticed that in many implementations the responsibilty of spawning tasks is handled by a type that merely sends the task to an associated executor, not by the task executor type itself. Furthermore, it became clear that the former trait name "`Executor`" didn't properly capture the essence of what it means to be an executor. Fundamentally, a task executor is a type that manages the execution of tasks. There exists no fixed set of methods that a trait could define. Instead, each task executor type offers different methods that make sense for its design goals. This is why we chose to rename the trait to `Spawn` to reflect that it merely defines a method for spawning tasks and makes no specifications about how to run them.
+The `std::task::Executor` trait is now called `std::task::Spawn`. We chose to rename the trait to `Spawn` because the functionality exposed by this trait is not the ability to execute, but the ability to spawn.
 
 As a consequence of this renaming, some functions on `Context` were adjusted:
 ```rust
@@ -48,7 +48,7 @@ use futures::spawn;
 spawn!(future).unwrap();
 ```
 
-`spawn_with_handle!` lets you spawn futures with any `Output: Send` type and also lets you await the produced output value:
+`spawn_with_handle!` lets you spawn futures with any `Output: Send` type and returns a future that resolves to the output of the spawned future:
 
 ```rust
 use futures::spawn_with_handle;
@@ -62,10 +62,10 @@ let output = await!(join_handle);
 Should spawning fail, a `SpawnError` error is returned which contains information about why it failed.
 
 So what futures can be spawned? There are some requirements: The future needs to be `Send` and `'static` and the output needs to be `Send`. Here's why:
-- The `'static` lifetime means that the future cannot contain any non-static (exterior) references. This is required so that the spawned task can be run independently to the task that spawns it.
-- The `Send` bounds mean that the future and its output can be safely sent to other operating system threads. This is required so that multithreaded executors can run the spawned task on any operating thread they choose.
+- The `'static` lifetime means that the future cannot contain any non-static references. This is required so that the spawned task can be run independently to the task that spawns it.
+- The `Send` bounds mean that the future and its output can be sent to other threads. This is required so that multithreaded executors can run the spawned task on any thread they choose.
 
-Note: You can execute non-`Send`, non-`'static` futures concurrently via the `join!` macro.
+Note: You can still execute non-`Send`, non-`'static` futures concurrently via the `join!` macro.
 
 ### Spawn methods
 

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -18,7 +18,7 @@ This release introduces the `spawn!` and `spawn_with_handle!` macros for use in 
 spawn!(future).unwrap();
 ```
 
-`spawn_with_handle!` lets you spawn futures with any `Output` type and also lets you await the output:
+`spawn_with_handle!` lets you spawn futures with any `Output: Send` type and also lets you await the produced output value:
 
 ```rust
 let join_handle = spawn_with_handle!(future).unwrap();

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -29,7 +29,7 @@ impl<'a> Context<'a> {
 
     pub fn spawner(&mut self) -> &mut dyn Spawn { /* --snip-- */ }
 
-    pub fn with_spawner<'b, Sp: Spawn>(&'b mut self, spawner: &'b mut Sp) -> Context<'b>
+    pub fn with_spawner<'b, Sp: Spawn>(&'b mut self, spawner: &'b mut Sp) -> Context<'b> { /* --snip-- */ }
 
     // --snip--
 }

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -7,7 +7,7 @@ date:   2018-01-01
 categories: blog
 ---
 
-This release introduces the easy to use `spawn!` and `spawn_with_handle!` macros for use in async functions, closures and blocks. Both let you spawn a task that polls the given future to completion. The task is spawned onto the current context's executor.
+This release introduces the `spawn!` and `spawn_with_handle!` macros for use in async functions, closures and blocks. Both macros let you spawn a task that polls the given future to completion. The task is spawned onto the current context's executor.
 
 `spawn!` lets you spawn futures with `Output = ()`:
 
@@ -68,4 +68,4 @@ This method can't be implemented just yet due to compiler limitations:
 - Arbitrary self types are currently not object-safe: `Future::poll` uses `PinMut` as arbitrary self type. This unfortunately makes it impossible to create trait objects for `Future`. Therefore, `Box<dyn Future>` and `&dyn Future` are *currently* not supported.
 - Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the type inside it and can therfore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
 
-To circumvent these limitations, we currently have `FutureObj` and `Executor::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one heap allocation less because the future is kept on the stack for as long as possible.
+To circumvent these limitations, we currently have `FutureObj` and `Executor::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one fewer heap allocation because the future is kept on the stack for as long as possible.

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -7,9 +7,14 @@ date:   2018-01-01
 categories: blog
 ---
 
-## `pin-utils` crate
+`0.3.0-alpha.3` requires a recent nightly (2018-08-xx or newer):
+```sh
+$ rustup update
+```
 
 ## Compatibility layer
+
+A compatibility layer between 0.3 an 0.1 was developped. It is now possible to convert an 0.3 future into an 0.1 future and vice versa. Similar conversions for streams and sinks are also supported. Additionally it is now possible to run 0.3 futures and async functions on Tokio's executor. We have a dedicated blog post coming up that explains this in more detail.
 
 ## Spawning
 
@@ -77,7 +82,7 @@ Inside `poll`, you can use these methods by accessing the context's spawner via 
 
 ```rust
 fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<T> {
-    cx.spawner().spawn(future);
+    cx.spawner().spawn(future).unwrap();
 }
 ```
 
@@ -97,3 +102,20 @@ This method can't be implemented just yet due to compiler limitations:
 - Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the concrete type behind it and can therefore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
 
 To circumvent these limitations, we currently have `FutureObj` and `Spawn::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one fewer heap allocation because the future is kept on the stack for as long as possible.
+
+## `pin-utils` crate
+
+The pin macros now live in their own crate, the `pin-utils` crate. The macros are general purpose and can be used in any project that uses the pinning API.
+
+The crate includes the macros for (un)pin projections `unsafe_pinned!` and `unsafe_unpinned!` and the macro for stack pinning `pin_mut!`:
+
+```rust
+let foo = Foo { /* ... */ };
+pin_mut!(foo); // PinMut<Foo>
+```
+
+Version `0.1.0-alpha.1` is now available on [crates.io](https://crates.io/crates/pin-utils) and the API docs are available on [docs.rs](https://docs.rs/pin-utils).
+
+## Further changes
+
+A complete list of changes can be found in our [changelog](https://github.com/rust-lang-nursery/futures-rs/blob/master/CHANGELOG.md).

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -20,7 +20,7 @@ A compatibility layer between 0.3 an 0.1 was developped. It is now possible to c
 
 ### `Spawn` trait
 
-The `std::task::Executor` trait is now called `Spawn`. The purpose of the trait remains unchanged - it is to provide a mechanism for spawning tasks. We noticed that in many implementations the responsibilty of spawning tasks is handled by a type that merely sends the task to an associated executor, not by the task executor type itself. Furthermore, it became clear that the former trait name "`Executor`" didn't properly capture the essence of what it means to be an executor. Fundamentally, a task executor is a type that manages the execution of tasks. There exists no fixed set of methods that a trait could define. Instead, each task executor type offers different methods that make sense for its design goals. This is why we chose to rename the trait to `Spawn` to reflect that it merely defines a method for spawning tasks and makes no specifications about how to run them.
+The `std::task::Executor` trait is now called `std::task::Spawn`. The purpose of the trait remains unchanged - it is to provide a mechanism for spawning tasks. We noticed that in many implementations the responsibilty of spawning tasks is handled by a type that merely sends the task to an associated executor, not by the task executor type itself. Furthermore, it became clear that the former trait name "`Executor`" didn't properly capture the essence of what it means to be an executor. Fundamentally, a task executor is a type that manages the execution of tasks. There exists no fixed set of methods that a trait could define. Instead, each task executor type offers different methods that make sense for its design goals. This is why we chose to rename the trait to `Spawn` to reflect that it merely defines a method for spawning tasks and makes no specifications about how to run them.
 
 As a consequence of this renaming, some functions on `Context` were adjusted:
 ```rust
@@ -34,6 +34,7 @@ impl<'a> Context<'a> {
     ...
 }
 ```
+
 ### Spawn macros
 
 This release of futures-rs introduces the `spawn!` and `spawn_with_handle!` macros for use in async functions, closures and blocks. Both macros let you spawn a task that polls the given future to completion. The task is spawned via the current context's spawner.
@@ -42,7 +43,7 @@ This release of futures-rs introduces the `spawn!` and `spawn_with_handle!` macr
 
 ```rust
 #![feature(async_await, await_macro, futures_api)]
-#[macro_use] extern crate futures;
+use futures::spawn;
 
 spawn!(future).unwrap();
 ```
@@ -50,6 +51,8 @@ spawn!(future).unwrap();
 `spawn_with_handle!` lets you spawn futures with any `Output: Send` type and also lets you await the produced output value:
 
 ```rust
+use futures::spawn_with_handle;
+
 let join_handle = spawn_with_handle!(future).unwrap();
 let output = await!(join_handle);
 ```

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -25,6 +25,8 @@ let join_handle = spawn_with_handle!(future).unwrap();
 let output = await!(join_handle);
 ```
 
+`spawn!` is slightly cheaper than `spawn_with_handle!`.
+
 Should spawning fail, a `SpawnError` error is returned which contains information about why it failed.
 
 So what futures can be spawned? There are some requirements: The future needs to be `Send` and `'static` and the output needs to be `Send`. Here's why:

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -1,0 +1,71 @@
+---
+layout: post
+title:  "Futures 0.3.0-alpha.3"
+author: "Josef Brandl"
+author_github: "MajorBreakfast"
+date:   2018-01-01
+categories: blog
+---
+
+This release introduces the easy to use `spawn!` and `spawn_with_handle!` macros for use in async functions, closures and blocks. Both let you spawn a task that polls the given future to completion. The task is spawned onto the current context's executor.
+
+`spawn!` lets you spawn futures with `Output = ()`:
+
+```rust
+#![feature(async_await, await_macro, futures_api)]
+#[macro_use] extern crate futures;
+
+spawn!(future).unwrap();
+```
+
+`spawn_with_handle!` lets you spawn futures with any `Output` type and also lets you await the output:
+
+```rust
+let join_handle = spawn_with_handle!(future).unwrap();
+let output = await!(join_handle);
+```
+
+Should spawning fail, a `SpawnError` error is returned which contains information about why it failed.
+
+So what futures can be spawned? There are some requirements: The future needs to be `Send` and `'static` and the output needs to be `Send`. Here's why:
+- The `'static` lifetime means that the future cannot contain any non-static (exterior) references. This is required so that the spawned task can be run independently to the task that spawns it.
+- The `Send` bounds mean that the future and its output can be safely sent to other operating system threads. This is required so that multithreaded executors can run the spawned task on any operating thread they choose.
+
+Note: You can execute non-`Send`, non-`'static` futures concurrently via the `join!` macro.
+
+For use outside of async functions, there's also something new: The `ExecutorExt` trait. It provides the methods `spawn` and `spawn_with_handle`:
+
+```rust
+use futures::task::ExecutorExt;
+
+// spawn()
+executor.spawn(future).unwrap();
+
+// spawn_with_handle()
+let join_handle = executor.spawn_with_handle(future).unwrap();
+```
+
+Inside `poll`, you can use these methods by accessing the executor via `Context::executor`:
+
+```rust
+fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<T> {
+    cx.executor().spawn(future);
+}
+```
+
+## The plan: `spawn` with `dyn Future`
+
+We plan to eventually replace `ExecutorExt::spawn` with `Executor::spawn`. This method will live directly in the `Executor` trait defined in libcore. It's signature will look like this:
+
+```rust
+fn spawn(
+    &mut self,
+    future: dyn Future<Output = ()> + Send + 'static,
+) -> Result<(), SpawnError>
+```
+
+This method can't be implemented just yet due to compiler limitations:
+- Arbitrary self types are currently not object-safe: `Future::poll` uses `PinMut` as arbitrary self type. This unfortunately makes it impossible to create trait objects for `Future`. Therefore, `Box<dyn Future>` and `&dyn Future` are *currently* not supported.
+- Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the type inside it and can therfore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
+
+To circumvent these limitations, we currently have `FutureObj` and `Executor::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one heap allocation less because the future is kept on the stack for as long as possible.

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -66,6 +66,6 @@ fn spawn(
 
 This method can't be implemented just yet due to compiler limitations:
 - Arbitrary self types are currently not object-safe: `Future::poll` uses `PinMut` as arbitrary self type. This unfortunately makes it impossible to create trait objects for `Future`. Therefore, `Box<dyn Future>` and `&dyn Future` are *currently* not supported.
-- Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the type inside it and can therfore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
+- Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the type inside it and can therefore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
 
 To circumvent these limitations, we currently have `FutureObj` and `Executor::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one fewer heap allocation because the future is kept on the stack for as long as possible.

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -7,7 +7,31 @@ date:   2018-01-01
 categories: blog
 ---
 
-This release introduces the `spawn!` and `spawn_with_handle!` macros for use in async functions, closures and blocks. Both macros let you spawn a task that polls the given future to completion. The task is spawned onto the current context's executor.
+## `pin-utils` crate
+
+## Compatibility layer
+
+## Spawning
+
+### `Spawn` trait
+
+The `std::task::Executor` trait is now called `Spawn`. The purpose of the trait remains unchanged - it is to provide a mechanism for spawning tasks. We noticed that in many implementations the responsibilty of spawning tasks is handled by a type that merely sends the task to an associated executor, not by the task executor type itself. Furthermore, it became clear that the former trait name "`Executor`" didn't properly capture the essence of what it means to be an executor. Fundamentally, a task executor is a type that manages the execution of tasks. There exists no fixed set of methods that a trait could define. Instead, each task executor type offers different methods that make sense for its design goals. This is why we chose to rename the trait to `Spawn` to reflect that it merely defines a method for spawning tasks and makes no specifications about how to run them.
+
+As a consequence of this renaming, some functions on `Context` were adjusted:
+```rust
+impl<'a> Context<'a> {
+    pub fn new(local_waker: &'a LocalWaker, spawner: &'a mut dyn Spawn) -> Context<'a> { ... }
+
+    pub fn spawner(&mut self) -> &mut dyn Spawn { ... }
+
+    pub fn with_spawner<'b, Sp: Spawn>(&'b mut self, spawner: &'b mut Sp) -> Context<'b>
+
+    ...
+}
+```
+### Spawn macros
+
+This release of futures-rs introduces the `spawn!` and `spawn_with_handle!` macros for use in async functions, closures and blocks. Both macros let you spawn a task that polls the given future to completion. The task is spawned via the current context's spawner.
 
 `spawn!` lets you spawn futures with `Output = ()`:
 
@@ -35,29 +59,31 @@ So what futures can be spawned? There are some requirements: The future needs to
 
 Note: You can execute non-`Send`, non-`'static` futures concurrently via the `join!` macro.
 
-For use outside of async functions, there's also something new: The `ExecutorExt` trait. It provides the methods `spawn` and `spawn_with_handle`:
+### Spawn methods
+
+For use outside of async functions, there's also something new: The `SpawnExt` trait. It provides the methods `spawn` and `spawn_with_handle`:
 
 ```rust
-use futures::task::ExecutorExt;
+use futures::task::SpawnExt;
 
 // spawn()
-executor.spawn(future).unwrap();
+spawner.spawn(future).unwrap();
 
 // spawn_with_handle()
-let join_handle = executor.spawn_with_handle(future).unwrap();
+let join_handle = spawner.spawn_with_handle(future).unwrap();
 ```
 
-Inside `poll`, you can use these methods by accessing the executor via `Context::executor`:
+Inside `poll`, you can use these methods by accessing the context's spawner via `Context::spawner`:
 
 ```rust
 fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<T> {
-    cx.executor().spawn(future);
+    cx.spawner().spawn(future);
 }
 ```
 
-## The plan: `spawn` with `dyn Future`
+### The plan: `spawn` with `dyn Future`
 
-We plan to eventually replace `ExecutorExt::spawn` with `Executor::spawn`. This method will live directly in the `Executor` trait defined in libcore. It's signature will look like this:
+We plan to eventually replace `SpawnExt::spawn` with `Spawn::spawn`. This method will live directly in the `Spawn` trait defined in libcore. It's signature will look like this:
 
 ```rust
 fn spawn(
@@ -70,4 +96,4 @@ This method can't be implemented just yet due to compiler limitations:
 - Arbitrary self types are currently not object-safe: `Future::poll` uses `PinMut` as arbitrary self type. This unfortunately makes it impossible to create trait objects for `Future`. Therefore, `Box<dyn Future>` and `&dyn Future` are *currently* not supported.
 - Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the concrete type behind it and can therefore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
 
-To circumvent these limitations, we currently have `FutureObj` and `Executor::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one fewer heap allocation because the future is kept on the stack for as long as possible.
+To circumvent these limitations, we currently have `FutureObj` and `Spawn::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one fewer heap allocation because the future is kept on the stack for as long as possible.

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -68,6 +68,6 @@ fn spawn(
 
 This method can't be implemented just yet due to compiler limitations:
 - Arbitrary self types are currently not object-safe: `Future::poll` uses `PinMut` as arbitrary self type. This unfortunately makes it impossible to create trait objects for `Future`. Therefore, `Box<dyn Future>` and `&dyn Future` are *currently* not supported.
-- Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the type inside it and can therefore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
+- Unsized rvalues are not yet available: Trait objects (`dyn Trait`) are `!Sized` because the size of a trait object depends on the size of the concrete type behind it and can therefore only be known at runtime. Currently we often use `Box<dyn Trait>` which stores the trait object on the heap to circumvent that. The unsized rvalues feature will make it possible to store `!Sized` types on the stack.
 
 To circumvent these limitations, we currently have `FutureObj` and `Executor::spawn_obj`. These are, however, just a temporary solution until we can introduce the planned `spawn` method. The planned `spawn` method will make it possible to have one fewer heap allocation because the future is kept on the stack for as long as possible.

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -25,7 +25,7 @@ let join_handle = spawn_with_handle!(future).unwrap();
 let output = await!(join_handle);
 ```
 
-`spawn!` is slightly cheaper than `spawn_with_handle!`.
+`spawn!` is slightly cheaper than `spawn_with_handle!` since it doesn't need to provide a way to get the output.
 
 Should spawning fail, a `SpawnError` error is returned which contains information about why it failed.
 

--- a/_posts/2018-01-01-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-01-01-futures-0.3.0-alpha.3.md
@@ -25,13 +25,13 @@ The `std::task::Executor` trait is now called `std::task::Spawn`. The purpose of
 As a consequence of this renaming, some functions on `Context` were adjusted:
 ```rust
 impl<'a> Context<'a> {
-    pub fn new(local_waker: &'a LocalWaker, spawner: &'a mut dyn Spawn) -> Context<'a> { ... }
+    pub fn new(local_waker: &'a LocalWaker, spawner: &'a mut dyn Spawn) -> Context<'a> { /* --snip-- */ }
 
-    pub fn spawner(&mut self) -> &mut dyn Spawn { ... }
+    pub fn spawner(&mut self) -> &mut dyn Spawn { /* --snip-- */ }
 
     pub fn with_spawner<'b, Sp: Spawn>(&'b mut self, spawner: &'b mut Sp) -> Context<'b>
 
-    ...
+    // --snip--
 }
 ```
 

--- a/_posts/2018-08-15-futures-0.3.0-alpha.3.md
+++ b/_posts/2018-08-15-futures-0.3.0-alpha.3.md
@@ -3,11 +3,11 @@ layout: post
 title:  "Futures 0.3.0-alpha.3"
 author: "Josef Brandl"
 author_github: "MajorBreakfast"
-date:   2018-01-01
+date:   2018-08-15
 categories: blog
 ---
 
-`0.3.0-alpha.3` requires a recent nightly (2018-08-xx or newer):
+`0.3.0-alpha.3` requires a recent nightly (2018-08-13 or newer):
 ```sh
 $ rustup update
 ```
@@ -122,3 +122,5 @@ Version `0.1.0-alpha.1` is now available on [crates.io](https://crates.io/crates
 ## Further changes
 
 A complete list of changes can be found in our [changelog](https://github.com/rust-lang-nursery/futures-rs/blob/master/CHANGELOG.md).
+
+A big thanks goes to every one who contributed to this release! This includes [@tinaun](https://github.com/tinaun), [@Nemo157](https://github.com/Nemo157), [@cramertj](https://github.com/cramertj) and [@MajorBreakfast](https://github.com/MajorBreakfast) and our new contributors [@gbonik](https://github.com/gbonik) and [@dbcfd](https://github.com/dbcfd)!


### PR DESCRIPTION
Do not merge.

[rendered](https://github.com/MajorBreakfast/futures-rs/blob/blog-alpha-3/_posts/2018-01-01-futures-0.3.0-alpha.3.md)

Should we make this a standalone blog post or include it in the alpha 3 announcement? (Let's not rush the release of alpha 3, though)