### PR TITLE
Enable Travis CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 rust:
   - nightly
 sudo: false
+cache: cargo
 
 matrix:
   include:


### PR DESCRIPTION
Compare https://travis-ci.com/Nemo157/futures-rs/builds/80862596 and https://travis-ci.com/Nemo157/futures-rs/builds/80863382, the first was the first build for this branch with no cache, the second was a rebuild of the same commit using the cache from the first.

Overall it took more processing time total (23:24 vs 26:18), but the longest builds were speed up by not having to re-download and build the dependencies so the wall clock time was lower (7:16 vs 6:35).