### PR TITLE
Add Eager Select

### DIFF
--- a/futures-util/src/stream/eager_select.rs
+++ b/futures-util/src/stream/eager_select.rs
@@ -1,0 +1,80 @@
+use crate::stream::{StreamExt, Fuse};
+use core::marker::Unpin;
+use core::mem::PinMut;
+use futures_core::stream::Stream;
+use futures_core::task::{self, Poll};
+
+/// An adapter for merging the output of two streams.
+///
+/// The merged stream produces items from either of the underlying streams as
+/// they become available, and the streams are polled in a round-robin fashion.
+///
+/// Will complete as soon as any stream completes
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct EagerSelect<St1, St2> {
+    stream1: Fuse<St1>,
+    stream2: Fuse<St2>,
+    flag: bool,
+}
+
+impl<St1: Unpin, St2: Unpin> Unpin for EagerSelect<St1, St2> {}
+
+impl<St1, St2> EagerSelect<St1, St2>
+    where St1: Stream,
+          St2: Stream<Item = St1::Item>
+{
+    pub(super) fn new(stream1: St1, stream2: St2) -> EagerSelect<St1, St2> {
+        EagerSelect {
+            stream1: stream1.fuse(),
+            stream2: stream2.fuse(),
+            flag: false,
+        }
+    }
+}
+
+impl<St1, St2> Stream for EagerSelect<St1, St2>
+    where St1: Stream,
+          St2: Stream<Item = St1::Item>
+{
+    type Item = St1::Item;
+
+    fn poll_next(
+        self: PinMut<Self>,
+        cx: &mut task::Context
+    ) -> Poll<Option<St1::Item>> {
+        let EagerSelect { flag, stream1, stream2 } =
+            unsafe { PinMut::get_mut_unchecked(self) };
+        let stream1 = unsafe { PinMut::new_unchecked(stream1) };
+        let stream2 = unsafe { PinMut::new_unchecked(stream2) };
+
+        if *flag {
+            poll_inner(flag, stream1, stream2, cx)
+        } else {
+            poll_inner(flag, stream2, stream1, cx)
+        }
+    }
+}
+
+fn poll_inner<St1, St2>(
+    flag: &mut bool,
+    a: PinMut<St1>,
+    b: PinMut<St2>,
+    cx: &mut task::Context
+) -> Poll<Option<St1::Item>>
+    where St1: Stream, St2: Stream<Item = St1::Item>
+{
+    if let Poll::Ready(poll_result) = a.poll_next(cx) {
+        return Poll::Ready(poll_result)
+    }
+
+    match b.poll_next(cx) {
+        Poll::Pending => Poll::Pending,
+        Poll::Ready(Some(item)) => {
+            // give the other stream a chance to go first next time as we pulled something off `b`.
+            *flag = !*flag;
+            Poll::Ready(Some(item))
+        }
+        Poll::Ready(None) => Poll::Ready(None),
+    }
+}

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -71,6 +71,9 @@ pub use self::poll_fn::{poll_fn, PollFn};
 mod select;
 pub use self::select::Select;
 
+mod eager_select;
+pub use self::eager_select::EagerSelect;
+
 mod skip;
 pub use self::skip::Skip;
 
@@ -873,6 +876,21 @@ pub trait StreamExt: Stream {
               Self: Sized,
     {
         Select::new(self, other)
+    }
+
+    /// Creates a stream that selects the next element from either this stream
+    /// or the provided one, whichever is ready first.
+    ///
+    /// This combinator will attempt to pull items from both streams. Each
+    /// stream will be polled in a round-robin fashion, and whenever a stream is
+    /// ready to yield an item that item is yielded.
+    ///
+    /// This will complete once one of the streams completes
+    fn eager_select<St>(self, other: St) -> EagerSelect<Self, St>
+        where St: Stream<Item = Self::Item>,
+              Self: Sized,
+    {
+        EagerSelect::new(self, other)
     }
 
     /// A future that completes after the given stream has been fully processed

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -313,7 +313,7 @@ pub mod stream {
         unfold, Unfold,
 
         StreamExt,
-        Chain, Concat, Filter, FilterMap, Flatten, Fold, Forward, ForEach, Fuse,
+        Chain, Concat, EagerSelect, Filter, FilterMap, Flatten, Fold, Forward, ForEach, Fuse,
         StreamFuture, Inspect, Map, Next, Peekable, Select, Skip, SkipWhile,
         Take, TakeWhile, Then, Zip
     };

--- a/futures/tests_disabled/all.rs
+++ b/futures/tests_disabled/all.rs
@@ -377,6 +377,106 @@ fn select2() {
 }
 
 #[test]
+fn eager_select() {
+    assert_done(|| f_ok(2).select(empty()).then(unselect), Ok(2));
+    assert_done(|| empty().select(f_ok(2)).then(unselect), Ok(2));
+    assert_done(|| f_err(2).select(empty()).then(unselect), Err(2));
+    assert_done(|| empty().select(f_err(2)).then(unselect), Err(2));
+
+    assert_done(|| {
+        f_ok(1).select(f_ok(2))
+            .map_err(|_| 0)
+            .and_then(|either_tup| {
+                let (a, b) = either_tup.into_inner();
+                b.map(move |b| a + b)
+            })
+    }, Ok(3));
+
+    // Finish one half of a select and then fail the second, ensuring that we
+    // get the notification of the second one.
+    {
+        let ((a, b), (c, d)) = (oneshot::channel::<i32>(), oneshot::channel::<i32>());
+        let f = b.select(d);
+        let (tx, rx) = channel();
+        f.map(move |r| tx.send(r).unwrap()).forget();
+        a.send(1).unwrap();
+        let (val, next) = rx.recv().unwrap().into_inner();
+        assert_eq!(val, 1);
+        let (tx, rx) = channel();
+        next.map_err(move |_r| tx.send(2).unwrap()).forget();
+        assert_eq!(rx.try_recv().err().unwrap(), TryRecvError::Empty);
+        drop(c);
+        assert_eq!(rx.recv().unwrap(), 2);
+    }
+
+    // Fail the second half and ensure that we see the first one finish
+    {
+        let ((a, b), (c, d)) = (oneshot::channel::<i32>(), oneshot::channel::<i32>());
+        let f = b.select(d);
+        let (tx, rx) = channel();
+        f.map_err(move |r| tx.send((1, r.into_inner().1)).unwrap()).forget();
+        drop(c);
+        let (val, next) = rx.recv().unwrap();
+        assert_eq!(val, 1);
+        let (tx, rx) = channel();
+        next.map(move |r| tx.send(r).unwrap()).forget();
+        assert_eq!(rx.try_recv().err().unwrap(), TryRecvError::Empty);
+        a.send(2).unwrap();
+        assert_eq!(rx.recv().unwrap(), 2);
+    }
+
+    // Cancelling the first half should cancel the second
+    {
+        let ((_a, b), (_c, d)) = (oneshot::channel::<i32>(), oneshot::channel::<i32>());
+        let ((btx, brx), (dtx, drx)) = (channel(), channel());
+        let b = b.map(move |v| { btx.send(v).unwrap(); v });
+        let d = d.map(move |v| { dtx.send(v).unwrap(); v });
+        let f = b.select(d);
+        drop(f);
+        assert!(drx.recv().is_err());
+        assert!(brx.recv().is_err());
+    }
+
+    // Cancel after a schedule
+    {
+        let ((_a, b), (_c, d)) = (oneshot::channel::<i32>(), oneshot::channel::<i32>());
+        let ((btx, brx), (dtx, drx)) = (channel(), channel());
+        let b = b.map(move |v| { btx.send(v).unwrap(); v });
+        let d = d.map(move |v| { dtx.send(v).unwrap(); v });
+        let mut f = b.select(d);
+        let _res = noop_waker_cx(|cx| f.poll(cx));
+        drop(f);
+        assert!(drx.recv().is_err());
+        assert!(brx.recv().is_err());
+    }
+
+    // Cancel propagates
+    {
+        let ((a, b), (_c, d)) = (oneshot::channel::<i32>(), oneshot::channel::<i32>());
+        let ((btx, brx), (dtx, drx)) = (channel(), channel());
+        let b = b.map(move |v| { btx.send(v).unwrap(); v });
+        let d = d.map(move |v| { dtx.send(v).unwrap(); v });
+        let (tx, rx) = channel();
+        b.select(d).map(move |_| tx.send(()).unwrap()).forget();
+        drop(a);
+        assert!(drx.recv().is_err());
+        assert!(brx.recv().is_err());
+        assert!(rx.recv().is_err());
+    }
+
+    // Cancel on early drop
+    {
+        let (tx, rx) = channel();
+        let f = f_ok(1).select(empty::<_, ()>().map(move |()| {
+            tx.send(()).unwrap();
+            1
+        }));
+        drop(f);
+        assert!(rx.recv().is_err());
+    }
+}
+
+#[test]
 fn option() {
     assert_eq!(Ok(Some(())), block_on(Some(ok::<(), ()>(())).into_future()));
     assert_eq!(Ok::<_, ()>(None::<()>), block_on(None::<FutureResult<(), ()>>.into_future()));


### PR DESCRIPTION
Add EagerSelect combinator, and eager_select stream operation. Will perform the same functionality as select, until one of the streams completes, at which point the combinator will complete.

Addresses https://github.com/rust-lang-nursery/futures-rs/issues/1171