### PR TITLE
Update size assertions

### DIFF
--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -84,7 +84,7 @@ fn select_size() {
             ready => {},
         }
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 40);
+    assert_eq!(::std::mem::size_of_val(&fut), 24);
 
     let fut = async {
         let mut ready1 = future::ready(0i32);
@@ -94,7 +94,7 @@ fn select_size() {
             ready2 => {},
         }
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 56);
+    assert_eq!(::std::mem::size_of_val(&fut), 40);
 }
 
 #[test]
@@ -103,14 +103,14 @@ fn join_size() {
         let ready = future::ready(0i32);
         join!(ready)
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 32);
+    assert_eq!(::std::mem::size_of_val(&fut), 16);
 
     let fut = async {
         let ready1 = future::ready(0i32);
         let ready2 = future::ready(0i32);
         join!(ready1, ready2)
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 64);
+    assert_eq!(::std::mem::size_of_val(&fut), 44);
 }
 
 #[test]
@@ -119,14 +119,14 @@ fn try_join_size() {
         let ready = future::ready(Ok::<i32, i32>(0));
         try_join!(ready)
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 32);
+    assert_eq!(::std::mem::size_of_val(&fut), 16);
 
     let fut = async {
         let ready1 = future::ready(Ok::<i32, i32>(0));
         let ready2 = future::ready(Ok::<i32, i32>(0));
         try_join!(ready1, ready2)
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 64);
+    assert_eq!(::std::mem::size_of_val(&fut), 44);
 }
 
 


### PR DESCRIPTION
@cramertj Should this be changed to `<=` to detect only regressions?