### PR TITLE
Exclude futures-executor-preview from Travis Rustdoc check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,9 @@ matrix:
     - name: cargo doc
       rust: nightly
       script:
-        - RUSTDOCFLAGS=-Dwarnings cargo doc --all --exclude futures-preview
+        - RUSTDOCFLAGS=-Dwarnings cargo doc --all
+            --exclude futures-preview
+            --exclude futures-executor-preview
         - cargo doc
 
 script:


### PR DESCRIPTION
This is an interim solution. I've posted [a comment](https://github.com/rust-lang/rust/issues/43466#issuecomment-410650216) to the intra doc links issue.