### PR TITLE
Adjust docs on select

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -868,6 +868,9 @@ pub trait StreamExt: Stream {
     /// This combinator will attempt to pull items from both streams. Each
     /// stream will be polled in a round-robin fashion, and whenever a stream is
     /// ready to yield an item that item is yielded.
+    ///
+    /// When either this stream or the provided one ends, the remaining stream will be polled to
+    /// completion or error. The stream that ended will no longer be polled.
     fn select<St>(self, other: St) -> Select<Self, St>
         where St: Stream<Item = Self::Item>,
               Self: Sized,

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -870,7 +870,7 @@ pub trait StreamExt: Stream {
     /// ready to yield an item that item is yielded.
     ///
     /// When either this stream or the provided one ends, the remaining stream will be polled to
-    /// completion or error. The stream that ended will no longer be polled.
+    /// completion. The stream that ended will no longer be polled.
     fn select<St>(self, other: St) -> Select<Self, St>
         where St: Stream<Item = Self::Item>,
               Self: Sized,

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -8,6 +8,9 @@ use futures_core::task::{self, Poll};
 ///
 /// The merged stream produces items from either of the underlying streams as
 /// they become available, and the streams are polled in a round-robin fashion.
+///
+/// When either this stream or the provided one ends, the remaining stream will be polled to
+/// completion or error. The stream that ended will no longer be polled.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Select<St1, St2> {

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -10,7 +10,7 @@ use futures_core::task::{self, Poll};
 /// they become available, and the streams are polled in a round-robin fashion.
 ///
 /// When either this stream or the provided one ends, the remaining stream will be polled to
-/// completion or error. The stream that ended will no longer be polled.
+/// completion. The stream that ended will no longer be polled.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Select<St1, St2> {


### PR DESCRIPTION
Related to https://github.com/rust-lang-nursery/futures-rs/pull/1172, adding to select docs behavior when one stream ends.

Docs for zip specify this behavior, so no changes needed there.