### PR TITLE
Change doc URLs to .../futures-api-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures/">
+  <a href="https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures/">
     Documentation
   </a> | <a href="https://rust-lang-nursery.github.io/futures-rs/">
     Website

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_channel"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_channel"
 description = """
 Channels for asynchronous communication using futures-rs.
 """

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_channel")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_channel")]
 
 macro_rules! if_std {
     ($($i:item)*) => ($(

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_core"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_core"
 description = """
 The core traits and types in for the `futures` library.
 """

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_core")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_core")]
 
 #[doc(hidden)] pub use crate::future::Future;
 #[doc(hidden)] pub use crate::future::TryFuture;

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_executor"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_executor"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_executor")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_executor")]
 
 macro_rules! if_std {
     ($($i:item)*) => ($(

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_io"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_io"
 description = """
 The `AsyncRead` and `AsyncWrite` traits for the futures-rs library.
 """

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_io")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_io")]
 
 #![feature(futures_api)]
 

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_sink"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_sink"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![no_std]
 #![warn(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_sink")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_sink")]
 
 #![feature(pin, arbitrary_self_types, futures_api)]
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_util"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_util"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(bare_trait_objects)]
 #![allow(unknown_lints)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures_util")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures_util")]
 
 macro_rules! if_std {
     ($($i:item)*) => ($(

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -10,7 +10,7 @@ readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -28,7 +28,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.2/futures")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.2/futures")]
 
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "nightly", feature(use_extern_macros))]


### PR DESCRIPTION
Shortly after I published alpha 2 I realized that I should have called the repo `futures-api-docs`, not `futures-doc`. I'd like to change this now