### PR TITLE
Build crates with minimal versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       rust: nightly
       script:
         - cargo bench --all
-        - cargo bench -p futures-util-preview --features=bench
+        - cargo bench --manifest-path futures-util/Cargo.toml --features=bench
 
     - name: cargo build --no-default-features
       rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
     - name: cargo test
       os: linux
 
+    - name: cargo test (with minimal versions)
+      os: linux
+      script:
+        - cargo update -Zminimal-versions
+        - cargo test
+
     - name: cargo clippy
       rust: nightly
       install:
@@ -39,6 +45,18 @@ matrix:
     - name: cargo build --all-features
       rust: nightly
       script:
+        - cargo build --manifest-path futures/Cargo.toml --all-features
+        - cargo build --manifest-path futures-core/Cargo.toml --all-features
+        - cargo build --manifest-path futures-channel/Cargo.toml --all-features
+        - cargo build --manifest-path futures-executor/Cargo.toml --all-features
+        - cargo build --manifest-path futures-io/Cargo.toml --all-features
+        - cargo build --manifest-path futures-sink/Cargo.toml --all-features
+        - cargo build --manifest-path futures-util/Cargo.toml --all-features
+
+    - name: cargo build --all-features (with minimal versions)
+      rust: nightly
+      script:
+        - cargo update -Zminimal-versions
         - cargo build --manifest-path futures/Cargo.toml --all-features
         - cargo build --manifest-path futures-core/Cargo.toml --all-features
         - cargo build --manifest-path futures-channel/Cargo.toml --all-features

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -24,7 +24,7 @@ default = ["std"]
 futures-core-preview = { path = "../futures-core", version = "0.3.0-alpha.2", default-features = false}
 futures-util-preview = { path = "../futures-util", version = "0.3.0-alpha.2", default-features = false}
 futures-channel-preview = { path = "../futures-channel", version = "0.3.0-alpha.2", default-features = false}
-num_cpus = { version = "1.0", optional = true }
+num_cpus = { version = "1.8.0", optional = true }
 lazy_static = { version = "1.1.0", optional = true }
 pin-utils = "0.1.0-alpha.1"
 


### PR DESCRIPTION
Follow-up PR to https://github.com/rust-lang-nursery/futures-rs/pull/1189

The CI should break if we're relying on features not available in the minimal versions we specify.

cc @cramertj 