### PR TITLE
Adjust Docs on Select

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -868,12 +868,16 @@ pub trait StreamExt: Stream {
         Chunks::new(self, capacity)
     }
 
-    /// Creates a stream that selects the next element from either this stream
-    /// or the provided one, whichever is ready first.
-    ///
     /// This combinator will attempt to pull items from both streams. Each
     /// stream will be polled in a round-robin fashion, and whenever a stream is
     /// ready to yield an item that item is yielded.
+    ///
+    /// After one of the two input stream completes, the remaining one will be
+    /// polled exclusively. The returned stream completes when both input
+    /// streams have completed.
+    ///
+    /// Note that this method consumes both streams and returns a wrapped
+    /// version of them.
     fn select<St>(self, other: St) -> Select<Self, St>
         where St: Stream<Item = Self::Item>,
               Self: Sized,

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -6,8 +6,13 @@ use futures_core::task::{self, Poll};
 
 /// An adapter for merging the output of two streams.
 ///
-/// The merged stream produces items from either of the underlying streams as
-/// they become available, and the streams are polled in a round-robin fashion.
+/// The merged stream will attempt to pull items from both input streams. Each
+/// stream will be polled in a round-robin fashion, and whenever a stream is
+/// ready to yield an item that item is yielded.
+///
+/// After one of the two input stream completes, the remaining one will be
+/// polled exclusively. The returned stream completes when both input
+/// streams have completed.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Select<St1, St2> {


### PR DESCRIPTION
Adjust documentation on StreamExt select combinator to indicate behavior when
one of the stream ends early.

Squashed, updated version of https://github.com/rust-lang-nursery/futures-rs/pull/1183 after comments.

@MajorBreakfast @cramertj 