### PR TITLE
Add aliases for result-wrapping `futures::ready`

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -26,7 +26,7 @@ mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
 
 mod ready;
-pub use self::ready::{ready, Ready};
+pub use self::ready::{ready, ok, err, Ready};
 
 // Combinators
 mod flatten;

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -37,3 +37,37 @@ impl<T> Future for Ready<T> {
 pub fn ready<T>(t: T) -> Ready<T> {
     Ready(Some(t))
 }
+
+/// Create a future that is immediately ready with a success value.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(async_await, await_macro, futures_api)]
+/// # futures::executor::block_on(async {
+/// use futures::future;
+///
+/// let a = future::ok::<i32, i32>(1);
+/// assert_eq!(await!(a), Ok(1));
+/// # });
+/// ```
+pub fn ok<T, E>(t: T) -> Ready<Result<T, E>> {
+    Ready(Some(Ok(t)))
+}
+
+/// Create a future that is immediately ready with an error value.
+///
+/// # Examples
+///
+/// ```
+/// #![feature(async_await, await_macro, futures_api)]
+/// # futures::executor::block_on(async {
+/// use futures::future;
+///
+/// let a = future::err::<i32, i32>(1);
+/// assert_eq!(await!(a), Err(1));
+/// # });
+/// ```
+pub fn err<T, E>(err: E) -> Ready<Result<T, E>> {
+    Ready(Some(Err(err)))
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -189,7 +189,7 @@ pub mod future {
         lazy, Lazy,
         maybe_done, MaybeDone,
         poll_fn, PollFn,
-        ready, Ready,
+        ready, ok, err, Ready,
 
         OptionFuture,
 


### PR DESCRIPTION
These are common enough that they deserve an alias, IMO.

cc @seanmonstar 