### PR TITLE
feat: Avoid cloning the output of Shared on the last poll

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -586,8 +586,9 @@ pub trait FutureExt: Future {
     /// Create a cloneable handle to this future where all handles will resolve
     /// to the same result.
     ///
-    /// The shared() method provides a method to convert any future into a
-    /// cloneable future. It enables a future to be polled by multiple threads.
+    /// The `shared` combinator method provides a method to convert any future
+    /// into a cloneable future. It enables a future to be polled by multiple
+    /// threads.
     ///
     /// This method is only available when the `std` feature of this
     /// library is activated, and it is activated by default.

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -630,6 +630,7 @@ pub trait FutureExt: Future {
     fn shared(self) -> Shared<Self>
     where
         Self: Sized,
+        Self::Output: Clone,
     {
         Shared::new(self)
     }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -1,5 +1,5 @@
 use crate::task::local_waker_ref_from_nonlocal;
-use futures_core::future::Future;
+use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{LocalWaker, Poll, Wake, Waker};
 use slab::Slab;
 use std::cell::UnsafeCell;
@@ -171,6 +171,12 @@ where
             FutureOrOutput::Output(ref item) => &item,
             FutureOrOutput::Future(_) => unreachable!(),
         }
+    }
+}
+
+impl<Fut: Future> FusedFuture for Shared<Fut> {
+    fn is_terminated(&self) -> bool {
+        self.inner.is_none()
     }
 }
 

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -244,7 +244,7 @@ where
             }
         };
 
-        if let Some(_) = Arc::get_mut(&mut this.inner) {
+        if Arc::get_mut(&mut this.inner).is_some() {
             unsafe {
                 *this.inner.future_or_output.get() = FutureOrOutput::Done;
             }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::task::local_waker_from_nonlocal;
 
 /// A future that is cloneable and can be polled in multiple threads.
-/// Use `Future::shared()` method to convert any future into a `Shared` future.
+/// Use [`FutureExt::shared()`](crate::FutureExt::shared) method to convert any future into a `Shared` future.
 #[must_use = "futures do nothing unless polled"]
 pub struct Shared<Fut: Future> {
     inner: Option<Arc<Inner<Fut>>>,
@@ -93,9 +93,9 @@ where
     Fut: Future,
     Fut::Output: Clone,
 {
-    /// Returns Some containing a reference to this `Shared`'s output if it has
-    /// already been computed by a clone or `None` if it hasn't been computed yet
-    /// or if this `Shared` already returned its output from poll.
+    /// Returns Some containing a reference to this [`Shared`](crate::future::Shared)'s output if it has
+    /// already been computed by a clone or [`None`](std::option::Option::None) if it hasn't been computed yet
+    /// or if this [`Shared`](std::option::Option::Some) already returned its output from poll.
     pub fn peek(&self) -> Option<&Fut::Output> {
         match self.inner.as_ref().map(|inner| inner.notifier.state.load(SeqCst)) {
             Some(COMPLETE) => unsafe { Some(self.inner().get_output()) },

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -93,10 +93,9 @@ where
     Fut: Future,
     Fut::Output: Clone,
 {
-    /// If any clone of this `Shared` has completed execution and there are still at least one
-    /// clone of this `Shared` alive then, returns its result immediately
-    /// without blocking. Otherwise, returns None without triggering the work represented by
-    /// this `Shared`.
+    /// Returns Some containing a reference to this `Shared`'s output if it has
+    /// already been computed by a clone or `None` if it hasn't been computed yet
+    /// or if this `Shared` already returned its output from poll.
     pub fn peek(&self) -> Option<&Fut::Output> {
         match self.inner.as_ref().map(|inner| inner.notifier.state.load(SeqCst)) {
             Some(COMPLETE) => unsafe { Some(self.inner().get_output()) },

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -114,7 +114,7 @@ fn peek() {
     spawn.spawn_local_obj(LocalFutureObj::new(Box::new(f1.map(|_| ())))).unwrap();
     local_pool.run();
     for _ in 0..2 {
-        assert_eq!(f2.peek().unwrap(), Ok(42));
+        assert_eq!(*f2.peek().unwrap(), Ok(42));
     }
 }
 


### PR DESCRIPTION
If a `Shared` instance knows that it is the last instance it can now
move the output out and return it without cloning.

Followup of #1093