### PR TITLE
Rename FutureTestExt::delay to pending_once

### DIFF
--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -18,7 +18,7 @@ pub fn assert_is_unpin_stream<S: Stream + Unpin>(_: &mut S) {}
 /// };
 /// use pin_utils::pin_mut;
 ///
-/// let mut stream = stream::once((async { 5 }).delay());
+/// let mut stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
 ///
 /// assert_stream_pending!(stream);
@@ -55,7 +55,7 @@ macro_rules! assert_stream_pending {
 /// };
 /// use pin_utils::pin_mut;
 ///
-/// let mut stream = stream::once((async { 5 }).delay());
+/// let mut stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
 ///
 /// assert_stream_pending!(stream);
@@ -98,7 +98,7 @@ macro_rules! assert_stream_next {
 /// };
 /// use pin_utils::pin_mut;
 ///
-/// let mut stream = stream::once((async { 5 }).delay());
+/// let mut stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
 ///
 /// assert_stream_pending!(stream);

--- a/futures-test/src/future/mod.rs
+++ b/futures-test/src/future/mod.rs
@@ -1,8 +1,8 @@
 //! Additional combinators for testing futures.
 
-mod delay;
+mod pending_once;
 
-use self::delay::Delayed;
+use self::pending_once::PendingOnce;
 use futures_core::future::Future;
 use futures_executor;
 use std::thread;
@@ -10,7 +10,7 @@ use std::thread;
 /// Additional combinators for testing futures.
 pub trait FutureTestExt: Future {
     /// Introduces one [`Poll::Pending`](futures_core::task::Poll::Pending)
-    /// before polling the given future
+    /// before polling the given future.
     ///
     /// # Examples
     ///
@@ -22,7 +22,7 @@ pub trait FutureTestExt: Future {
     /// use futures_test::future::FutureTestExt;
     /// use pin_utils::pin_mut;
     ///
-    /// let future = (async { 5 }).delay();
+    /// let future = (async { 5 }).pending_once();
     /// pin_mut!(future);
     ///
     /// let cx = &mut task::no_spawn_context();
@@ -30,11 +30,11 @@ pub trait FutureTestExt: Future {
     /// assert_eq!(future.poll_unpin(cx), Poll::Pending);
     /// assert_eq!(future.poll_unpin(cx), Poll::Ready(5));
     /// ```
-    fn delay(self) -> Delayed<Self>
+    fn pending_once(self) -> PendingOnce<Self>
     where
         Self: Sized,
     {
-        delay::Delayed::new(self)
+        pending_once::PendingOnce::new(self)
     }
 
     /// Runs this future on a dedicated executor running in a background thread.

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -6,16 +6,17 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// Combinator that guarantees one [`Poll::Pending`] before polling its inner
 /// future.
 ///
-/// This is created by the [`FutureTestExt::delay`](super::FutureTestExt::delay)
+/// This is created by the
+/// [`FutureTestExt::pending_once`](super::FutureTestExt::pending_once)
 /// method.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
-pub struct Delayed<Fut: Future> {
+pub struct PendingOnce<Fut: Future> {
     future: Fut,
     polled_before: bool,
 }
 
-impl<Fut: Future> Delayed<Fut> {
+impl<Fut: Future> PendingOnce<Fut> {
     unsafe_pinned!(future: Fut);
     unsafe_unpinned!(polled_before: bool);
 
@@ -27,7 +28,7 @@ impl<Fut: Future> Delayed<Fut> {
     }
 }
 
-impl<Fut: Future> Future for Delayed<Fut> {
+impl<Fut: Future> Future for PendingOnce<Fut> {
     type Output = Fut::Output;
 
     fn poll(

--- a/futures/tests/unfold.rs
+++ b/futures/tests/unfold.rs
@@ -12,9 +12,9 @@ use futures_test::future::FutureTestExt;
 fn unfold1() {
     let mut stream = stream::unfold(0, |state| {
         if state <= 2 {
-            future::ready(Some((state * 2, state + 1))).delay()
+            future::ready(Some((state * 2, state + 1))).pending_once()
         } else {
-            future::ready(None).delay()
+            future::ready(None).pending_once()
         }
     });
 


### PR DESCRIPTION
Now that we're making this combinator public API, we should consider renaming it to `pending_once`. `delay` always makes me think about a timespan.