### PR TITLE
Async Context Example #1203

### DIFF
--- a/futures/examples/functional.rs
+++ b/futures/examples/functional.rs
@@ -1,0 +1,57 @@
+#![feature(futures_api, async_await, await_macro)]
+#[macro_use] extern crate futures;
+
+use futures::{
+    channel::mpsc,
+    executor, //standard executors to provide a context for futures and streams
+    futures::ready,
+    StreamExt
+};
+
+fn main() {
+    let (tx, rx) = mpsc::unbounded::<i32>();
+
+    //
+    // Create a future by building an async block that will be implemented as a future,
+    // whose Future::poll will be called sometime later with a std::task::Context
+    //
+    let fut_values = async {
+        //
+        // Create another async block, again that implements future and will
+        // be provided a std::task::Context at some point
+        //
+        let fut_tx_result = async {
+            (0..100).for_each(|v| {
+                tx.unbounded_send(v).expect("Failed to send");
+            })
+        };
+
+        //
+        // Use the context that has been provided to this async block by
+        // Future::poll to spawn a future, which entails Future::poll
+        // being invoked by some std::task::Context, whose parent is the
+        // context of the current async block
+        //
+        spawn!(fut_tx_result);
+
+        let fut_values = rx
+            .map(|v| ready(v * 2))
+            .collect();
+
+        //
+        // Await the result of collecting the stream, by polling the Future using
+        // the std::task::Context of this async block.
+        //
+        await!(fut_values)
+    };
+
+    //
+    // Actually execute the above future, which will invoke Future::poll and
+    // subsequenty chain appropriate Future::poll and std::task::Context's to
+    // drive all futures, eventually driving the fut_values future to
+    // completion.
+    //
+    let values: Vec<i32> = executor::block_on(fut_values);
+
+    println!("Values={:?}", values);
+}

--- a/futures/examples/imperative.rs
+++ b/futures/examples/imperative.rs
@@ -1,0 +1,57 @@
+#![feature(futures_api, async_await, await_macro)]
+#[macro_use] extern crate futures;
+
+use futures::{
+    channel::mpsc,
+    executor, //standard executors to provide a context for futures and streams
+    StreamExt
+};
+
+fn main() {
+    let (tx, mut rx) = mpsc::unbounded::<i32>();
+
+    //
+    // Create a future by building an async block that will be implemented as a future,
+    // whose Future::poll will be called sometime later with a std::task::Context
+    //
+    let fut_values = async {
+        //
+        // Create another async block, again that implements future and will
+        // be provided a std::task::Context at some point
+        //
+        let fut_tx_result = async {
+            (0..100).for_each(|v| {
+                tx.unbounded_send(v).expect("Failed to send");
+            })
+        };
+
+        //
+        // Use the context that has been provided to this async block by
+        // Future::poll to spawn a future, which entails Future::poll
+        // being invoked by some std::task::Context, whose parent is the
+        // context of the current async block
+        //
+        spawn!(fut_tx_result);
+
+        let mut pending = vec![];
+        //
+        // Await the result of rx.next(), by polling the Future using the
+        // std::task::Context of this async block
+        //
+        while let Some(v) = await!(rx.next()) {
+            pending.push(v * 2);
+        };
+
+        pending
+    };
+
+    //
+    // Actually execute the above future, which will invoke Future::poll and
+    // subsequenty chain appropriate Future::poll and std::task::Context's to
+    // drive all futures, eventually driving the fut_values future to
+    // completion.
+    //
+    let values: Vec<i32> = executor::block_on(fut_values);
+
+    println!("Values={:?}", values);
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -20,6 +20,72 @@
 //! threading. Large asynchronous computations are built up using futures,
 //! streams and sinks, and then spawned as independent tasks that are run to
 //! completion, but *do not block* the thread running them.
+//!
+//! The following example describes how the task system context is built and used
+//! within macros and keywords such as async and await!.
+//!
+//!'''rust
+//! #![feature(futures_api, async_await, await_macro)]
+//! #[macro_use] extern crate futures;
+//!
+//! use futures::{
+//!     channel::mpsc,
+//!     executor, //standard executors to provide a context for futures and streams
+//!     futures::ready,
+//!     StreamExt
+//! };
+//!
+//! fn main() {
+//!     let (tx, rx) = mpsc::unbounded::<i32>();
+//!
+//!     //
+//!     // Create a future by building an async block that will be implemented as a future,
+//!     // whose Future::poll will be called sometime later with a std::task::Context
+//!     //
+//!     let fut_values = async {
+//!         //
+//!         // Create another async block, again that implements future and will
+//!         // be provided a std::task::Context at some point
+//!         //
+//!         let fut_tx_result = async {
+//!             (0..100).for_each(|v| {
+//!                 tx.unbounded_send(v).expect("Failed to send");
+//!             })
+//!         };
+//!
+//!         //
+//!         // Use the context that has been provided to this async block by
+//!         // Future::poll to spawn a future, which entails Future::poll
+//!         // being invoked by some std::task::Context, whose parent is the
+//!         // context of the current async block
+//!         //
+//!         spawn!(fut_tx_result);
+//!
+//!         let fut_values = rx
+//!             .map(|v| ready(v * 2))
+//!             .collect();
+//!
+//!         //
+//!         // Await the result of collecting the stream, by polling the Future using
+//!         // the std::task::Context of this async block.
+//!         //
+//!         await!(fut_values)
+//!     };
+//!
+//!     //
+//!     // Actually execute the above future, which will invoke Future::poll and
+//!     // subsequenty chain appropriate Future::poll and std::task::Context's to
+//!     // drive all futures, eventually driving the fut_values future to
+//!     // completion.
+//!     //
+//!     let values: Vec<i32> = executor::block_on(fut_values);
+//!
+//!     println!("Values={:?}", values);
+//! }
+//!```
+//!
+//! The majority of examples and code snippets in this crate assume that they are
+//! inside an async block as written above.
 
 #![feature(pin, arbitrary_self_types, futures_api)]
 


### PR DESCRIPTION
Not ready for merge.

This example is meant to address #1203 providing clarification of how context is created and passed through macros and the async keyword.

The code in examples folder is currently meant to be temporary (quick compilation of single example), and to be removed when example is finalized.