### PR TITLE
Fix unsound take() in FuturesUnordered

### DIFF
--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -1,0 +1,55 @@
+use futures_core::future::Future;
+use futures_core::task::{self, Poll};
+use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use std::marker::Pinned;
+use std::mem::PinMut;
+use std::ptr;
+
+/// Combinator for the
+/// [`FutureTestExt::assert_unmoved`](super::FutureTestExt::assert_unmoved)
+/// method.
+#[derive(Debug, Clone)]
+#[must_use = "futures do nothing unless polled"]
+pub struct AssertUnmoved<Fut> {
+    future: Fut,
+    this_ptr: *const AssertUnmoved<Fut>,
+    _pinned: Pinned,
+}
+
+impl<Fut> AssertUnmoved<Fut> {
+    unsafe_pinned!(future: Fut);
+    unsafe_unpinned!(this_ptr: *const Self);
+
+    pub(super) fn new(future: Fut) -> Self {
+        Self {
+            future,
+            this_ptr: ptr::null(),
+            _pinned: Pinned,
+        }
+    }
+}
+
+impl<Fut: Future> Future for AssertUnmoved<Fut> {
+    type Output = Fut::Output;
+
+    fn poll(
+        mut self: PinMut<Self>,
+        cx: &mut task::Context,
+    ) -> Poll<Self::Output> {
+        let cur_this = &*self as *const Self;
+        if self.this_ptr.is_null() {
+            // First time being polled
+            *self.this_ptr() = cur_this;
+        } else {
+            assert_eq!(self.this_ptr, cur_this, "Future moved between poll calls");
+        }
+        self.future().poll(cx)
+    }
+}
+
+impl<Fut> Drop for AssertUnmoved<Fut> {
+    fn drop(&mut self) {
+        let cur_this = &*self as *const Self;
+        assert_eq!(self.this_ptr, cur_this, "Future moved before drop");
+    }
+}

--- a/futures-test/src/future/mod.rs
+++ b/futures-test/src/future/mod.rs
@@ -1,14 +1,32 @@
 //! Additional combinators for testing futures.
 
-mod pending_once;
+mod assert_unmoved;
+use self::assert_unmoved::AssertUnmoved;
 
+mod pending_once;
 use self::pending_once::PendingOnce;
+
 use futures_core::future::Future;
 use futures_executor;
 use std::thread;
 
 /// Additional combinators for testing futures.
 pub trait FutureTestExt: Future {
+    /// Asserts that the given is not moved after being polled.
+    ///
+    /// A check for movement is performed each time the future is polled
+    /// and when `Drop` is called.
+    ///
+    /// Aside from keeping track of the location at which the future was first
+    /// polled and providing assertions, this future adds no runtime behavior
+    /// and simply delegates to the child future.
+    fn assert_unmoved(self) -> AssertUnmoved<Self>
+    where
+        Self: Sized,
+    {
+        AssertUnmoved::new(self)
+    }
+
     /// Introduces one [`Poll::Pending`](futures_core::task::Poll::Pending)
     /// before polling the given future.
     ///

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -9,7 +9,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// This is created by the
 /// [`FutureTestExt::pending_once`](super::FutureTestExt::pending_once)
 /// method.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless polled"]
 pub struct PendingOnce<Fut: Future> {
     future: Fut,

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -189,7 +189,9 @@ impl<Fut> FuturesUnordered<Fut> {
         // `FuturesUnordered`, which correctly tracks `Fut`'s lifetimes and
         // such.
         unsafe {
-            drop((*task.future.get()).take());
+            // Set to `None` rather than `take()`ing to prevent moving the
+            // future.
+            *task.future.get() = None;
         }
 
         // If the queued flag was previously set, then it means that this task

--- a/futures/tests/futures_unordered.rs
+++ b/futures/tests/futures_unordered.rs
@@ -2,11 +2,14 @@
 
 use futures::channel::oneshot;
 use futures::executor::{block_on, block_on_stream};
-use futures::future::{self, FutureExt, FutureObj};
+use futures::future::{self, Future, FutureExt, FutureObj};
 use futures::stream::{StreamExt, futures_unordered, FuturesUnordered};
-use futures::task::Poll;
+use futures::task::{self, Poll};
 use futures_test::task::no_spawn_context;
 use std::boxed::Box;
+use std::marker::Pinned;
+use std::mem::PinMut;
+use std::ptr;
 
 #[test]
 fn works_1() {
@@ -124,4 +127,44 @@ fn iter_mut_len() {
     assert!(iter_mut.next().is_some());
     assert_eq!(iter_mut.len(), 0);
     assert!(iter_mut.next().is_none());
+}
+
+#[test]
+fn futures_not_moved_after_poll() {
+    struct DontMoveMe {
+        this: *const DontMoveMe,
+        _pinned: Pinned,
+    }
+
+    impl Future for DontMoveMe {
+        type Output = ();
+        fn poll(self: PinMut<Self>, cx: &mut task::Context)
+            -> Poll<Self::Output>
+        {
+            let cur_this = &*self as *const DontMoveMe;
+            if self.this == ptr::null() {
+                // First time being polled.
+                cx.local_waker().wake();
+                unsafe { PinMut::get_mut_unchecked(self).this = cur_this };
+                Poll::Pending
+            } else {
+                assert_eq!(self.this, cur_this, "Future moved between poll calls");
+                Poll::Ready(())
+            }
+        }
+    }
+
+    impl Drop for DontMoveMe {
+        fn drop(&mut self) {
+            let cur_this = &*self as *const DontMoveMe;
+            assert_eq!(self.this, cur_this, "Future moved before drop");
+        }
+    }
+
+    let dmm = || DontMoveMe { this: ptr::null(), _pinned: Pinned };
+    let mut stream = block_on_stream(futures_unordered(vec![dmm(), dmm(), dmm()]));
+    assert_eq!(Some(()), stream.next());
+    assert_eq!(Some(()), stream.next());
+    assert_eq!(Some(()), stream.next());
+    assert_eq!(None, stream.next());
 }


### PR DESCRIPTION
Fix a bug in `FuturesUnordered` that would cause the inner future to be moved before `Drop` being called, which is unsound. Added a test to ensure that we don't regress this behavior.