### PR TITLE
StreamObj should be exported by the main futures crate

### DIFF
--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -298,7 +298,10 @@ pub mod stream {
     //!   [`futures_unordered`](crate::stream::futures_unordered()), which
     //!   constructs a stream from a collection of futures.
 
-    pub use futures_core::stream::{Stream, TryStream};
+    pub use futures_core::stream::{
+        Stream, TryStream,
+        StreamObj, LocalStreamObj, UnsafeStreamObj
+    };
 
     pub use futures_util::stream::{
         iter, Iter,


### PR DESCRIPTION
PR #1221 missed re-exporting the StreamObj values.