### PR TITLE
Deprecate `executor::Executor` and `executor::Run`

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -50,6 +50,7 @@ use std::fmt;
 use futures::{IntoFuture, Future, Poll, Async};
 use futures::future::{lazy, Executor, ExecuteError};
 use futures::sync::oneshot::{channel, Sender, Receiver};
+#[allow(deprecated)]
 use futures::executor::{self, Run, Executor as OldExecutor};
 
 /// A thread pool intended to run CPU intensive work.
@@ -132,6 +133,7 @@ pub struct CpuFuture<T, E> {
 }
 
 enum Message {
+    #[allow(deprecated)]
     Run(Run),
     Close,
 }
@@ -211,6 +213,7 @@ impl CpuPool {
             tx: Some(tx),
             keep_running_flag: keep_running_flag.clone(),
         };
+        #[allow(deprecated)]
         executor::spawn(sender).execute(self.inner.clone());
         CpuFuture { inner: rx , keep_running_flag: keep_running_flag.clone() }
     }
@@ -239,6 +242,7 @@ impl<F> Executor<F> for CpuPool
     where F: Future<Item = (), Error = ()> + Send + 'static,
 {
     fn execute(&self, future: F) -> Result<(), ExecuteError<F>> {
+        #[allow(deprecated)]
         executor::spawn(future).execute(self.inner.clone());
         Ok(())
     }
@@ -279,6 +283,7 @@ impl Drop for CpuPool {
     }
 }
 
+#[allow(deprecated)]
 impl OldExecutor for Inner {
     fn execute(&self, run: Run) {
         self.send(Message::Run(run))

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -8,6 +8,7 @@
 //! [online]: https://tokio.rs/docs/going-deeper-futures/tasks/
 
 #[allow(deprecated)]
+#[doc(hidden)]
 #[cfg(feature = "use_std")]
 pub use task_impl::{Unpark, Executor, Run};
 


### PR DESCRIPTION
These two APIs have long been deprecated, they just have not been
annotated as such.

This patch also hides a number of deprecated functions to help keep the
generated documentation cleaner.