### PR TITLE
Don't run clippy if it's not currently available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,13 @@ matrix:
 
     - name: cargo clippy
       rust: nightly
-      install:
-        - rustup component add clippy-preview
       script:
-        - cargo clippy --all --all-features -- -Dwarnings
+        - if rustup component add clippy-preview;
+          then
+            cargo clippy --all --all-features -- -Dwarnings;
+          else
+            echo 'Skipping clippy';
+          fi
 
     - name: cargo bench
       rust: nightly


### PR DESCRIPTION
Fixes #1234 

Same reasoning as in https://github.com/rust-lang-nursery/pin-utils/pull/7, better to allow in code that would be warned against than block CI when clippy is not included in a nightly.