### PR TITLE
impl Unpin for NotifyHandle with feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - cargo doc --no-deps
   - cargo doc --no-deps --manifest-path futures-cpupool/Cargo.toml
   - if [ "$BENCH" = "1" ]; then cargo bench; fi
+  - if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then cargo test --features nightly; fi
 env:
   global:
     - secure: "iwVcMVIF7ZSY82fK5UyyUvVvJxMSYrbZawh1+4Oi8pvOdYq1gptcDoOC8jxWwCwrNF1b+/85n+jlEUngEqqSmV5PjAbWPjoc+u4Zn7CRi1AlxoUlvHPiQm4vM4Mkkd6GsqoIZttCeedU9m/w0nQ18uUtK8uD6vr2FVdcMnUnkYQAxuGOowGLrwidukzfBXMCu/JrwKMIbt61knAFiI/KJknu0h1mRrhpeF/sQ3tJFzRRcQeFJkbfwDzltMpPo1hq5D3HI4ONjYi/qO2pwUhDk4umfp9cLW9MS8rQvptxJTQmWemHi+f2/U4ld6a0URL6kEuMkt/EbH0A74eFtlicfRs44dX9MlWoqbLypnC3ymqmHcpwcwNA3HmZyg800MTuU+BPK41HIPdO9tPpxjHEiqvNDknH7qs+YBnis0eH7DHJgEjXq651PjW7pm+rnHPwsj+OzKE1YBNxBQZZDkS3VnZJz+O4tVsOzc3IOz0e+lf7VVuI17C9haj117nKp3umC4MVBA0S8RfreFgqpyDeY2zwcqOr0YOlEGGRl0vyWP8Qcxx12kQ7+doLolt6Kxda4uO0hKRmIF6+qki1T+L7v8BOGOtCncz4f7IX48eQ7+Wu0OtglRn45qAa3CxjUuW6xX3KSNH66PCXV0Jtp8Ga2SSevX2wtbbFu9f+9R+PQY4="

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ appveyor = { repository = "rust-lang-nursery/futures-rs" }
 [dependencies]
 
 [features]
+nightly = []
 use_std = []
 with-deprecated = []
 default = ["use_std", "with-deprecated"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/futures/0.1")]
+#![cfg_attr(feature = "nightly", feature(pin))]
 
 #[macro_use]
 #[cfg(feature = "use_std")]

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -712,3 +712,11 @@ impl<T: Notify> From<&'static T> for NotifyHandle {
         unsafe { NotifyHandle::new(src as *const _ as *mut StaticRef<T>) }
     }
 }
+
+#[cfg(feature = "nightly")]
+mod nightly {
+    use super::NotifyHandle;
+    use core::marker::Unpin;
+
+    impl Unpin for NotifyHandle {}
+}

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -700,3 +700,11 @@ impl<T> From<Arc<T>> for NotifyHandle
         }
     }
 }
+
+#[cfg(feature = "nightly")]
+mod nightly {
+    use super::TaskUnpark;
+    use core::marker::Unpin;
+
+    impl Unpin for TaskUnpark {}
+}

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -703,8 +703,9 @@ impl<T> From<Arc<T>> for NotifyHandle
 
 #[cfg(feature = "nightly")]
 mod nightly {
-    use super::TaskUnpark;
+    use super::{TaskUnpark, UnparkEvents};
     use core::marker::Unpin;
 
     impl Unpin for TaskUnpark {}
+    impl Unpin for UnparkEvents {}
 }


### PR DESCRIPTION
This adds an implementation of `Unpin` for `NotifyHandle`. `Unpin` is
only available on the nightly channel, so the implementation is guarded
by a feature flag.

The implementation will always be needed as the struct contains a raw
pointer to a trait object.