### PR TITLE
Backport Sender::is_closed method

### DIFF
--- a/src/sync/mpsc/mod.rs
+++ b/src/sync/mpsc/mod.rs
@@ -600,6 +600,11 @@ impl<T> Sender<T> {
         Ok(self.poll_unparked(true))
     }
 
+    /// Returns whether this channel is closed without needing a context.
+    pub fn is_closed(&self) -> bool {
+        !decode_state(self.inner.state.load(SeqCst)).is_open
+    }
+
     fn poll_unparked(&mut self, do_park: bool) -> Async<()> {
         // First check the `maybe_parked` variable. This avoids acquiring the
         // lock in most cases
@@ -665,6 +670,11 @@ impl<T> Sink for Sender<T> {
 }
 
 impl<T> UnboundedSender<T> {
+    /// Returns whether this channel is closed without needing a context.
+    pub fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
     /// Sends the provided message along this channel.
     ///
     /// This is an unbounded sender, so this function differs from `Sink::send`


### PR DESCRIPTION
This PR backports #836 to 0.1. Note that in 99416a (v0.1), a [function called `is_closed`](https://github.com/rust-lang-nursery/futures-rs/blob/99416a63b521c5e0a0f7b09ed65b9c7a62674196/src/sync/mpsc/mod.rs#L1144) is implemented for `State` which also checks `self.num_messages` and does not exist on `master`. This is confusing. I don't know enough about the internals of `mpsc` to know which one is correct (and whether we also need to check `num_messages` on `master`).