### PR TITLE
Updates for rustc nightly.

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-channel-preview"
 edition = "2018"

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-core-preview"
 edition = "2018"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-executor-preview"
 edition = "2018"

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-io-preview"
 edition = "2018"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-sink-preview"
 edition = "2018"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-test-preview"
 edition = "2018"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-util-preview"
 edition = "2018"

--- a/futures-util/src/compat/compat.rs
+++ b/futures-util/src/compat/compat.rs
@@ -7,8 +7,8 @@
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 pub struct Compat<T, Sp> {
-    crate inner: T,
-    crate spawn: Option<Sp>,
+    pub(crate) inner: T,
+    pub(crate) spawn: Option<Sp>,
 }
 
 impl<T, Sp> Compat<T, Sp> {
@@ -18,7 +18,7 @@ impl<T, Sp> Compat<T, Sp> {
     }
 
     /// Creates a new [`Compat`].
-    crate fn new(inner: T, spawn: Option<Sp>) -> Compat<T, Sp> {
+    pub(crate) fn new(inner: T, spawn: Option<Sp>) -> Compat<T, Sp> {
         Compat { inner, spawn }
     }
 }

--- a/futures-util/src/future/chain.rs
+++ b/futures-util/src/future/chain.rs
@@ -4,7 +4,7 @@ use futures_core::task::{self, Poll};
 
 #[must_use = "futures do nothing unless polled"]
 #[derive(Debug)]
-crate enum Chain<Fut1, Fut2, Data> {
+pub(crate) enum Chain<Fut1, Fut2, Data> {
     First(Fut1, Option<Data>),
     Second(Fut2),
     Empty,
@@ -14,11 +14,11 @@ impl<Fut1, Fut2, Data> Chain<Fut1, Fut2, Data>
     where Fut1: Future,
           Fut2: Future,
 {
-    crate fn new(fut1: Fut1, data: Data) -> Chain<Fut1, Fut2, Data> {
+    pub(crate) fn new(fut1: Fut1, data: Data) -> Chain<Fut1, Fut2, Data> {
         Chain::First(fut1, Some(data))
     }
 
-    crate fn poll<F>(
+    pub(crate) fn poll<F>(
         self: PinMut<Self>,
         cx: &mut task::Context,
         f: F,

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -65,7 +65,7 @@ pub use self::with_spawner::WithSpawner;
 
 // Implementation details
 mod chain;
-crate use self::chain::Chain;
+pub(crate) use self::chain::Chain;
 
 if_std! {
     use std::pin::PinBox;

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -56,7 +56,7 @@ pub use self::unwrap_or_else::UnwrapOrElse;
 
 // Implementation details
 mod try_chain;
-crate use self::try_chain::{TryChain, TryChainAction};
+pub(crate) use self::try_chain::{TryChain, TryChainAction};
 
 impl<Fut: TryFuture> TryFutureExt for Fut {}
 

--- a/futures-util/src/try_future/try_chain.rs
+++ b/futures-util/src/try_future/try_chain.rs
@@ -4,13 +4,13 @@ use futures_core::task::{self, Poll};
 
 #[must_use = "futures do nothing unless polled"]
 #[derive(Debug)]
-crate enum TryChain<Fut1, Fut2, Data> {
+pub(crate) enum TryChain<Fut1, Fut2, Data> {
     First(Fut1, Option<Data>),
     Second(Fut2),
     Empty,
 }
 
-crate enum TryChainAction<Fut2>
+pub(crate) enum TryChainAction<Fut2>
     where Fut2: TryFuture,
 {
     Future(Fut2),
@@ -21,11 +21,11 @@ impl<Fut1, Fut2, Data> TryChain<Fut1, Fut2, Data>
     where Fut1: TryFuture,
           Fut2: TryFuture,
 {
-    crate fn new(fut1: Fut1, data: Data) -> TryChain<Fut1, Fut2, Data> {
+    pub(crate) fn new(fut1: Fut1, data: Data) -> TryChain<Fut1, Fut2, Data> {
         TryChain::First(fut1, Some(data))
     }
 
-    crate fn poll<F>(
+    pub(crate) fn poll<F>(
         self: PinMut<Self>,
         cx: &mut task::Context,
         f: F,

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 name = "futures-preview"
 edition = "2018"


### PR DESCRIPTION
- Use visibility `pub(crate)` in lieu of `crate`, now that the latter is marked as experimental.
- Remove cargo feature "edition," now that it's stable.