### PR TITLE
Add `extern crate test` back in to benches

### DIFF
--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -1,5 +1,7 @@
 #![feature(test, futures_api, pin, arbitrary_self_types)]
 
+extern crate test;
+
 use futures::ready;
 use futures::channel::mpsc::{self, Sender, UnboundedSender};
 use futures::executor::LocalPool;
@@ -8,7 +10,7 @@ use futures::sink::Sink;
 use futures::task::{self, Poll, Wake, LocalWaker};
 use std::pin::PinMut;
 use std::sync::Arc;
-use test::Bencher;
+use self::test::Bencher;
 
 fn notify_noop() -> LocalWaker {
     struct Noop;

--- a/futures-executor/benches/poll.rs
+++ b/futures-executor/benches/poll.rs
@@ -1,12 +1,14 @@
 #![feature(test, pin, arbitrary_self_types, futures_api)]
 
+extern crate test;
+
 use futures::executor::LocalPool;
 use futures::future::{Future, FutureExt};
 use futures::task::{self, Poll, Waker, LocalWaker, Wake};
 use std::marker::Unpin;
 use std::pin::PinMut;
 use std::sync::Arc;
-use test::Bencher;
+use self::test::Bencher;
 
 fn notify_noop() -> LocalWaker {
     struct Noop;

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -1,11 +1,13 @@
 #![feature(test, futures_api, pin, arbitrary_self_types)]
 
+extern crate test;
+
 use futures::executor::block_on;
 use futures::future::Future;
 use futures::task::{self, Poll, Waker};
 use std::marker::Unpin;
 use std::pin::PinMut;
-use test::Bencher;
+use self::test::Bencher;
 
 #[bench]
 fn thread_yield_single_thread_one_wait(b: &mut Bencher) {

--- a/futures-util/benches/futures_unordered.rs
+++ b/futures-util/benches/futures_unordered.rs
@@ -9,7 +9,7 @@ use futures::stream::{StreamExt, FuturesUnordered};
 use futures::task::Poll;
 use std::collections::VecDeque;
 use std::thread;
-use test::Bencher;
+use self::test::Bencher;
 
 #[bench]
 fn oneshots(b: &mut Bencher) {

--- a/futures-util/benches/futures_unordered.rs
+++ b/futures-util/benches/futures_unordered.rs
@@ -1,5 +1,7 @@
 #![feature(test, futures_api)]
 
+extern crate test;
+
 use futures::channel::oneshot;
 use futures::executor::block_on;
 use futures::future;


### PR DESCRIPTION
Required until there's a way to specify this dependency in the `Cargo.toml`.

See https://github.com/rust-lang/rust/pull/54116#issuecomment-422303058