### PR TITLE
Disable denying rustdoc warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,11 +68,7 @@ matrix:
     - name: cargo doc
       rust: nightly
       script:
-        - RUSTDOCFLAGS=-Dwarnings cargo doc --all
-            --exclude futures-preview
-            --exclude futures-executor-preview
-            --exclude futures-test-preview
-        - cargo doc
+        - cargo doc --all
 
 script:
   - cargo test --all


### PR DESCRIPTION
There are currently too many bugs in the intra-doc-resolution feature to rely on its failures being our fault.