### PR TITLE
[WIP] Follow latest pinning API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ members = [
   "futures-util",
   "futures-test",
 ]
+
+[patch.crates-io]
+pin-utils = { git = "https://github.com/Kroisse/pin-utils.git", branch = "pin" }

--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -6,7 +6,7 @@ use futures::executor::LocalPool;
 use futures::stream::{Stream, StreamExt};
 use futures::sink::Sink;
 use futures::task::{self, Poll, Wake, LocalWaker};
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::Arc;
 use test::Bencher;
 
@@ -100,16 +100,16 @@ struct TestSender {
 impl Stream for TestSender {
     type Item = u32;
 
-    fn poll_next(mut self: PinMut<Self>, cx: &mut task::Context)
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context)
         -> Poll<Option<Self::Item>>
     {
         let this = &mut *self;
-        let mut tx = PinMut::new(&mut this.tx);
+        let mut tx = Pin::new(&mut this.tx);
 
-        ready!(tx.reborrow().poll_ready(cx)).unwrap();
-        tx.reborrow().start_send(this.last + 1).unwrap();
+        ready!(tx.as_mut().poll_ready(cx)).unwrap();
+        tx.as_mut().start_send(this.last + 1).unwrap();
         this.last += 1;
-        assert_eq!(Poll::Ready(Ok(())), tx.reborrow().poll_flush(cx));
+        assert_eq!(Poll::Ready(Ok(())), tx.as_mut().poll_flush(cx));
         Poll::Ready(Some(this.last))
     }
 }

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -84,7 +84,7 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
@@ -113,7 +113,7 @@ pub struct Sender<T> {
     maybe_parked: bool,
 }
 
-// We never project PinMut<Sender> to `PinMut<T>`
+// We never project Pin<&mut Sender> to `Pin<&mut T>`
 impl<T> Unpin for Sender<T> {}
 
 /// The transmission end of an unbounded mpsc channel.
@@ -139,7 +139,7 @@ pub struct Receiver<T> {
 #[derive(Debug)]
 pub struct UnboundedReceiver<T>(Receiver<T>);
 
-// `PinMut<UnboundedReceiver<T>>` is never projected to `PinMut<T>`
+// `PinMut<UnboundedReceiver<T>>` is never projected to `Pin<&mut T>`
 impl<T> Unpin for UnboundedReceiver<T> {}
 
 /// The error type for [`Sender`s](Sender) used as `Sink`s.
@@ -960,7 +960,7 @@ impl<T> Stream for Receiver<T> {
     type Item = T;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<T>> {
         loop {
@@ -1030,10 +1030,10 @@ impl<T> Stream for UnboundedReceiver<T> {
     type Item = T;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<T>> {
-        PinMut::new(&mut self.0).poll_next(cx)
+        Pin::new(&mut self.0).poll_next(cx)
     }
 }
 

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -3,7 +3,7 @@
 use futures_core::future::Future;
 use futures_core::task::{self, Poll, Waker};
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::SeqCst;
@@ -419,7 +419,7 @@ impl<T> Future for Receiver<T> {
     type Output = Result<T, Canceled>;
 
     fn poll(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<T, Canceled>> {
         self.inner.recv(cx)

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -32,30 +32,30 @@ fn send_recv_no_buffer() {
         let (tx, rx) = mpsc::channel::<i32>(0);
         pin_mut!(tx, rx);
 
-        assert!(tx.reborrow().poll_flush(cx).is_ready());
-        assert!(tx.reborrow().poll_ready(cx).is_ready());
+        assert!(tx.as_mut().poll_flush(cx).is_ready());
+        assert!(tx.as_mut().poll_ready(cx).is_ready());
 
         // Send first message
-        assert!(tx.reborrow().start_send(1).is_ok());
-        assert!(tx.reborrow().poll_ready(cx).is_pending());
+        assert!(tx.as_mut().start_send(1).is_ok());
+        assert!(tx.as_mut().poll_ready(cx).is_pending());
 
         // poll_ready said Pending, so no room in buffer, therefore new sends
         // should get rejected with is_full.
-        assert!(tx.reborrow().start_send(0).unwrap_err().is_full());
-        assert!(tx.reborrow().poll_ready(cx).is_pending());
+        assert!(tx.as_mut().start_send(0).unwrap_err().is_full());
+        assert!(tx.as_mut().poll_ready(cx).is_pending());
 
         // Take the value
-        assert_eq!(rx.reborrow().poll_next(cx), Poll::Ready(Some(1)));
-        assert!(tx.reborrow().poll_ready(cx).is_ready());
+        assert_eq!(rx.as_mut().poll_next(cx), Poll::Ready(Some(1)));
+        assert!(tx.as_mut().poll_ready(cx).is_ready());
 
         // Send second message
-        assert!(tx.reborrow().poll_ready(cx).is_ready());
-        assert!(tx.reborrow().start_send(2).is_ok());
-        assert!(tx.reborrow().poll_ready(cx).is_pending());
+        assert!(tx.as_mut().poll_ready(cx).is_ready());
+        assert!(tx.as_mut().start_send(2).is_ok());
+        assert!(tx.as_mut().poll_ready(cx).is_pending());
 
         // Take the value
-        assert_eq!(rx.reborrow().poll_next(cx), Poll::Ready(Some(2)));
-        assert!(tx.reborrow().poll_ready(cx).is_ready());
+        assert_eq!(rx.as_mut().poll_next(cx), Poll::Ready(Some(2)));
+        assert!(tx.as_mut().poll_ready(cx).is_ready());
 
         Poll::Ready(())
     }));

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -4,7 +4,7 @@ use futures::channel::oneshot::{self, Sender};
 use futures::executor::block_on;
 use futures::future::{Future, FutureExt, poll_fn};
 use futures::task::{self, Poll};
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::mpsc;
 use std::thread;
 
@@ -42,7 +42,7 @@ struct WaitForCancel {
 impl Future for WaitForCancel {
     type Output = ();
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.tx.poll_cancel(cx)
     }
 }

--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -1,7 +1,7 @@
 //! Futures.
 
 use crate::task::{self, Poll};
-use core::pin::PinMut;
+use core::pin::Pin;
 
 pub use core::future::{Future, FutureObj, LocalFutureObj, UnsafeFutureObj};
 
@@ -20,7 +20,7 @@ pub trait TryFuture {
     /// directly inheriting from the `Future` trait; in the future it won't be
     /// needed.
     fn try_poll(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<Self::Ok, Self::Error>>;
 }
@@ -32,7 +32,7 @@ impl<F, T, E> TryFuture for F
     type Error = E;
 
     #[inline]
-    fn try_poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<F::Output> {
+    fn try_poll(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<F::Output> {
         self.poll(cx)
     }
 }

--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -2,7 +2,7 @@ use super::Stream;
 use crate::task::{self, Poll};
 use core::fmt;
 use core::marker::{PhantomData, Unpin};
-use core::pin::PinMut;
+use core::pin::Pin;
 
 /// A custom trait object for polling streams, roughly akin to
 /// `Box<dyn Stream<Item = T> + 'a>`.
@@ -64,7 +64,7 @@ impl<'a, T> Stream for LocalStreamObj<'a, T> {
 
     #[inline]
     fn poll_next(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<T>> {
         unsafe { (self.poll_next_fn)(self.ptr, cx) }
@@ -112,10 +112,10 @@ impl<'a, T> Stream for StreamObj<'a, T> {
 
     #[inline]
     fn poll_next(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<T>> {
-        let pinned_field = unsafe { PinMut::map_unchecked(self, |x| &mut x.0) };
+        let pinned_field = unsafe { Pin::map_unchecked_mut(self, |x| &mut x.0) };
         pinned_field.poll_next(cx)
     }
 }
@@ -168,25 +168,25 @@ where
         ptr: *mut (),
         cx: &mut task::Context,
     ) -> Poll<Option<T>> {
-        PinMut::new_unchecked(&mut *(ptr as *mut F)).poll_next(cx)
+        Pin::new_unchecked(&mut *(ptr as *mut F)).poll_next(cx)
     }
 
     unsafe fn drop(_ptr: *mut ()) {}
 }
 
-unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for PinMut<'a, F>
+unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for Pin<&'a mut F>
 where
     F: Stream<Item = T> + 'a,
 {
     fn into_raw(self) -> *mut () {
-        unsafe { PinMut::get_mut_unchecked(self) as *mut F as *mut () }
+        unsafe { Pin::get_mut_unchecked(self) as *mut F as *mut () }
     }
 
     unsafe fn poll_next(
         ptr: *mut (),
         cx: &mut task::Context,
     ) -> Poll<Option<T>> {
-        PinMut::new_unchecked(&mut *(ptr as *mut F)).poll_next(cx)
+        Pin::new_unchecked(&mut *(ptr as *mut F)).poll_next(cx)
     }
 
     unsafe fn drop(_ptr: *mut ()) {}
@@ -194,7 +194,6 @@ where
 
 if_std! {
     use std::boxed::Box;
-    use std::pin::PinBox;
 
     unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for Box<F>
         where F: Stream<Item = T> + 'a
@@ -205,7 +204,7 @@ if_std! {
 
         unsafe fn poll_next(ptr: *mut (), cx: &mut task::Context) -> Poll<Option<T>> {
             let ptr = ptr as *mut F;
-            let pin: PinMut<F> = PinMut::new_unchecked(&mut *ptr);
+            let pin: Pin<&mut F> = Pin::new_unchecked(&mut *ptr);
             pin.poll_next(cx)
         }
 
@@ -214,26 +213,26 @@ if_std! {
         }
     }
 
-    unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for PinBox<F>
+    unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for Pin<Box<F>>
         where F: Stream<Item = T> + 'a
     {
-        fn into_raw(self) -> *mut () {
-            PinBox::into_raw(self) as *mut ()
+        fn into_raw(mut self) -> *mut () {
+            unsafe { Pin::get_mut_unchecked(Pin::as_mut(&mut self)) as *mut F as *mut () }
         }
 
         unsafe fn poll_next(ptr: *mut (), cx: &mut task::Context) -> Poll<Option<T>> {
             let ptr = ptr as *mut F;
-            let pin: PinMut<F> = PinMut::new_unchecked(&mut *ptr);
+            let pin: Pin<&mut F> = Pin::new_unchecked(&mut *ptr);
             pin.poll_next(cx)
         }
 
         unsafe fn drop(ptr: *mut ()) {
-            drop(PinBox::from_raw(ptr as *mut F))
+            drop(Box::from_raw(ptr as *mut F))
         }
     }
 
-    impl<'a, F: Stream<Item = ()> + Send + 'a> From<PinBox<F>> for StreamObj<'a, ()> {
-        fn from(boxed: PinBox<F>) -> Self {
+    impl<'a, F: Stream<Item = ()> + Send + 'a> From<Pin<Box<F>>> for StreamObj<'a, ()> {
+        fn from(boxed: Pin<Box<F>>) -> Self {
             StreamObj::new(boxed)
         }
     }
@@ -244,8 +243,8 @@ if_std! {
         }
     }
 
-    impl<'a, F: Stream<Item = ()> + 'a> From<PinBox<F>> for LocalStreamObj<'a, ()> {
-        fn from(boxed: PinBox<F>) -> Self {
+    impl<'a, F: Stream<Item = ()> + 'a> From<Pin<Box<F>>> for LocalStreamObj<'a, ()> {
+        fn from(boxed: Pin<Box<F>>) -> Self {
             LocalStreamObj::new(boxed)
         }
     }

--- a/futures-executor/benches/poll.rs
+++ b/futures-executor/benches/poll.rs
@@ -4,7 +4,7 @@ use futures::executor::LocalPool;
 use futures::future::{Future, FutureExt};
 use futures::task::{self, Poll, Waker, LocalWaker, Wake};
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::Arc;
 use test::Bencher;
 
@@ -31,7 +31,7 @@ fn task_init(b: &mut Bencher) {
     impl Future for MyFuture {
         type Output = ();
 
-        fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
             if self.num == NUM {
                 Poll::Ready(())
             } else {

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -4,7 +4,7 @@ use futures::executor::block_on;
 use futures::future::Future;
 use futures::task::{self, Poll, Waker};
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use test::Bencher;
 
 #[bench]
@@ -18,7 +18,7 @@ fn thread_yield_single_thread_one_wait(b: &mut Bencher) {
     impl Future for Yield {
         type Output = ();
 
-        fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
             if self.rem == 0 {
                 Poll::Ready(())
             } else {
@@ -46,7 +46,7 @@ fn thread_yield_single_thread_many_wait(b: &mut Bencher) {
     impl Future for Yield {
         type Output = ();
 
-        fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
             if self.rem == 0 {
                 Poll::Ready(())
             } else {
@@ -83,7 +83,7 @@ fn thread_yield_multi_thread(b: &mut Bencher) {
     impl Future for Yield {
         type Output = ();
 
-        fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
             if self.rem == 0 {
                 Poll::Ready(())
             } else {

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -154,7 +154,7 @@ impl LocalPool {
                 let mut main_cx = Context::new(local_waker, spawn);
 
                 // if our main task is done, so are we
-                let result = future.reborrow().poll(&mut main_cx);
+                let result = future.as_mut().poll(&mut main_cx);
                 if let Poll::Ready(output) = result {
                     return Poll::Ready(output);
                 }

--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -1,25 +1,25 @@
 use crate::{Sink, Poll};
 use futures_core::task;
 use futures_channel::mpsc::{Sender, SendError, UnboundedSender};
-use std::pin::PinMut;
+use std::pin::Pin;
 
 impl<T> Sink for Sender<T> {
     type SinkItem = T;
     type SinkError = SendError;
 
-    fn poll_ready(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         (*self).poll_ready(cx)
     }
 
-    fn start_send(mut self: PinMut<Self>, msg: T) -> Result<(), Self::SinkError> {
+    fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::SinkError> {
         (*self).start_send(msg)
     }
 
-    fn poll_flush(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(mut self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(mut self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         self.close_channel();
         Poll::Ready(Ok(()))
     }
@@ -29,19 +29,19 @@ impl<T> Sink for UnboundedSender<T> {
     type SinkItem = T;
     type SinkError = SendError;
 
-    fn poll_ready(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         UnboundedSender::poll_ready(&*self, cx)
     }
 
-    fn start_send(mut self: PinMut<Self>, msg: T) -> Result<(), Self::SinkError> {
+    fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::SinkError> {
         UnboundedSender::start_send(&mut *self, msg)
     }
 
-    fn poll_flush(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         self.close_channel();
         Poll::Ready(Ok(()))
     }
@@ -51,20 +51,20 @@ impl<'a, T> Sink for &'a UnboundedSender<T> {
     type SinkItem = T;
     type SinkError = SendError;
 
-    fn poll_ready(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         UnboundedSender::poll_ready(*self, cx)
     }
 
-    fn start_send(self: PinMut<Self>, msg: T) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), Self::SinkError> {
         self.unbounded_send(msg)
             .map_err(|err| err.into_send_error())
     }
 
-    fn poll_flush(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         self.close_channel();
         Poll::Ready(Ok(()))
     }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -18,7 +18,7 @@ macro_rules! if_std {
 
 use futures_core::task::{self, Poll};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 
 /// A `Sink` is a value into which other values can be sent, asynchronously.
 ///
@@ -65,7 +65,7 @@ pub trait Sink {
     ///
     /// In most cases, if the sink encounters an error, the sink will
     /// permanently be unable to receive items.
-    fn poll_ready(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>>;
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>>;
 
     /// Begin the process of sending a value to the sink.
     /// Each call to this function must be proceeded by a successful call to
@@ -86,7 +86,7 @@ pub trait Sink {
     ///
     /// In most cases, if the sink encounters an error, the sink will
     /// permanently be unable to receive items.
-    fn start_send(self: PinMut<Self>, item: Self::SinkItem)
+    fn start_send(self: Pin<&mut Self>, item: Self::SinkItem)
                   -> Result<(), Self::SinkError>;
 
     /// Flush any remaining output from this sink.
@@ -101,7 +101,7 @@ pub trait Sink {
     ///
     /// In most cases, if the sink encounters an error, the sink will
     /// permanently be unable to receive items.
-    fn poll_flush(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>>;
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>>;
 
     /// Flush any remaining output and close this sink, if necessary.
     ///
@@ -114,48 +114,48 @@ pub trait Sink {
     ///
     /// If this function encounters an error, the sink should be considered to
     /// have failed permanently, and no more `Sink` methods should be called.
-    fn poll_close(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>>;
+    fn poll_close(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>>;
 }
 
 impl<'a, S: ?Sized + Sink + Unpin> Sink for &'a mut S {
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn poll_ready(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-        PinMut::new(&mut **self).poll_ready(cx)
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        Pin::new(&mut **self).poll_ready(cx)
     }
 
-    fn start_send(mut self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
-        PinMut::new(&mut **self).start_send(item)
+    fn start_send(mut self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+        Pin::new(&mut **self).start_send(item)
     }
 
-    fn poll_flush(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-        PinMut::new(&mut **self).poll_flush(cx)
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        Pin::new(&mut **self).poll_flush(cx)
     }
 
-    fn poll_close(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-        PinMut::new(&mut **self).poll_close(cx)
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        Pin::new(&mut **self).poll_close(cx)
     }
 }
 
-impl<'a, S: ?Sized + Sink> Sink for PinMut<'a, S> {
+impl<'a, S: ?Sized + Sink> Sink for Pin<&'a mut S> {
     type SinkItem = S::SinkItem;
     type SinkError = S::SinkError;
 
-    fn poll_ready(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-        S::poll_ready((*self).reborrow(), cx)
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        S::poll_ready((*self).as_mut(), cx)
     }
 
-    fn start_send(mut self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
-        S::start_send((*self).reborrow(), item)
+    fn start_send(mut self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+        S::start_send((*self).as_mut(), item)
     }
 
-    fn poll_flush(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-        S::poll_flush((*self).reborrow(), cx)
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        S::poll_flush((*self).as_mut(), cx)
     }
 
-    fn poll_close(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-        S::poll_close((*self).reborrow(), cx)
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        S::poll_close((*self).as_mut(), cx)
     }
 }
 
@@ -171,21 +171,21 @@ if_std! {
         type SinkItem = T;
         type SinkError = VecSinkError;
 
-        fn poll_ready(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        fn poll_ready(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
         }
 
-        fn start_send(self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+        fn start_send(self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
             // TODO: impl<T> Unpin for Vec<T> {}
-            unsafe { PinMut::get_mut_unchecked(self) }.push(item);
+            unsafe { Pin::get_mut_unchecked(self) }.push(item);
             Ok(())
         }
 
-        fn poll_flush(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        fn poll_flush(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
         }
 
-        fn poll_close(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        fn poll_close(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
         }
     }
@@ -194,21 +194,21 @@ if_std! {
         type SinkItem = T;
         type SinkError = VecSinkError;
 
-        fn poll_ready(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        fn poll_ready(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
         }
 
-        fn start_send(self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+        fn start_send(self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
             // TODO: impl<T> Unpin for Vec<T> {}
-            unsafe { PinMut::get_mut_unchecked(self) }.push_back(item);
+            unsafe { Pin::get_mut_unchecked(self) }.push_back(item);
             Ok(())
         }
 
-        fn poll_flush(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        fn poll_flush(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
         }
 
-        fn poll_close(self: PinMut<Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+        fn poll_close(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
         }
     }
@@ -217,20 +217,20 @@ if_std! {
         type SinkItem = S::SinkItem;
         type SinkError = S::SinkError;
 
-        fn poll_ready(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-            PinMut::new(&mut **self).poll_ready(cx)
+        fn poll_ready(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+            Pin::new(&mut **self).poll_ready(cx)
         }
 
-        fn start_send(mut self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
-            PinMut::new(&mut **self).start_send(item)
+        fn start_send(mut self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+            Pin::new(&mut **self).start_send(item)
         }
 
-        fn poll_flush(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-            PinMut::new(&mut **self).poll_flush(cx)
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+            Pin::new(&mut **self).poll_flush(cx)
         }
 
-        fn poll_close(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
-            PinMut::new(&mut **self).poll_close(cx)
+        fn poll_close(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+            Pin::new(&mut **self).poll_close(cx)
         }
     }
 }
@@ -246,38 +246,38 @@ impl<A, B> Sink for Either<A, B>
     type SinkItem = <A as Sink>::SinkItem;
     type SinkError = <A as Sink>::SinkError;
 
-    fn poll_ready(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match PinMut::get_mut_unchecked(self) {
-                Either::Left(x) => PinMut::new_unchecked(x).poll_ready(cx),
-                Either::Right(x) => PinMut::new_unchecked(x).poll_ready(cx),
+            match Pin::get_mut_unchecked(self) {
+                Either::Left(x) => Pin::new_unchecked(x).poll_ready(cx),
+                Either::Right(x) => Pin::new_unchecked(x).poll_ready(cx),
             }
         }
     }
 
-    fn start_send(self: PinMut<Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
         unsafe {
-            match PinMut::get_mut_unchecked(self) {
-                Either::Left(x) => PinMut::new_unchecked(x).start_send(item),
-                Either::Right(x) => PinMut::new_unchecked(x).start_send(item),
+            match Pin::get_mut_unchecked(self) {
+                Either::Left(x) => Pin::new_unchecked(x).start_send(item),
+                Either::Right(x) => Pin::new_unchecked(x).start_send(item),
             }
         }
     }
 
-    fn poll_flush(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match PinMut::get_mut_unchecked(self) {
-                Either::Left(x) => PinMut::new_unchecked(x).poll_flush(cx),
-                Either::Right(x) => PinMut::new_unchecked(x).poll_flush(cx),
+            match Pin::get_mut_unchecked(self) {
+                Either::Left(x) => Pin::new_unchecked(x).poll_flush(cx),
+                Either::Right(x) => Pin::new_unchecked(x).poll_flush(cx),
             }
         }
     }
 
-    fn poll_close(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match PinMut::get_mut_unchecked(self) {
-                Either::Left(x) => PinMut::new_unchecked(x).poll_close(cx),
-                Either::Right(x) => PinMut::new_unchecked(x).poll_close(cx),
+            match Pin::get_mut_unchecked(self) {
+                Either::Left(x) => Pin::new_unchecked(x).poll_close(cx),
+                Either::Right(x) => Pin::new_unchecked(x).poll_close(cx),
             }
         }
     }

--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -30,7 +30,7 @@ macro_rules! assert_stream_pending {
     ($stream:expr) => {{
         let mut stream = &mut $stream;
         $crate::assert::assert_is_unpin_stream(stream);
-        let stream = $crate::std_reexport::pin::PinMut::new(stream);
+        let stream = $crate::std_reexport::pin::Pin::new(stream);
         let cx = &mut $crate::task::no_spawn_context();
         let poll = $crate::futures_core_reexport::stream::Stream::poll_next(
             stream, cx,
@@ -67,7 +67,7 @@ macro_rules! assert_stream_next {
     ($stream:expr, $item:expr) => {{
         let mut stream = &mut $stream;
         $crate::assert::assert_is_unpin_stream(stream);
-        let stream = $crate::std_reexport::pin::PinMut::new(stream);
+        let stream = $crate::std_reexport::pin::Pin::new(stream);
         let cx = &mut $crate::task::no_spawn_context();
         match $crate::futures_core_reexport::stream::Stream::poll_next(stream, cx) {
             $crate::futures_core_reexport::task::Poll::Ready(Some(x)) => {
@@ -110,7 +110,7 @@ macro_rules! assert_stream_done {
     ($stream:expr) => {{
         let mut stream = &mut $stream;
         $crate::assert::assert_is_unpin_stream(stream);
-        let stream = $crate::std_reexport::pin::PinMut::new(stream);
+        let stream = $crate::std_reexport::pin::Pin::new(stream);
         let cx = &mut $crate::task::no_spawn_context();
         match $crate::futures_core_reexport::stream::Stream::poll_next(stream, cx) {
             $crate::futures_core_reexport::task::Poll::Ready(Some(_)) => {

--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -2,7 +2,7 @@ use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::marker::Pinned;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::ptr;
 
 /// Combinator for the
@@ -33,7 +33,7 @@ impl<Fut: Future> Future for AssertUnmoved<Fut> {
     type Output = Fut::Output;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         let cur_this = &*self as *const Self;

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -1,6 +1,6 @@
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
-use std::pin::PinMut;
+use std::pin::Pin;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Combinator that guarantees one [`Poll::Pending`] before polling its inner
@@ -32,7 +32,7 @@ impl<Fut: Future> Future for PendingOnce<Fut> {
     type Output = Fut::Output;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         if *self.polled_before() {

--- a/futures-util/src/async_await/join.rs
+++ b/futures-util/src/async_await/join.rs
@@ -33,14 +33,14 @@ macro_rules! join {
             let mut all_done = true;
             $(
                 if $crate::core_reexport::future::Future::poll(
-                    unsafe { $crate::core_reexport::pin::PinMut::new_unchecked(&mut $fut) }, cx).is_pending()
+                    unsafe { $crate::core_reexport::pin::Pin::new_unchecked(&mut $fut) }, cx).is_pending()
                 {
                     all_done = false;
                 }
             )*
             if all_done {
                 $crate::core_reexport::task::Poll::Ready(($(
-                    unsafe { $crate::core_reexport::pin::PinMut::new_unchecked(&mut $fut) }.take_output().unwrap(),
+                    unsafe { $crate::core_reexport::pin::Pin::new_unchecked(&mut $fut) }.take_output().unwrap(),
                 )*))
             } else {
                 $crate::core_reexport::task::Poll::Pending
@@ -101,15 +101,15 @@ macro_rules! try_join {
             let mut all_done = true;
             $(
                 if $crate::core_reexport::future::Future::poll(
-                    unsafe { $crate::core_reexport::pin::PinMut::new_unchecked(&mut $fut) }, cx).is_pending()
+                    unsafe { $crate::core_reexport::pin::Pin::new_unchecked(&mut $fut) }, cx).is_pending()
                 {
                     all_done = false;
-                } else if unsafe { $crate::core_reexport::pin::PinMut::new_unchecked(&mut $fut) }.output_mut().unwrap().is_err() {
+                } else if unsafe { $crate::core_reexport::pin::Pin::new_unchecked(&mut $fut) }.output_mut().unwrap().is_err() {
                     // `.err().unwrap()` rather than `.unwrap_err()` so that we don't introduce
                     // a `T: Debug` bound.
                     return $crate::core_reexport::task::Poll::Ready(
                         $crate::core_reexport::result::Result::Err(
-                            unsafe { $crate::core_reexport::pin::PinMut::new_unchecked(&mut $fut) }.take_output().unwrap().err().unwrap()
+                            unsafe { $crate::core_reexport::pin::Pin::new_unchecked(&mut $fut) }.take_output().unwrap().err().unwrap()
                         )
                     );
                 }
@@ -119,7 +119,7 @@ macro_rules! try_join {
                     $crate::core_reexport::result::Result::Ok(($(
                         // `.ok().unwrap()` rather than `.unwrap()` so that we don't introduce
                         // an `E: Debug` bound.
-                        unsafe { $crate::core_reexport::pin::PinMut::new_unchecked(&mut $fut) }.take_output().unwrap().ok().unwrap(),
+                        unsafe { $crate::core_reexport::pin::Pin::new_unchecked(&mut $fut) }.take_output().unwrap().ok().unwrap(),
                     )*))
                 )
             } else {

--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -1,12 +1,12 @@
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
 /// A macro which yields to the event loop once.
-/// 
-/// This is equivalent to returning [`Poll::Pending`](futures_core::task::Poll) 
-/// from a [`Future::poll`](futures_core::future::Future::poll) implementation. 
-/// Similarly, when using this macro, it must be ensured that [`wake`](std::task::Waker::wake) 
+///
+/// This is equivalent to returning [`Poll::Pending`](futures_core::task::Poll)
+/// from a [`Future::poll`](futures_core::future::Future::poll) implementation.
+/// Similarly, when using this macro, it must be ensured that [`wake`](std::task::Waker::wake)
 /// is called somewhere when further progress can be made.
 ///
 /// This macro is only usable inside of async functions, closures, and blocks.
@@ -30,7 +30,7 @@ pub struct PendingOnce {
 
 impl Future for PendingOnce {
     type Output = ();
-    fn poll(mut self: PinMut<Self>, _: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Self::Output> {
         if self.is_ready {
             Poll::Ready(())
         } else {

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
@@ -27,7 +27,7 @@ pub struct PollOnce<F: Future + Unpin> {
 
 impl<F: Future + Unpin> Future for PollOnce<F> {
     type Output = Poll<F::Output>;
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
-        Poll::Ready(PinMut::new(&mut self.future).poll(cx))
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        Poll::Ready(Pin::new(&mut self.future).poll(cx))
     }
 }

--- a/futures-util/src/async_await/select.rs
+++ b/futures-util/src/async_await/select.rs
@@ -50,7 +50,7 @@ macro_rules! select {
         let __priv_res = await!($crate::future::poll_fn(|cx| {
             $(
                 match $crate::core_reexport::future::Future::poll(
-                    $crate::core_reexport::pin::PinMut::new(&mut $name), cx)
+                    $crate::core_reexport::pin::Pin::new(&mut $name), cx)
                 {
                     $crate::core_reexport::task::Poll::Ready(x) =>
                         return $crate::core_reexport::task::Poll::Ready(__PrivResult::$name(x)),

--- a/futures-util/src/compat/compat01to03.rs
+++ b/futures-util/src/compat/compat01to03.rs
@@ -5,19 +5,19 @@ use futures::executor::{
 };
 use futures::{Async as Async01, Future as Future01, Stream as Stream01};
 use futures_core::{task as task03, Future as Future03, Stream as Stream03};
-use std::pin::PinMut;
+use std::pin::Pin;
 
 impl<Fut: Future01> Future03 for Compat<Fut, ()> {
     type Output = Result<Fut::Item, Fut::Error>;
 
     fn poll(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task03::Context,
     ) -> task03::Poll<Self::Output> {
         let notify = &WakerToHandle(cx.waker());
 
         executor01::with_notify(notify, 0, move || {
-            match unsafe { PinMut::get_mut_unchecked(self) }.inner.poll() {
+            match unsafe { Pin::get_mut_unchecked(self) }.inner.poll() {
                 Ok(Async01::Ready(t)) => task03::Poll::Ready(Ok(t)),
                 Ok(Async01::NotReady) => task03::Poll::Pending,
                 Err(e) => task03::Poll::Ready(Err(e)),
@@ -30,13 +30,13 @@ impl<St: Stream01> Stream03 for Compat<St, ()> {
     type Item = Result<St::Item, St::Error>;
 
     fn poll_next(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task03::Context,
     ) -> task03::Poll<Option<Self::Item>> {
         let notify = &WakerToHandle(cx.waker());
 
         executor01::with_notify(notify, 0, move || {
-            match unsafe { PinMut::get_mut_unchecked(self) }.inner.poll() {
+            match unsafe { Pin::get_mut_unchecked(self) }.inner.poll() {
                 Ok(Async01::Ready(Some(t))) => task03::Poll::Ready(Some(Ok(t))),
                 Ok(Async01::Ready(None)) => task03::Poll::Ready(None),
                 Ok(Async01::NotReady) => task03::Poll::Pending,

--- a/futures-util/src/compat/compat03to01.rs
+++ b/futures-util/src/compat/compat03to01.rs
@@ -58,7 +58,7 @@ where
         item: Self::SinkItem,
     ) -> StartSend01<Self::SinkItem, Self::SinkError> {
         with_context(self, |mut inner, cx| {
-            match inner.reborrow().poll_ready(cx) {
+            match inner.as_mut().poll_ready(cx) {
                 task03::Poll::Ready(Ok(())) => {
                     inner.start_send(item).map(|()| AsyncSink01::Ready)
                 }
@@ -102,10 +102,10 @@ fn with_context<T, E, R, F>(compat: &mut Compat<T, E>, f: F) -> R
 where
     T: Unpin,
     E: task03::Spawn,
-    F: FnOnce(PinMut<T>, &mut task03::Context) -> R,
+    F: FnOnce(Pin<&mut T>, &mut task03::Context) -> R,
 {
     let waker = current_as_waker();
     let spawn = compat.spawn.as_mut().unwrap();
     let mut cx = task03::Context::new(&waker, spawn);
-    f(PinMut::new(&mut compat.inner), &mut cx)
+    f(Pin::new(&mut compat.inner), &mut cx)
 }

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -3,7 +3,7 @@ use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -122,7 +122,7 @@ pub struct Aborted;
 impl<Fut> Future for Abortable<Fut> where Fut: Future {
     type Output = Result<Fut::Output, Aborted>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         // Check if the future has been aborted
         if self.inner.cancel.load(Ordering::Relaxed) {
             return Poll::Ready(Err(Aborted))

--- a/futures-util/src/future/catch_unwind.rs
+++ b/futures-util/src/future/catch_unwind.rs
@@ -2,7 +2,7 @@ use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
 use std::any::Any;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
 use std::prelude::v1::*;
 
@@ -28,7 +28,7 @@ impl<Fut> Future for CatchUnwind<Fut>
 {
     type Output = Result<Fut::Output, Box<dyn Any + Send>>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         match catch_unwind(AssertUnwindSafe(|| self.future().poll(cx))) {
             Ok(res) => res.map(Ok),
             Err(e) => Poll::Ready(Err(e))

--- a/futures-util/src/future/empty.rs
+++ b/futures-util/src/future/empty.rs
@@ -1,5 +1,5 @@
 use core::marker;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
@@ -36,7 +36,7 @@ pub fn empty<T>() -> Empty<T> {
 impl<T> Future for Empty<T> {
     type Output = T;
 
-    fn poll(self: PinMut<Self>, _: &mut task::Context) -> Poll<T> {
+    fn poll(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<T> {
         Poll::Pending
     }
 }

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -1,6 +1,6 @@
 use super::chain::Chain;
 use core::fmt;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -48,7 +48,7 @@ impl<Fut> Future for Flatten<Fut>
 {
     type Output = <Fut::Output as Future>::Output;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.state().poll(cx, |a, ()| a)
     }
 }

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -1,4 +1,4 @@
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -29,7 +29,7 @@ impl<Fut: Future> Fuse<Fut> {
 impl<Fut: Future> Future for Fuse<Fut> {
     type Output = Fut::Output;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Fut::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Fut::Output> {
         // safety: we use this &mut only for matching, not for movement
         let v = match self.future().as_pin_mut() {
             Some(fut) => {
@@ -42,7 +42,7 @@ impl<Fut: Future> Future for Fuse<Fut> {
             None => return Poll::Pending,
         };
 
-        PinMut::set(self.future(), None);
+        Pin::set(self.future(), None);
         Poll::Ready(v)
     }
 }

--- a/futures-util/src/future/inspect.rs
+++ b/futures-util/src/future/inspect.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -34,7 +34,7 @@ impl<Fut, F> Future for Inspect<Fut, F>
 {
     type Output = Fut::Output;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Fut::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Fut::Output> {
         let e = match self.future().poll(cx) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(e) => e,

--- a/futures-util/src/future/into_stream.rs
+++ b/futures-util/src/future/into_stream.rs
@@ -1,4 +1,4 @@
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -25,7 +25,7 @@ impl<Fut: Future> IntoStream<Fut> {
 impl<Fut: Future> Stream for IntoStream<Fut> {
     type Item = Fut::Output;
 
-    fn poll_next(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<Self::Item>> {
         let v = match self.future().as_pin_mut() {
             Some(fut) => {
                 match fut.poll(cx) {
@@ -36,7 +36,7 @@ impl<Fut: Future> Stream for IntoStream<Fut> {
             None => return Poll::Ready(None),
         };
 
-        PinMut::set(self.future(), None);
+        Pin::set(self.future(), None);
         Poll::Ready(Some(v))
     }
 }

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -2,7 +2,7 @@
 
 use crate::future::{MaybeDone, maybe_done};
 use core::fmt;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -48,7 +48,7 @@ macro_rules! generate {
 
             #[allow(clippy::useless_let_if_seq)]
             fn poll(
-                mut self: PinMut<Self>, cx: &mut task::Context
+                mut self: Pin<&mut Self>, cx: &mut task::Context
             ) -> Poll<Self::Output> {
                 let mut all_done = true;
                 $(

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
@@ -12,7 +12,7 @@ pub struct Lazy<F> {
     f: Option<F>
 }
 
-// safe because we never generate `PinMut<F>`
+// safe because we never generate `Pin<&mut F>`
 impl<F> Unpin for Lazy<F> {}
 
 /// Creates a new future that allows delayed execution of a closure.
@@ -46,7 +46,7 @@ impl<R, F> Future for Lazy<F>
 {
     type Output = R;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<R> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<R> {
         Poll::Ready((self.f.take().unwrap())(cx))
     }
 }

--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -32,7 +32,7 @@ impl<Fut, F, T> Future for Map<Fut, F>
 {
     type Output = T;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<T> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<T> {
         match self.future().poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(output) => {

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -2,7 +2,7 @@
 
 use core::marker::Unpin;
 use core::mem;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
@@ -35,10 +35,10 @@ impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
 ///
 /// let future = future::maybe_done(future::ready(5));
 /// pin_mut!(future);
-/// assert_eq!(future.reborrow().take_output(), None);
-/// let () = await!(future.reborrow());
-/// assert_eq!(future.reborrow().take_output(), Some(5));
-/// assert_eq!(future.reborrow().take_output(), None);
+/// assert_eq!(future.as_mut().take_output(), None);
+/// let () = await!(future.as_mut());
+/// assert_eq!(future.as_mut().take_output(), Some(5));
+/// assert_eq!(future.as_mut().take_output(), None);
 /// # });
 /// ```
 pub fn maybe_done<Fut: Future>(future: Fut) -> MaybeDone<Fut> {
@@ -52,9 +52,9 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// has not yet been called.
     #[inline]
     #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
-    pub fn output_mut<'a>(self: PinMut<'a, Self>) -> Option<&'a mut Fut::Output> {
+    pub fn output_mut<'a>(self: Pin<&'a mut Self>) -> Option<&'a mut Fut::Output> {
         unsafe {
-            let this = PinMut::get_mut_unchecked(self);
+            let this = Pin::get_mut_unchecked(self);
             match this {
                 MaybeDone::Done(res) => Some(res),
                 _ => None,
@@ -65,9 +65,9 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// Attempt to take the output of a `MaybeDone` without driving it
     /// towards completion.
     #[inline]
-    pub fn take_output(self: PinMut<Self>) -> Option<Fut::Output> {
+    pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Output> {
         unsafe {
-            let this = PinMut::get_mut_unchecked(self);
+            let this = Pin::get_mut_unchecked(self);
             match this {
                 MaybeDone::Done(_) => {},
                 MaybeDone::Future(_) | MaybeDone::Gone => return None,
@@ -84,11 +84,11 @@ impl<Fut: Future> MaybeDone<Fut> {
 impl<Fut: Future> Future for MaybeDone<Fut> {
     type Output = ();
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let res = unsafe {
-            match PinMut::get_mut_unchecked(self.reborrow()) {
+            match Pin::get_mut_unchecked(self.as_mut()) {
                 MaybeDone::Future(a) => {
-                    if let Poll::Ready(res) = PinMut::new_unchecked(a).poll(cx) {
+                    if let Poll::Ready(res) = Pin::new_unchecked(a).poll(cx) {
                         res
                     } else {
                         return Poll::Pending
@@ -98,7 +98,7 @@ impl<Fut: Future> Future for MaybeDone<Fut> {
                 MaybeDone::Gone => panic!("MaybeDone polled after value taken"),
             }
         };
-        PinMut::set(self, MaybeDone::Done(res));
+        Pin::set(self, MaybeDone::Done(res));
         Poll::Ready(())
     }
 }

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -4,7 +4,7 @@
 //! including the `FutureExt` trait which adds methods to `Future` types.
 
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll, Spawn};
@@ -68,8 +68,6 @@ mod chain;
 pub(crate) use self::chain::Chain;
 
 if_std! {
-    use std::pin::PinBox;
-
     mod abortable;
     pub use self::abortable::{abortable, Abortable, AbortHandle, AbortRegistration, Aborted};
 
@@ -625,10 +623,10 @@ pub trait FutureExt: Future {
 
     /// Wrap the future in a Box, pinning it.
     #[cfg(feature = "std")]
-    fn boxed(self) -> PinBox<Self>
+    fn boxed(self) -> Pin<Box<Self>>
         where Self: Sized
     {
-        PinBox::new(self)
+        Box::pinned(self)
     }
 
     /// Turns a `Future` into a `TryFuture` with `Error = ()`.
@@ -681,7 +679,7 @@ pub trait FutureExt: Future {
     fn poll_unpin(&mut self, cx: &mut task::Context) -> Poll<Self::Output>
         where Self: Unpin + Sized
     {
-        PinMut::new(self).poll(cx)
+        Pin::new(self).poll(cx)
     }
 }
 

--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -1,6 +1,6 @@
 //! Definition of the `Option` (optional step) combinator
 
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -37,7 +37,7 @@ impl<F: Future> Future for OptionFuture<F> {
     type Output = Option<F::Output>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Self::Output> {
         match self.option().as_pin_mut() {

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -1,7 +1,7 @@
 //! Definition of the `PollFn` adapter combinator
 
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
@@ -48,7 +48,7 @@ impl<T, F> Future for PollFn<F>
 {
     type Output = T;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<T> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<T> {
         (&mut self.f)(cx)
     }
 }

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 
@@ -16,7 +16,7 @@ impl<T> Future for Ready<T> {
     type Output = T;
 
     #[inline]
-    fn poll(mut self: PinMut<Self>, _cx: &mut task::Context) -> Poll<T> {
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut task::Context) -> Poll<T> {
         Poll::Ready(self.0.take().unwrap())
     }
 }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -4,7 +4,7 @@ use slab::Slab;
 use std::fmt;
 use std::cell::UnsafeCell;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
@@ -150,7 +150,7 @@ where
 {
     type Output = Fut::Output;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let this = &mut *self;
 
         this.set_waker(cx);
@@ -193,7 +193,7 @@ where
             // Poll the future
             let res = unsafe {
                 if let FutureOrOutput::Future(future) = &mut *this.inner.future_or_output.get() {
-                    PinMut::new_unchecked(future).poll(&mut cx)
+                    Pin::new_unchecked(future).poll(&mut cx)
                 } else {
                     unreachable!()
                 }

--- a/futures-util/src/future/then.rs
+++ b/futures-util/src/future/then.rs
@@ -1,5 +1,5 @@
 use super::Chain;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -35,7 +35,7 @@ impl<Fut1, Fut2, F> Future for Then<Fut1, Fut2, F>
 {
     type Output = Fut2::Output;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Fut2::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Fut2::Output> {
         self.chain().poll(cx, |output, f| f(output))
     }
 }

--- a/futures-util/src/future/unit_error.rs
+++ b/futures-util/src/future/unit_error.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -29,7 +29,7 @@ impl<Fut, T> Future for UnitError<Fut>
 {
     type Output = Result<T, ()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Result<T, ()>> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<T, ()>> {
         self.future().poll(cx).map(Ok)
     }
 }

--- a/futures-util/src/future/with_spawner.rs
+++ b/futures-util/src/future/with_spawner.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll, Spawn};
 
@@ -28,9 +28,9 @@ impl<Fut, Sp> Future for WithSpawner<Fut, Sp>
 {
     type Output = Fut::Output;
 
-    fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Fut::Output> {
-        let this = unsafe { PinMut::get_mut_unchecked(self) };
-        let fut = unsafe { PinMut::new_unchecked(&mut this.future) };
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Fut::Output> {
+        let this = unsafe { Pin::get_mut_unchecked(self) };
+        let fut = unsafe { Pin::new_unchecked(&mut this.future) };
         let spawner = &mut this.spawner;
         fut.poll(&mut cx.with_spawner(spawner))
     }

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -3,7 +3,7 @@ use futures_core::task::{self, Poll};
 use futures_io::AsyncWrite;
 use std::io;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// A future used to fully close an I/O object.
 ///
@@ -27,7 +27,7 @@ impl<'a, W: AsyncWrite + ?Sized> Close<'a, W> {
 impl<W: AsyncWrite + ?Sized> Future for Close<'_, W> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.writer.poll_close(cx)
     }
 }

--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -4,7 +4,7 @@ use futures_io::{AsyncRead, AsyncWrite};
 use std::boxed::Box;
 use std::io;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// A future which will copy all data from a reader into a writer.
 ///
@@ -23,7 +23,7 @@ pub struct CopyInto<'a, R: ?Sized + 'a, W: ?Sized + 'a> {
     buf: Box<[u8]>,
 }
 
-// No projections of PinMut<CopyInto> into PinMut<Field> are ever done.
+// No projections of Pin<&mut CopyInto> into Pin<&mut Field> are ever done.
 impl<R: ?Sized, W: ?Sized> Unpin for CopyInto<'_, R, W> {}
 
 impl<'a, R: ?Sized, W: ?Sized> CopyInto<'a, R, W> {
@@ -46,7 +46,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
 {
     type Output = io::Result<u64>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let this = &mut *self;
         loop {
             // If our buffer is empty, then we need to read some data to

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -2,7 +2,7 @@ use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use std::io;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 use futures_io::AsyncWrite;
 
@@ -32,7 +32,7 @@ impl<W> Future for Flush<'_, W>
 {
     type Output = io::Result<()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.writer.poll_flush(cx)
     }
 }

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -3,7 +3,7 @@ use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use std::io;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// A future which can be used to easily read available number of bytes to fill
 /// a buffer.
@@ -25,7 +25,7 @@ impl<'a, R: AsyncRead + ?Sized> Read<'a, R> {
 impl<R: AsyncRead + ?Sized> Future for Read<'_, R> {
     type Output = io::Result<usize>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let this = &mut *self;
         this.reader.poll_read(cx, this.buf)
     }

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -4,7 +4,7 @@ use futures_core::task::{self, Poll};
 use std::io;
 use std::marker::Unpin;
 use std::mem;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// A future which can be used to easily read exactly enough bytes to fill
 /// a buffer.
@@ -33,7 +33,7 @@ fn eof() -> io::Error {
 impl<R: AsyncRead + ?Sized> Future for ReadExact<'_, R> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let this = &mut *self;
         while !this.buf.is_empty() {
             let n = try_ready!(this.reader.poll_read(cx, this.buf));

--- a/futures-util/src/io/read_to_end.rs
+++ b/futures-util/src/io/read_to_end.rs
@@ -3,7 +3,7 @@ use futures_core::task::{self, Poll};
 use futures_io::AsyncRead;
 use std::io;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::vec::Vec;
 
 /// A future which can be used to easily read the entire contents of a stream
@@ -83,7 +83,7 @@ impl<A> Future for ReadToEnd<'_, A>
 {
     type Output = io::Result<()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         let this = &mut *self;
         read_to_end_internal(this.reader, cx, this.buf)
     }

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -2,7 +2,7 @@ use crate::lock::BiLock;
 use futures_core::task::{self, Poll};
 use futures_io::{AsyncRead, AsyncWrite, IoVec};
 use std::io;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// The readable half of an object returned from `AsyncRead::split`.
 #[derive(Debug)]
@@ -26,7 +26,7 @@ fn lock_and_then<T, U, E, F>(
     match lock.poll_lock(cx) {
         // Safety: the value behind the bilock used by `ReadHalf` and `WriteHalf` is never exposed
         // as a `PinMut` anywhere other than here as a way to get to `&mut`.
-        Poll::Ready(mut l) => f(unsafe { PinMut::get_mut_unchecked(l.as_pin_mut()) }, cx),
+        Poll::Ready(mut l) => f(unsafe { Pin::get_mut_unchecked(l.as_pin_mut()) }, cx),
         Poll::Pending => Poll::Pending,
     }
 }

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -4,7 +4,7 @@ use futures_io::AsyncWrite;
 use std::io;
 use std::marker::Unpin;
 use std::mem;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// A future used to write the entire contents of some data to a stream.
 ///
@@ -33,7 +33,7 @@ fn zero_write() -> io::Error {
 impl<W: AsyncWrite + ?Sized> Future for WriteAll<'_, W> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
         let this = &mut *self;
         while !this.buf.is_empty() {
             let n = try_ready!(this.writer.poll_write(cx, this.buf));

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -36,28 +36,28 @@ pub mod core_reexport {
 macro_rules! delegate_sink {
     ($field:ident) => {
         fn poll_ready(
-            mut self: PinMut<Self>,
+            mut self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context,
         ) -> $crate::core_reexport::task::Poll<Result<(), Self::SinkError>> {
             self.$field().poll_ready(cx)
         }
 
         fn start_send(
-            mut self: PinMut<Self>,
+            mut self: Pin<&mut Self>,
             item: Self::SinkItem
         ) -> Result<(), Self::SinkError> {
             self.$field().start_send(item)
         }
 
         fn poll_flush(
-            mut self: PinMut<Self>,
+            mut self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context
         ) -> $crate::core_reexport::task::Poll<Result<(), Self::SinkError>> {
             self.$field().poll_flush(cx)
         }
 
         fn poll_close(
-            mut self: PinMut<Self>,
+            mut self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context
         ) -> $crate::core_reexport::task::Poll<Result<(), Self::SinkError>> {
             self.$field().poll_close(cx)

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use futures_sink::Sink;
@@ -25,9 +25,9 @@ impl<Si: Sink + Unpin + ?Sized> Future for Close<'_, Si> {
     type Output = Result<(), Si::SinkError>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
-        PinMut::new(&mut self.sink).poll_close(cx)
+        Pin::new(&mut self.sink).poll_close(cx)
     }
 }

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use core::marker::PhantomData;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::task::{self, Poll};
 use futures_sink::Sink;
 
@@ -42,28 +42,28 @@ impl<T> Sink for Drain<T> {
     type SinkError = DrainError;
 
     fn poll_ready(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         _cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
     fn start_send(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         _item: Self::SinkItem,
     ) -> Result<(), Self::SinkError> {
         Ok(())
     }
 
     fn poll_flush(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         _cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
     fn poll_close(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         _cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -1,5 +1,5 @@
 use crate::sink::{SinkExt, SinkMapErr};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use futures_sink::{Sink};
@@ -62,7 +62,7 @@ impl<S, E> Stream for SinkErrInto<S, E>
     type Item = S::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<S::Item>> {
         self.sink().poll_next(cx)

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -1,5 +1,5 @@
 use core::fmt::{Debug, Formatter, Result as FmtResult};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::task::{self, Poll};
 use futures_sink::Sink;
 use pin_utils::unsafe_pinned;
@@ -51,7 +51,7 @@ impl<Si1, Si2> Sink for Fanout<Si1, Si2>
     type SinkError = Si1::SinkError;
 
     fn poll_ready(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         let sink1_ready = try_poll!(self.sink1().poll_ready(cx)).is_ready();
@@ -61,7 +61,7 @@ impl<Si1, Si2> Sink for Fanout<Si1, Si2>
     }
 
     fn start_send(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         item: Self::SinkItem,
     ) -> Result<(), Self::SinkError> {
         self.sink1().start_send(item.clone())?;
@@ -70,7 +70,7 @@ impl<Si1, Si2> Sink for Fanout<Si1, Si2>
     }
 
     fn poll_flush(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         let sink1_ready = try_poll!(self.sink1().poll_flush(cx)).is_ready();
@@ -80,7 +80,7 @@ impl<Si1, Si2> Sink for Fanout<Si1, Si2>
     }
 
     fn poll_close(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         let sink1_ready = try_poll!(self.sink1().poll_close(cx)).is_ready();

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use futures_sink::Sink;
@@ -31,9 +31,9 @@ impl<Si: Sink + Unpin + ?Sized> Future for Flush<'_, Si> {
     type Output = Result<(), Si::SinkError>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
-        PinMut::new(&mut self.sink).poll_flush(cx)
+        Pin::new(&mut self.sink).poll_flush(cx)
     }
 }

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use futures_sink::{Sink};
@@ -35,8 +35,8 @@ impl<Si, F> SinkMapErr<Si, F> {
 
     /// Get a pinned reference to the inner sink.
     #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, Si> {
-        unsafe { PinMut::map_unchecked(self, |x| &mut x.sink) }
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+        unsafe { Pin::map_unchecked_mut(self, |x| &mut x.sink) }
     }
 
     /// Consumes this combinator, returning the underlying sink.
@@ -47,7 +47,7 @@ impl<Si, F> SinkMapErr<Si, F> {
         self.sink
     }
 
-    fn take_f(mut self: PinMut<Self>) -> F {
+    fn take_f(mut self: Pin<&mut Self>) -> F {
         self.f().take().expect("polled MapErr after completion")
     }
 }
@@ -60,7 +60,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
     type SinkError = E;
 
     fn poll_ready(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         #[allow(clippy::redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
@@ -68,7 +68,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
     }
 
     fn start_send(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         item: Self::SinkItem,
     ) -> Result<(), Self::SinkError> {
         #[allow(clippy::redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
@@ -76,7 +76,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
     }
 
     fn poll_flush(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         #[allow(clippy::redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
@@ -84,7 +84,7 @@ impl<Si, F, E> Sink for SinkMapErr<Si, F>
     }
 
     fn poll_close(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         #[allow(clippy::redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
@@ -96,7 +96,7 @@ impl<S: Stream, F> Stream for SinkMapErr<S, F> {
     type Item = S::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<S::Item>> {
         self.sink().poll_next(cx)

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{self, Poll};
 use futures_sink::Sink;
@@ -29,15 +29,15 @@ impl<Si: Sink + Unpin + ?Sized> Future for Send<'_, Si> {
     type Output = Result<(), Si::SinkError>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         let this = &mut *self;
         if let Some(item) = this.item.take() {
-            let mut sink = PinMut::new(this.sink);
-            match sink.reborrow().poll_ready(cx) {
+            let mut sink = Pin::new(&mut this.sink);
+            match sink.as_mut().poll_ready(cx) {
                 Poll::Ready(Ok(())) => {
-                    if let Err(e) = sink.reborrow().start_send(item) {
+                    if let Err(e) = sink.as_mut().start_send(item) {
                         return Poll::Ready(Err(e));
                     }
                 }
@@ -51,7 +51,7 @@ impl<Si: Sink + Unpin + ?Sized> Future for Send<'_, Si> {
 
         // we're done sending the item, but want to block on flushing the
         // sink
-        try_ready!(PinMut::new(this.sink).poll_flush(cx));
+        try_ready!(Pin::new(&mut this.sink).poll_flush(cx));
 
         Poll::Ready(Ok(()))
     }

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -1,6 +1,6 @@
 use core::marker::{Unpin, PhantomData};
 use core::mem;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -63,16 +63,16 @@ impl<Fut, T> State<Fut, T> {
     #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     #[allow(clippy::wrong_self_convention)]
     fn as_pin_mut<'a>(
-        self: PinMut<'a, Self>,
-    ) -> State<PinMut<'a, Fut>, PinMut<'a, T>> {
+        self: Pin<&'a mut Self>,
+    ) -> State<Pin<&'a mut Fut>, Pin<&'a mut T>> {
         unsafe {
-            match PinMut::get_mut_unchecked(self) {
+            match Pin::get_mut_unchecked(self) {
                 State::Empty =>
                     State::Empty,
                 State::Process(fut) =>
-                    State::Process(PinMut::new_unchecked(fut)),
+                    State::Process(Pin::new_unchecked(fut)),
                 State::Buffered(item) =>
-                    State::Buffered(PinMut::new_unchecked(item)),
+                    State::Buffered(Pin::new_unchecked(item)),
             }
         }
     }
@@ -87,7 +87,7 @@ impl<S, U, Fut, F> Stream for With<S, U, Fut, F>
     type Item = S::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<S::Item>> {
         self.sink().poll_next(cx)
@@ -119,7 +119,7 @@ impl<Si, U, Fut, F, E> With<Si, U, Fut, F>
     }
 
     fn poll(
-        self: &mut PinMut<Self>,
+        self: &mut Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), E>> {
         let buffered = match self.state().as_pin_mut() {
@@ -128,9 +128,9 @@ impl<Si, U, Fut, F, E> With<Si, U, Fut, F>
             State::Buffered(_) => None,
         };
         if let Some(buffered) = buffered {
-            PinMut::set(self.state(), State::Buffered(buffered));
+            Pin::set(self.state(), State::Buffered(buffered));
         }
-        if let State::Buffered(item) = unsafe { mem::replace(PinMut::get_mut_unchecked(self.state()), State::Empty) } {
+        if let State::Buffered(item) = unsafe { mem::replace(Pin::get_mut_unchecked(self.state()), State::Empty) } {
             Poll::Ready(self.sink().start_send(item).map_err(Into::into))
         } else {
             unreachable!()
@@ -148,23 +148,23 @@ impl<Si, U, Fut, F, E> Sink for With<Si, U, Fut, F>
     type SinkError = E;
 
     fn poll_ready(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         self.poll(cx)
     }
 
     fn start_send(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         item: Self::SinkItem,
     ) -> Result<(), Self::SinkError> {
         let item = (self.f())(item);
-        PinMut::set(self.state(), State::Process(item));
+        Pin::set(self.state(), State::Process(item));
         Ok(())
     }
 
     fn poll_flush(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         try_ready!(self.poll(cx));
@@ -173,7 +173,7 @@ impl<Si, U, Fut, F, E> Sink for With<Si, U, Fut, F>
     }
 
     fn poll_close(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         try_ready!(self.poll(cx));

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -6,7 +6,7 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::fmt;
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// An adaptor for a stream of futures to execute the futures concurrently, if
 /// possible, delivering results as they become available.
@@ -86,8 +86,8 @@ where
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, St> {
-        unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -107,7 +107,7 @@ where
     type Item = <St::Item as Future>::Output;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         // First up, try to spawn off as many futures as possible by filling up
@@ -120,7 +120,7 @@ where
         }
 
         // Attempt to pull the next value from the in_progress_queue
-        match PinMut::new(self.in_progress_queue()).poll_next(cx) {
+        match Pin::new(self.in_progress_queue()).poll_next(cx) {
             x @ Poll::Pending | x @ Poll::Ready(Some(_)) => return x,
             Poll::Ready(None) => {}
         }

--- a/futures-util/src/stream/catch_unwind.rs
+++ b/futures-util/src/stream/catch_unwind.rs
@@ -2,7 +2,7 @@ use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::any::Any;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
 use std::prelude::v1::*;
 
@@ -30,7 +30,7 @@ impl<St: Stream + UnwindSafe> Stream for CatchUnwind<St>
     type Item = Result<St::Item, Box<dyn Any + Send>>;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         if *self.caught_unwind() {

--- a/futures-util/src/stream/chain.rs
+++ b/futures-util/src/stream/chain.rs
@@ -1,4 +1,4 @@
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -37,7 +37,7 @@ where St1: Stream,
     type Item = St1::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         if let Some(first) = self.first().as_pin_mut() {
@@ -45,7 +45,7 @@ where St1: Stream,
                 return Poll::Ready(Some(item))
             }
         }
-        PinMut::set(self.first(), None);
+        Pin::set(self.first(), None);
         self.second().poll_next(cx)
     }
 }

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -4,7 +4,7 @@ use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::marker::Unpin;
 use std::mem;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::prelude::v1::*;
 
 /// An adaptor that chunks up elements in a vector.
@@ -34,7 +34,7 @@ impl<St: Stream> Chunks<St> where St: Stream {
         }
     }
 
-    fn take(mut self: PinMut<Self>) -> Vec<St::Item> {
+    fn take(mut self: Pin<&mut Self>) -> Vec<St::Item> {
         let cap = self.items().capacity();
         mem::replace(self.items(), Vec::with_capacity(cap))
     }
@@ -67,7 +67,7 @@ impl<St: Stream> Stream for Chunks<St> {
     type Item = Vec<St::Item>;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         let cap = self.items.capacity();

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -4,7 +4,7 @@ use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::marker::Unpin;
 use std::mem;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::prelude::v1::*;
 
 /// A future which collects all of the values of a stream into a vector.
@@ -23,7 +23,7 @@ impl<St: Stream, C: Default> Collect<St, C> {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(collection: C);
 
-    fn finish(mut self: PinMut<Self>) -> C {
+    fn finish(mut self: Pin<&mut Self>) -> C {
         mem::replace(self.collection(), Default::default())
     }
 
@@ -41,7 +41,7 @@ where St: Stream,
 {
     type Output = C;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<C> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<C> {
         loop {
             match ready!(self.stream().poll_next(cx)) {
                 Some(e) => self.collection().extend(Some(e)),

--- a/futures-util/src/stream/concat.rs
+++ b/futures-util/src/stream/concat.rs
@@ -1,6 +1,6 @@
 use core::fmt::{Debug, Formatter, Result as FmtResult};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use core::default::Default;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
@@ -54,7 +54,7 @@ where St: Stream,
     type Output = St::Item;
 
     fn poll(
-        mut self: PinMut<Self>, cx: &mut task::Context
+        mut self: Pin<&mut Self>, cx: &mut task::Context
     ) -> Poll<Self::Output> {
         loop {
             match self.stream().poll_next(cx) {

--- a/futures-util/src/stream/disabled/select_all.rs
+++ b/futures-util/src/stream/disabled/select_all.rs
@@ -1,7 +1,7 @@
 //! An unbounded set of streams
 
 use std::fmt::{self, Debug};
-use std::pin::PinMut;
+use std::pin::Pin;
 
 use futures_core::{Poll, Stream};
 use futures_core::task;

--- a/futures-util/src/stream/empty.rs
+++ b/futures-util/src/stream/empty.rs
@@ -1,5 +1,5 @@
 use core::marker::{Unpin, PhantomData};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 
@@ -26,7 +26,7 @@ impl<T> Unpin for Empty<T> {}
 impl<T> Stream for Empty<T> {
     type Item = T;
 
-    fn poll_next(self: PinMut<Self>, _: &mut task::Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Option<Self::Item>> {
         Poll::Ready(None)
     }
 }

--- a/futures-util/src/stream/filter.rs
+++ b/futures-util/src/stream/filter.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -79,7 +79,7 @@ impl<St, Fut, F> Stream for Filter<St, Fut, F>
     type Item = St::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<St::Item>> {
         loop {
@@ -89,12 +89,12 @@ impl<St, Fut, F> Stream for Filter<St, Fut, F>
                     None => return Poll::Ready(None),
                 };
                 let fut = (self.f())(&item);
-                PinMut::set(self.pending_fut(), Some(fut));
+                Pin::set(self.pending_fut(), Some(fut));
                 *self.pending_item() = Some(item);
             }
 
             let yield_item = ready!(self.pending_fut().as_pin_mut().unwrap().poll(cx));
-            PinMut::set(self.pending_fut(), None);
+            Pin::set(self.pending_fut(), None);
             let item = self.pending_item().take().unwrap();
 
             if yield_item {

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -64,13 +64,13 @@ impl<St> Stream for Flatten<St>
     type Item = <St::Item as Stream>::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         loop {
             if self.next().as_pin_mut().is_none() {
                 match ready!(self.stream().poll_next(cx)) {
-                    Some(e) => PinMut::set(self.next(), Some(e)),
+                    Some(e) => Pin::set(self.next(), Some(e)),
                     None => return Poll::Ready(None),
                 }
             }
@@ -78,7 +78,7 @@ impl<St> Stream for Flatten<St>
             if item.is_some() {
                 return Poll::Ready(item);
             } else {
-                PinMut::set(self.next(), None);
+                Pin::set(self.next(), None);
             }
         }
     }

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -46,13 +46,13 @@ impl<St, Fut, T, F> Future for Fold<St, Fut, T, F>
 {
     type Output = T;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<T> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<T> {
         loop {
             // we're currently processing a future to produce a new accum value
             if self.accum().is_none() {
                 let accum = ready!(self.future().as_pin_mut().unwrap().poll(cx));
                 *self.accum() = Some(accum);
-                PinMut::set(self.future(), None);
+                Pin::set(self.future(), None);
             }
 
             let item = ready!(self.stream().poll_next(cx));
@@ -61,7 +61,7 @@ impl<St, Fut, T, F> Future for Fold<St, Fut, T, F>
 
             if let Some(e) = item {
                 let future = (self.f())(accum, e);
-                PinMut::set(self.future(), Some(future));
+                Pin::set(self.future(), Some(future));
             } else {
                 return Poll::Ready(accum)
             }

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -1,6 +1,6 @@
 use crate::stream::{FuturesUnordered, StreamExt};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use core::num::NonZeroUsize;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
@@ -55,7 +55,7 @@ impl<St, Fut, F> Future for ForEachConcurrent<St, Fut, F>
 {
     type Output = ();
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<()> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<()> {
         loop {
             let mut made_progress_this_iter = false;
 
@@ -80,7 +80,7 @@ impl<St, Fut, F> Future for ForEachConcurrent<St, Fut, F>
                     None
                 };
                 if stream_completed {
-                    PinMut::set(self.stream(), None);
+                    Pin::set(self.stream(), None);
                 }
                 if let Some(elem) = elem {
                     let next_future = (self.f())(elem);

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use futures_sink::Sink;
@@ -57,8 +57,8 @@ impl<St: Stream> Fuse<St> {
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
-    pub fn get_pin_mut<'a>(self: PinMut<'a, Self>) -> PinMut<'a, St> {
-        unsafe { PinMut::map_unchecked(self, |x| x.get_mut()) }
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -74,7 +74,7 @@ impl<S: Stream> Stream for Fuse<S> {
     type Item = S::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<S::Item>> {
         if *self.done() {

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -58,7 +58,7 @@ impl<St, F> Stream for Inspect<St, F>
     type Item = St::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<St::Item>> {
         let item = ready!(self.stream().poll_next(cx));

--- a/futures-util/src/stream/into_future.rs
+++ b/futures-util/src/stream/into_future.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -62,12 +62,12 @@ impl<St: Stream + Unpin> Future for StreamFuture<St> {
     type Output = (Option<St::Item>, St);
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Self::Output> {
         let item = {
             let s = self.stream.as_mut().expect("polling StreamFuture twice");
-            ready!(PinMut::new(s).poll_next(cx))
+            ready!(Pin::new(s).poll_next(cx))
         };
         let stream = self.stream.take().unwrap();
         Poll::Ready((item, stream))

--- a/futures-util/src/stream/iter.rs
+++ b/futures-util/src/stream/iter.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 
@@ -40,7 +40,7 @@ impl<I> Stream for Iter<I>
 {
     type Item = I::Item;
 
-    fn poll_next(mut self: PinMut<Self>, _: &mut task::Context) -> Poll<Option<I::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Option<I::Item>> {
         Poll::Ready(self.iter.next())
     }
 }

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -59,7 +59,7 @@ impl<St, F, T> Stream for Map<St, F>
     type Item = T;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<T>> {
         let option = ready!(self.stream().poll_next(cx));

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -4,7 +4,7 @@
 //! including the `StreamExt` trait which adds methods to `Stream` types.
 
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use either::Either;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
@@ -95,7 +95,6 @@ pub use self::zip::Zip;
 if_std! {
     use std;
     use std::iter::Extend;
-    use std::pin::PinBox;
 
     mod buffer_unordered;
     pub use self::buffer_unordered::BufferUnordered;
@@ -779,10 +778,10 @@ pub trait StreamExt: Stream {
 
     /// Wrap the stream in a Box, pinning it.
     #[cfg(feature = "std")]
-    fn boxed(self) -> PinBox<Self>
+    fn boxed(self) -> Pin<Box<Self>>
         where Self: Sized
     {
-        PinBox::new(self)
+        Box::pinned(self)
     }
 
     /// An adaptor for creating a buffered list of pending futures.
@@ -1037,6 +1036,6 @@ pub trait StreamExt: Stream {
     ) -> Poll<Option<Self::Item>>
     where Self: Unpin + Sized
     {
-        PinMut::new(self).poll_next(cx)
+        Pin::new(self).poll_next(cx)
     }
 }

--- a/futures-util/src/stream/next.rs
+++ b/futures-util/src/stream/next.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -23,9 +23,9 @@ impl<St: Stream + Unpin> Future for Next<'_, St> {
     type Output = Option<St::Item>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
-        PinMut::new(&mut *self.stream).poll_next(cx)
+        Pin::new(&mut *self.stream).poll_next(cx)
     }
 }

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -39,7 +39,7 @@ impl<Fut: Future> Stream for Once<Fut> {
     type Item = Fut::Output;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Fut::Output>> {
         let val = if let Some(f) = self.future().as_pin_mut() {
@@ -47,7 +47,7 @@ impl<Fut: Future> Stream for Once<Fut> {
         } else {
             return Poll::Ready(None)
         };
-        PinMut::set(self.future(), None);
+        Pin::set(self.future(), None);
         Poll::Ready(Some(val))
     }
 }

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -1,6 +1,6 @@
 use crate::stream::{StreamExt, Fuse};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -35,7 +35,7 @@ impl<St: Stream> Peekable<St> {
     /// This method polls the underlying stream and return either a reference
     /// to the next item if the stream is ready or passes through any errors.
     pub fn peek<'a>(
-        self: &'a mut PinMut<Self>,
+        self: &'a mut Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<&'a St::Item>> {
         if self.peeked().is_some() {
@@ -55,7 +55,7 @@ impl<S: Stream> Stream for Peekable<S> {
     type Item = S::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<Self::Item>> {
         if let Some(item) = self.peeked().take() {

--- a/futures-util/src/stream/poll_fn.rs
+++ b/futures-util/src/stream/poll_fn.rs
@@ -1,7 +1,7 @@
 //! Definition of the `PollFn` combinator
 
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 
@@ -48,7 +48,7 @@ where
 {
     type Item = T;
 
-    fn poll_next(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Option<T>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Option<T>> {
         (&mut self.f)(cx)
     }
 }

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 
@@ -38,7 +38,7 @@ impl<T> Stream for Repeat<T>
 {
     type Item = T;
 
-    fn poll_next(self: PinMut<Self>, _: &mut task::Context) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, _: &mut task::Context) -> Poll<Option<Self::Item>> {
         Poll::Ready(Some(self.item.clone()))
     }
 }

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,6 +1,6 @@
 use crate::stream::{StreamExt, Fuse};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 
@@ -43,13 +43,13 @@ impl<St1, St2> Stream for Select<St1, St2>
     type Item = St1::Item;
 
     fn poll_next(
-        self: PinMut<Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<St1::Item>> {
         let Select { flag, stream1, stream2 } =
-            unsafe { PinMut::get_mut_unchecked(self) };
-        let stream1 = unsafe { PinMut::new_unchecked(stream1) };
-        let stream2 = unsafe { PinMut::new_unchecked(stream2) };
+            unsafe { Pin::get_mut_unchecked(self) };
+        let stream1 = unsafe { Pin::new_unchecked(stream1) };
+        let stream2 = unsafe { Pin::new_unchecked(stream2) };
 
         if *flag {
             poll_inner(flag, stream1, stream2, cx)
@@ -61,8 +61,8 @@ impl<St1, St2> Stream for Select<St1, St2>
 
 fn poll_inner<St1, St2>(
     flag: &mut bool,
-    a: PinMut<St1>,
-    b: PinMut<St2>,
+    a: Pin<&mut St1>,
+    b: Pin<&mut St2>,
     cx: &mut task::Context
 ) -> Poll<Option<St1::Item>>
     where St1: Stream, St2: Stream<Item = St1::Item>

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -55,7 +55,7 @@ impl<St: Stream> Stream for Skip<St> {
     type Item = St::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<St::Item>> {
         while *self.remaining() > 0 {

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -57,7 +57,7 @@ impl<St> Stream for Take<St>
     type Item = St::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<St::Item>> {
         if *self.remaining() == 0 {

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -74,7 +74,7 @@ impl<St, Fut, F> Stream for TakeWhile<St, Fut, F>
     type Item = St::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<St::Item>> {
         if *self.done_taking() {
@@ -87,12 +87,12 @@ impl<St, Fut, F> Stream for TakeWhile<St, Fut, F>
                 None => return Poll::Ready(None),
             };
             let fut = (self.f())(&item);
-            PinMut::set(self.pending_fut(), Some(fut));
+            Pin::set(self.pending_fut(), Some(fut));
             *self.pending_item() = Some(item);
         }
 
         let take = ready!(self.pending_fut().as_pin_mut().unwrap().poll(cx));
-        PinMut::set(self.pending_fut(), None);
+        Pin::set(self.pending_fut(), None);
         let item = self.pending_item().take().unwrap();
 
         if take {

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
@@ -44,7 +44,7 @@ impl<St, Fut, F> Stream for Then<St, Fut, F>
     type Item = Fut::Output;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<Fut::Output>> {
         if self.future().as_pin_mut().is_none() {
@@ -53,11 +53,11 @@ impl<St, Fut, F> Stream for Then<St, Fut, F>
                 Some(e) => e,
             };
             let fut = (self.f())(item);
-            PinMut::set(self.future(), Some(fut));
+            Pin::set(self.future(), Some(fut));
         }
 
         let e = ready!(self.future().as_pin_mut().unwrap().poll(cx));
-        PinMut::set(self.future(), None);
+        Pin::set(self.future(), None);
         Poll::Ready(Some(e))
     }
 }

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -1,6 +1,6 @@
 use crate::stream::{StreamExt, Fuse};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -43,7 +43,7 @@ impl<St1, St2> Stream for Zip<St1, St2>
     type Item = (St1::Item, St2::Item);
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context
     ) -> Poll<Option<Self::Item>> {
         if self.queued1().is_none() {

--- a/futures-util/src/task/atomic_waker.rs
+++ b/futures-util/src/task/atomic_waker.rs
@@ -174,7 +174,7 @@ impl AtomicWaker {
     /// use futures::task::{self, Poll, AtomicWaker};
     /// use std::sync::atomic::AtomicBool;
     /// use std::sync::atomic::Ordering::SeqCst;
-    /// use std::pin::PinMut;
+    /// use std::pin::Pin;
     ///
     /// struct Flag {
     ///     waker: AtomicWaker,
@@ -184,7 +184,7 @@ impl AtomicWaker {
     /// impl Future for Flag {
     ///     type Output = ();
     ///
-    ///     fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<()> {
+    ///     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<()> {
     ///         // Register **before** checking `set` to avoid a race condition
     ///         // that would result in lost notifications.
     ///         self.waker.register(cx.waker());

--- a/futures-util/src/try_future/and_then.rs
+++ b/futures-util/src/try_future/and_then.rs
@@ -1,5 +1,5 @@
 use super::{TryChain, TryChainAction};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -32,7 +32,7 @@ impl<Fut1, Fut2, F> Future for AndThen<Fut1, Fut2, F>
 {
     type Output = Result<Fut2::Ok, Fut2::Error>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         self.try_chain().poll(cx, |result, async_op| {
             match result {
                 Ok(ok) => TryChainAction::Future(async_op(ok)),

--- a/futures-util/src/try_future/err_into.rs
+++ b/futures-util/src/try_future/err_into.rs
@@ -1,5 +1,5 @@
 use core::marker::{PhantomData, Unpin};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -32,7 +32,7 @@ impl<Fut, E> Future for ErrInto<Fut, E>
     type Output = Result<Fut::Ok, E>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         self.future().try_poll(cx)

--- a/futures-util/src/try_future/into_future.rs
+++ b/futures-util/src/try_future/into_future.rs
@@ -1,4 +1,4 @@
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -24,7 +24,7 @@ impl<Fut: TryFuture> Future for IntoFuture<Fut> {
 
     #[inline]
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         self.future().try_poll(cx)

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -31,7 +31,7 @@ impl<Fut, F, E> Future for MapErr<Fut, F>
     type Output = Result<Fut::Ok, E>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         match self.future().try_poll(cx) {

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -31,7 +31,7 @@ impl<Fut, F, T> Future for MapOk<Fut, F>
     type Output = Result<T, Fut::Error>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         match self.future().try_poll(cx) {

--- a/futures-util/src/try_future/or_else.rs
+++ b/futures-util/src/try_future/or_else.rs
@@ -1,5 +1,5 @@
 use super::{TryChain, TryChainAction};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -33,7 +33,7 @@ impl<Fut1, Fut2, F> Future for OrElse<Fut1, Fut2, F>
     type Output = Result<Fut2::Ok, Fut2::Error>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         self.try_chain().poll(cx, |result, async_op| {

--- a/futures-util/src/try_future/try_join.rs
+++ b/futures-util/src/try_future/try_join.rs
@@ -3,7 +3,7 @@
 use crate::future::{MaybeDone, maybe_done};
 use crate::try_future::{TryFutureExt, IntoFuture};
 use core::fmt;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -70,7 +70,7 @@ macro_rules! generate {
 
             #[allow(clippy::useless_let_if_seq)]
             fn poll(
-                mut self: PinMut<Self>, cx: &mut task::Context
+                mut self: Pin<&mut Self>, cx: &mut task::Context
             ) -> Poll<Self::Output> {
                 let mut all_done = true;
                 if self.Fut1().poll(cx).is_pending() {

--- a/futures-util/src/try_future/unwrap_or_else.rs
+++ b/futures-util/src/try_future/unwrap_or_else.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -32,7 +32,7 @@ impl<Fut, F> Future for UnwrapOrElse<Fut, F>
     type Output = Fut::Ok;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         match self.future().try_poll(cx) {

--- a/futures-util/src/try_stream/err_into.rs
+++ b/futures-util/src/try_stream/err_into.rs
@@ -1,5 +1,5 @@
 use core::marker::{PhantomData, Unpin};
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -30,7 +30,7 @@ where
     type Item = Result<St::Ok, E>;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         self.stream().try_poll_next(cx)

--- a/futures-util/src/try_stream/into_stream.rs
+++ b/futures-util/src/try_stream/into_stream.rs
@@ -1,4 +1,4 @@
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{self, Poll};
 use pin_utils::unsafe_pinned;
@@ -41,7 +41,7 @@ impl<St: TryStream> Stream for IntoStream<St> {
 
     #[inline]
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         self.stream().try_poll_next(cx)

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -33,7 +33,7 @@ where
 
     #[allow(clippy::redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         match self.stream().try_poll_next(cx) {

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -33,7 +33,7 @@ where
 
     #[allow(clippy::redundant_closure)] // https://github.com/rust-lang-nursery/rust-clippy/issues/1439
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         match self.stream().try_poll_next(cx) {

--- a/futures-util/src/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/try_stream/try_buffer_unordered.rs
@@ -6,7 +6,7 @@ use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::marker::Unpin;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 /// A stream returned by the
 /// [`try_buffer_unordered`](super::TryStreamExt::try_buffer_unordered) method
@@ -70,7 +70,7 @@ impl<St> Stream for TryBufferUnordered<St>
     type Item = Result<<St::Ok as TryFuture>::Ok, St::Error>;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<Self::Item>> {
         // First up, try to spawn off as many futures as possible by filling up
@@ -84,7 +84,7 @@ impl<St> Stream for TryBufferUnordered<St>
         }
 
         // Attempt to pull the next value from the in_progress_queue
-        match PinMut::new(self.in_progress_queue()).poll_next(cx) {
+        match Pin::new(self.in_progress_queue()).poll_next(cx) {
             x @ Poll::Pending | x @ Poll::Ready(Some(_)) => return x,
             Poll::Ready(None) => {}
         }

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -4,7 +4,7 @@ use futures_core::task::{self, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::marker::Unpin;
 use std::mem;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::prelude::v1::*;
 
 /// A future which attempts to collect all of the values of a stream.
@@ -28,7 +28,7 @@ impl<St: TryStream, C: Default> TryCollect<St, C> {
         }
     }
 
-    fn finish(mut self: PinMut<Self>) -> C {
+    fn finish(mut self: Pin<&mut Self>) -> C {
         mem::replace(self.items(), Default::default())
     }
 }
@@ -41,7 +41,7 @@ impl<St, C> Future for TryCollect<St, C>
     type Output = Result<C, St::Error>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
         loop {

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -1,5 +1,5 @@
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::stream::TryStream;
 use futures_core::task::{self, Poll};
@@ -44,17 +44,17 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
 {
     type Output = Result<(), St::Error>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         loop {
             if let Some(future) = self.future().as_pin_mut() {
                 try_ready!(future.try_poll(cx));
             }
-            PinMut::set(self.future(), None);
+            Pin::set(self.future(), None);
 
             match ready!(self.stream().try_poll_next(cx)) {
                 Some(Ok(e)) => {
                     let future = (self.f())(e);
-                    PinMut::set(self.future(), Some(future));
+                    Pin::set(self.future(), Some(future));
                 }
                 Some(Err(e)) => return Poll::Ready(Err(e)),
                 None => return Poll::Ready(Ok(())),

--- a/futures-util/src/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/try_stream/try_for_each_concurrent.rs
@@ -1,6 +1,6 @@
 use crate::stream::{FuturesUnordered, StreamExt};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 use core::num::NonZeroUsize;
 use futures_core::future::Future;
 use futures_core::stream::TryStream;
@@ -55,7 +55,7 @@ impl<St, Fut, F> Future for TryForEachConcurrent<St, Fut, F>
 {
     type Output = Result<(), St::Error>;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         loop {
             let mut made_progress_this_iter = false;
 
@@ -80,7 +80,7 @@ impl<St, Fut, F> Future for TryForEachConcurrent<St, Fut, F>
                     None
                 };
                 if stream_completed {
-                    PinMut::set(self.stream(), None);
+                    Pin::set(self.stream(), None);
                 }
                 if let Some(elem) = elem {
                     let next_future = (self.f())(elem);

--- a/futures-util/src/try_stream/try_next.rs
+++ b/futures-util/src/try_stream/try_next.rs
@@ -2,7 +2,7 @@ use futures_core::future::Future;
 use futures_core::stream::TryStream;
 use futures_core::task::{self, Poll};
 use core::marker::Unpin;
-use core::pin::PinMut;
+use core::pin::Pin;
 
 /// A future which attempts to collect all of the values of a stream.
 ///
@@ -25,10 +25,10 @@ impl<St: TryStream + Unpin> Future for TryNext<'_, St> {
     type Output = Result<Option<St::Ok>, St::Error>;
 
     fn poll(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Self::Output> {
-        match PinMut::new(&mut *self.stream).try_poll_next(cx) {
+        match Pin::new(&mut *self.stream).try_poll_next(cx) {
             Poll::Ready(Some(Ok(x))) => Poll::Ready(Ok(Some(x))),
             Poll::Ready(Some(Err(e))) => Poll::Ready(Err(e)),
             Poll::Ready(None) => Poll::Ready(Ok(None)),

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -5,7 +5,7 @@ use futures::future::{self, Future, FutureExt, TryFutureExt};
 use futures::task::{self, Poll};
 use futures_test::future::FutureTestExt;
 use pin_utils::unsafe_pinned;
-use std::pin::PinMut;
+use std::pin::Pin;
 use std::sync::mpsc;
 
 #[test]
@@ -56,7 +56,7 @@ impl<F, T> FutureData<F, T> {
 impl<F: Future, T: Send + 'static> Future for FutureData<F, T> {
     type Output = F::Output;
 
-    fn poll(mut self: PinMut<Self>, cx: &mut task::Context) -> Poll<F::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<F::Output> {
         self.future().poll(cx)
     }
 }

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -5,7 +5,7 @@ use futures::sink::{Sink, SinkExt};
 use futures::stream::{self, Stream, StreamExt};
 use futures::task::{self, Poll};
 use pin_utils::unsafe_pinned;
-use std::pin::PinMut;
+use std::pin::Pin;
 
 struct Join<T, U> {
     stream: T,
@@ -21,7 +21,7 @@ impl<T: Stream, U> Stream for Join<T, U> {
     type Item = T::Item;
 
     fn poll_next(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Option<T::Item>> {
         self.stream().poll_next(cx)
@@ -33,28 +33,28 @@ impl<T, U: Sink> Sink for Join<T, U> {
     type SinkError = U::SinkError;
 
     fn poll_ready(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         self.sink().poll_ready(cx)
     }
 
     fn start_send(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         item: Self::SinkItem,
     ) -> Result<(), Self::SinkError> {
         self.sink().start_send(item)
     }
 
     fn poll_flush(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         self.sink().poll_flush(cx)
     }
 
     fn poll_close(
-        mut self: PinMut<Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context,
     ) -> Poll<Result<(), Self::SinkError>> {
         self.sink().poll_close(cx)


### PR DESCRIPTION
There is no advanced changes with new API like using `Pin<Rc<T>>` or else. Just a direct conversion from before.