### PR TITLE
Use io::ErrorKind's Into<io::Error> trait

### DIFF
--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -65,9 +65,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
             while this.pos < this.cap {
                 let i = try_ready!(this.writer.poll_write(cx, &this.buf[this.pos..this.cap]));
                 if i == 0 {
-                    return Poll::Ready(Err(
-                        io::Error::new(
-                            io::ErrorKind::WriteZero, "write zero byte into writer")));
+                    return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
                 } else {
                     this.pos += i;
                     this.amt += i as u64;

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -26,10 +26,6 @@ impl<'a, R: AsyncRead + ?Sized> ReadExact<'a, R> {
     }
 }
 
-fn eof() -> io::Error {
-    io::Error::new(io::ErrorKind::UnexpectedEof, "early eof")
-}
-
 impl<R: AsyncRead + ?Sized> Future for ReadExact<'_, R> {
     type Output = io::Result<()>;
 
@@ -42,7 +38,7 @@ impl<R: AsyncRead + ?Sized> Future for ReadExact<'_, R> {
                 this.buf = rest;
             }
             if n == 0 {
-                return Poll::Ready(Err(eof()))
+                return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()))
             }
         }
         Poll::Ready(Ok(()))

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -26,10 +26,6 @@ impl<'a, W: AsyncWrite + ?Sized> WriteAll<'a, W> {
     }
 }
 
-fn zero_write() -> io::Error {
-    io::Error::new(io::ErrorKind::WriteZero, "zero-length write")
-}
-
 impl<W: AsyncWrite + ?Sized> Future for WriteAll<'_, W> {
     type Output = io::Result<()>;
 
@@ -42,7 +38,7 @@ impl<W: AsyncWrite + ?Sized> Future for WriteAll<'_, W> {
                 this.buf = rest;
             }
             if n == 0 {
-                return Poll::Ready(Err(zero_write()))
+                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
             }
         }
 


### PR DESCRIPTION
This avoid allocating.