### PR TITLE
auto-redirect 0.2 docs to 0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: nightly
-      script: cargo bench --all && cd futures-util && cargo bench --features=bench
     - rust: stable
       script:
         - cargo build --manifest-path futures-core/Cargo.toml --no-default-features
@@ -16,29 +15,11 @@ matrix:
         - cargo build --manifest-path futures-executor/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features
-    - rust: nightly
-      script:
-        - cargo build --manifest-path futures-core/Cargo.toml --features nightly
-        - cargo build --manifest-path futures-stable/Cargo.toml --features nightly
-        - cargo build --manifest-path futures-async-runtime/Cargo.toml --features nightly
-        - cargo build --manifest-path futures-macro-async/Cargo.toml --features nightly
-        - cargo build --manifest-path futures/Cargo.toml --features nightly
-        - cargo test --manifest-path futures-macro-await/Cargo.toml --features nightly
-        - cargo test --manifest-path futures-core/Cargo.toml --features nightly
-        - cargo test --manifest-path futures/Cargo.toml --features nightly
-    - rust: nightly
-      script:
-        - rustup target add thumbv6m-none-eabi
-        - cargo build --manifest-path futures/Cargo.toml --target thumbv6m-none-eabi --no-default-features --features nightly
     - rust: 1.20.0
       script: cargo test --all
-    - rust: nightly
-      script:
-        - cargo test --manifest-path futures/testcrate/Cargo.toml
 
 script:
   - cargo test --all
-  - cargo test --all --release
 
 env:
   global:

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -2,7 +2,7 @@
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
 #![no_std]
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/futures/0.1")]
 
 #[cfg(test)]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -37,3 +37,6 @@ futures-macro-await-preview = { path = "../futures-macro-await", version = "0.2.
 nightly = ["futures-core-preview/nightly", "futures-stable-preview/nightly", "futures-async-runtime-preview/nightly", "futures-macro-async-preview", "futures-macro-await-preview", "futures-macro-async-preview/nightly"]
 std = ["futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-stable-preview/std", "futures-util-preview/std", "futures-async-runtime-preview/std"]
 default = ["std"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--html-in-header", "yanked-redirect.html"]

--- a/futures/yanked-redirect.html
+++ b/futures/yanked-redirect.html
@@ -1,0 +1,4 @@
+<meta http-equiv="refresh" content="0; URL='https://docs.rs/futures/0.1.*'" />
+<script type="text/javascript">
+    window.location = "https://docs.rs/futures/0.1.*";
+</script>


### PR DESCRIPTION
Since https://docs.rs/futures still sends users to the yanked 0.2 docs, we can publish a new 0.2.3 version that is then immediately yanked, but includes a new auto redirect to the 0.1 docs.