### PR TITLE
0.2: fix rustdoc yanked-redirect path

### DIFF
--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -39,4 +39,4 @@ std = ["futures-core-preview/std", "futures-executor-preview/std", "futures-io-p
 default = ["std"]
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--html-in-header", "yanked-redirect.html"]
+rustdoc-args = ["--html-in-header", ".cargo/registry/src/github.com-1ecc6299db9ec823/futures-0.2.3-docs-yank.2/yanked-redirect.html"]


### PR DESCRIPTION
It appears that the path `.cargo/registry/src/github.com-1ecc6299db9ec823/` is constant. If a different version is used to actually publish, this needs adjusting.