### PR TITLE
Fix the stack overflow in the compat layers (#1283)

### DIFF
--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -33,6 +33,7 @@ futures-util-preview = { path = "../futures-util", version = "0.3.0-alpha.7", de
 [dev-dependencies]
 pin-utils = "0.1.0-alpha.3"
 futures-test-preview = { path = "../futures-test", version = "0.3.0-alpha.7", default-features = false }
+tokio = "0.1.11"
 
 [features]
 nightly = ["futures-util-preview/nightly"]

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,0 +1,18 @@
+#![feature(await_macro, async_await, futures_api)]
+#![cfg(feature = "compat")]
+
+use tokio::timer::Delay;
+use tokio::runtime::Runtime;
+use std::time::Instant;
+use futures::prelude::*;
+use futures::compat::Future01CompatExt;
+
+#[test]
+fn can_use_01_futures_in_a_03_future_running_on_a_01_executor() {
+    let f = async {
+        await!(Delay::new(Instant::now()).compat())
+    };
+
+    let mut runtime = Runtime::new().unwrap();
+    runtime.block_on(f.boxed().compat()).unwrap();
+}


### PR DESCRIPTION
Since the `LocalWaker` is dropped immediately after polling the `task01::Task` can be stored on the stack.

Fixes #1283.