### PR TITLE
Remove feature(tool_lints), it is stable

### DIFF
--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,7 +1,6 @@
 //! Core traits and types for asynchronous operations in Rust.
 
 #![feature(pin, arbitrary_self_types, futures_api)]
-#![feature(tool_lints)] // to allow clippy lints
 
 #![no_std]
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -2,7 +2,6 @@
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
 #![feature(async_await, pin, arbitrary_self_types, futures_api)]
-#![feature(tool_lints)]
 #![cfg_attr(feature = "std", feature(await_macro))]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 


### PR DESCRIPTION
Fixes failure in https://travis-ci.org/rust-lang-nursery/futures-rs/jobs/441068122 (for #1286). Not tested in CI since clippy is unavailable on latest nightly, but tested locally with `nightly-2018-10-14`.