### PR TITLE
[WIP] Revamp select! macro

### DIFF
--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -21,6 +21,38 @@ pub trait FusedFuture {
     fn is_terminated(&self) -> bool;
 }
 
+impl<F: FusedFuture> FusedFuture for Pin<&mut F> {
+    fn is_terminated(&self) -> bool {
+        <F as FusedFuture>::is_terminated(&**self)
+    }
+}
+
+impl<F: FusedFuture + ?Sized> FusedFuture for &mut F {
+    fn is_terminated(&self) -> bool {
+        <F as FusedFuture>::is_terminated(&**self)
+    }
+}
+
+if_std! {
+    impl<F: FusedFuture + ?Sized> FusedFuture for Box<F> {
+        fn is_terminated(&self) -> bool {
+            <F as FusedFuture>::is_terminated(&**self)
+        }
+    }
+
+    impl<F: FusedFuture + ?Sized> FusedFuture for Pin<Box<F>> {
+        fn is_terminated(&self) -> bool {
+            <F as FusedFuture>::is_terminated(&**self)
+        }
+    }
+
+    impl<F: FusedFuture> FusedFuture for std::panic::AssertUnwindSafe<F> {
+        fn is_terminated(&self) -> bool {
+            <F as FusedFuture>::is_terminated(&**self)
+        }
+    }
+}
+
 /// A convenience for futures that return `Result` values that includes
 /// a variety of adapters tailored to such futures.
 pub trait TryFuture {

--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -5,9 +5,12 @@
 
 use core::marker::Unpin;
 use futures_core::future::Future;
+use futures_core::stream::Stream;
 
 #[doc(hidden)]
 pub use futures_core::future::FusedFuture;
+#[doc(hidden)]
+pub use futures_core::stream::FusedStream;
 
 #[macro_use]
 mod poll;
@@ -27,8 +30,12 @@ mod select;
 
 #[doc(hidden)]
 #[inline(always)]
-pub fn assert_unpin<T: Future + Unpin>(_: &T) {}
+pub fn assert_unpin<T: Unpin>(_: &T) {}
 
 #[doc(hidden)]
 #[inline(always)]
 pub fn assert_fused_future<T: Future + FusedFuture>(_: &T) {}
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn assert_fused_stream<T: Stream + FusedStream>(_: &T) {}

--- a/futures-util/src/async_await/select.rs
+++ b/futures-util/src/async_await/select.rs
@@ -19,14 +19,14 @@
 /// let mut b = future::empty::<()>();
 ///
 /// let res = select! {
-///     future(a as a) => a + 1,
-///     future(b as _) => 0,
+///     done(a -> a) => a + 1,
+///     done(b -> _) => 0,
 /// };
 /// assert_eq!(res, 5);
 /// # });
 /// ```
 ///
-/// In addition to `future(...)` matchers, `select!` accepts an `all complete`
+/// In addition to `future(...)` matchers, `select!` accepts an `complete`
 /// branch which can be used to match on the case where all the futures passed
 /// to select have already completed.
 ///
@@ -41,9 +41,9 @@
 ///
 /// loop {
 ///     select! {
-///         future(a as a) => total += a,
-///         future(b as b) => total += b,
-///         all complete => break,
+///         done(a -> a) => total += a,
+///         done(b -> b) => total += b,
+///         complete => break,
 ///     };
 /// }
 /// assert_eq!(total, 10);
@@ -54,12 +54,56 @@ macro_rules! select {
     () => {
         compile_error!("The `select!` macro requires at least one branch")
     };
+
+	(
+        @codegen
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete ()
+        used_labels $used_labels:tt
+    ) => {
+        $crate::select! {
+            @codegen
+            dones $done
+            nexts $next
+            default $default
+            complete (
+                panic!("all futures in select! were completed, \
+                       but no `complete =>` handler was provided"))
+            used_labels $used_labels
+        }
+    };
+    // Remember the lack of a default
     (
-        $(
-            future($future_name:ident as $bound_pat:pat) => $body:expr,
-        )*
-        all complete => $complete:expr $(,)*
+        @codegen
+        dones $done:tt
+        nexts $next:tt
+        default ()
+        complete $complete:tt
+        used_labels $used_labels:tt
+    ) => {
+        $crate::select! {
+            @codegen
+            dones $done
+            nexts $next
+            default ( unreachable!() )
+            no_default true
+            complete $complete
+            used_labels $used_labels
+        }
+    };
+
+    (
+        @codegen
+        dones ($( $fut_label:ident ($fut_name:ident -> $fut_pat:pat) => $fut_body:expr, )*)
+        nexts ($( $st_label:ident ($st_name:ident -> $st_pat:pat) => $st_body:expr, )*)
+        default ($default:expr)
+        $( no_default $no_default:ident )*
+        complete ($complete:expr)
+        used_labels ($( $used_label:ident, )*)
     ) => { {
+
         // Require all arguments to be `Unpin` so that we don't have to pin them,
         // allowing uncompleted futures to be reused by the caller after the
         // `select!` resolves.
@@ -68,15 +112,20 @@ macro_rules! select {
         // we can ensure that futures aren't polled after completion by use
         // in successive `select!` statements.
         $(
-            $crate::async_await::assert_unpin(&$future_name);
-            $crate::async_await::assert_fused_future(&$future_name);
+            $crate::async_await::assert_unpin(&$fut_name);
+            $crate::async_await::assert_fused_future(&$fut_name);
+        )*
+        $(
+            $crate::async_await::assert_unpin(&$st_name);
+            $crate::async_await::assert_fused_stream(&$st_name);
         )*
 
         #[allow(bad_style)]
-        enum __PrivResult<$($future_name,)*> {
+        enum __PrivResult<$($used_label,)*> {
             $(
-                $future_name($future_name),
+                $used_label($used_label),
             )*
+            __Default,
 			__Complete,
         }
 
@@ -84,14 +133,21 @@ macro_rules! select {
             let mut __any_polled = false;
 
             $(
-                if !$crate::async_await::FusedFuture::is_terminated(& $future_name) {
+                let mut $fut_label = &mut $fut_name;
+            )*
+            $(
+                let mut $st_label = $crate::stream::StreamExt::next(&mut $st_name);
+            )*
+
+            $(
+                if !$crate::async_await::FusedFuture::is_terminated(& $used_label) {
                     __any_polled = true;
                     match $crate::core_reexport::future::Future::poll(
-                        $crate::core_reexport::pin::Pin::new(&mut $future_name), lw)
+                        $crate::core_reexport::pin::Pin::new(&mut $used_label), lw)
                     {
                         $crate::core_reexport::task::Poll::Ready(x) =>
                             return $crate::core_reexport::task::Poll::Ready(
-                                __PrivResult::$future_name(x)
+                                __PrivResult::$used_label(x)
                             ),
                         $crate::core_reexport::task::Poll::Pending => {},
                     }
@@ -99,36 +155,511 @@ macro_rules! select {
             )*
 
             if !__any_polled {
-                return $crate::core_reexport::task::Poll::Ready(
-                    __PrivResult::__Complete);
+                $crate::core_reexport::task::Poll::Ready(
+                    __PrivResult::__Complete)
+            } else {
+                $(
+                    // only if there isn't a default case:
+                    drop($no_default);
+                    return $crate::core_reexport::task::Poll::Pending;
+                )*
+                #[allow(unreachable_code)]
+                $crate::core_reexport::task::Poll::Ready(
+                    __PrivResult::__Default)
             }
-
-            $crate::core_reexport::task::Poll::Pending
         }));
         match __priv_res {
             $(
-                __PrivResult::$future_name($bound_pat) => {
-                    $body
+                __PrivResult::$fut_label($fut_pat) => {
+                    $fut_body
                 }
             )*
+            $(
+                __PrivResult::$st_label($st_pat) => {
+                    $st_body
+                }
+            )*
+            __PrivResult::__Default => {
+                $default
+            }
 			__PrivResult::__Complete => {
 				$complete
 			}
         }
     } };
 
-	(
-        $(
-            future($future_name:ident as $bound_pat:pat) => $body:expr $(,)*
-        )*
+    // All tokens have been successfully parsed into separate cases--
+    // continue to individual case parsing and separation.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens()
     ) => {
-        $crate::select! {
-            $(
-                future($future_name as $bound_pat) => $body,
-            )*
-            all complete =>
-                panic!("all futures in select! were completed, \
-                       but no `all complete =>` handler was provided"),
-        }
+        $crate::select!(
+            @parse_case
+            dones()
+            nexts()
+            default()
+            complete()
+            cases($($head)*)
+            labels(
+                case1
+                case2
+                case3
+                case4
+                case5
+                case6
+                case7
+                case8
+                case9
+                case10
+                case11
+                case12
+                case13
+                case14
+                case15
+                case16
+                case17
+                case18
+                case19
+                case20
+                case21
+                case22
+                case23
+                case24
+                case25
+                case26
+                case27
+                case28
+                case29
+                case30
+                case31
+            )
+            used_labels ()
+        )
+    };
+
+    // insert empty argument list after `default` and `complete`
+    (@parse_list
+        cases($($head:tt)*)
+        tokens(default => $($tail:tt)*)
+    ) => {
+        $crate::select!(
+            @parse_list
+            cases($($head)*)
+            tokens(default() => $($tail)*)
+        )
+    };
+    (@parse_list
+        cases($($head:tt)*)
+        tokens(complete => $($tail:tt)*)
+    ) => {
+        $crate::select!(
+            @parse_list
+            cases($($head)*)
+            tokens(complete() => $($tail)*)
+        )
+    };
+
+    // The first case is separated by a comma.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens($case:ident $args:tt => $body:expr, $($tail:tt)*)
+    ) => {
+        $crate::select!(
+            @parse_list
+            cases($($head)* $case $args => { $body },)
+            tokens($($tail)*)
+        )
+    };
+    // Print an error if there is a semicolon after the block.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens($case:ident $args:tt => $body:block; $($tail:tt)*)
+    ) => {
+        compile_error!("did you mean to put a comma instead of the semicolon after `}`?")
+    };
+
+    // Don't require a comma after the case if it has a proper block.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens($case:ident $args:tt => $body:block $($tail:tt)*)
+    ) => {
+        $crate::select!(
+            @parse_list
+            cases($($head)* $case $args => { $body },)
+            tokens($($tail)*)
+        )
+    };
+    // Only one case remains.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens($case:ident $args:tt => $body:expr)
+    ) => {
+        $crate::select!(
+            @parse_list
+            cases($($head)* $case $args => { $body },)
+            tokens()
+        )
+    };
+    // Accept a trailing comma at the end of the list.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens($case:ident $args:tt => $body:expr,)
+    ) => {
+        $crate::select!(
+            @parse_list
+            ($($head)* $case $args => { $body },)
+            ()
+        )
+    };
+    // Diagnose and print an error.
+    (@parse_list
+        cases($($head:tt)*)
+        tokens($(tail:tt)*)
+    ) => {
+        $crate::select!(@parse_list_error1 $($tail)*)
+    };
+    // Stage 1: check the case type.
+    (@parse_list_error1 recv $($tail:tt)*) => {
+        $crate::select!(@parse_list_error2 done $($tail)*)
+    };
+    (@parse_list_error1 send $($tail:tt)*) => {
+        $crate::select!(@parse_list_error2 next $($tail)*)
+    };
+    (@parse_list_error1 default $($tail:tt)*) => {
+        $crate::select!(@parse_list_error2 default $($tail)*)
+    };
+    (@parse_list_error1 complete $($tail:tt)*) => {
+        $crate::select!(@parse_list_error2 complete $($tail)*)
+    };
+    (@parse_list_error1 $t:tt $($tail:tt)*) => {
+        compile_error!(concat!(
+            "expected one of `done(...)`, `next(...)`, `default`, or `complete`, found `",
+            stringify!($t),
+            "`",
+        ))
+    };
+    (@parse_list_error1 $($tail:tt)*) => {
+        $crate::select!(@parse_list_error2 $($tail)*);
+    };
+    // Stage 2: check the argument list.
+    (@parse_list_error2 $case:ident) => {
+        compile_error!(concat!(
+            "missing argument list after `",
+            stringify!($case),
+            "`",
+        ))
+    };
+    (@parse_list_error2 $case:ident => $($tail:tt)*) => {
+        compile_error!(concat!(
+            "missing argument list after `",
+            stringify!($case),
+            "`",
+        ))
+    };
+    (@parse_list_error2 $($tail:tt)*) => {
+        $crate::select!(@parse_list_error3 $($tail)*)
+    };
+    // Stage 3: check the `=>` and what comes after it.
+    (@parse_list_error3 $case:ident($($args:tt)*)) => {
+        compile_error!(concat!(
+            "missing `=>` after the argument list of `",
+            stringify!($case),
+            "`",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) =>) => {
+        compile_error!("expected expression after `=>`")
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => $body:expr; $($tail:tt)*) => {
+        compile_error!(concat!(
+            "did you mean to put a comma instead of the semicolon after `",
+            stringify!($body),
+            "`?",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => recv($($a:tt)*) $($tail:tt)*) => {
+        compile_error!("expected an expression after `=>`")
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => send($($a:tt)*) $($tail:tt)*) => {
+        compile_error!("expected an expression after `=>`")
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => default($($a:tt)*) $($tail:tt)*) => {
+        compile_error!("expected an expression after `=>`")
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => $f:ident($($a:tt)*) $($tail:tt)*) => {
+        compile_error!(concat!(
+            "did you mean to put a comma after `",
+            stringify!($f),
+            "(",
+            stringify!($($a)*),
+            ")`?",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => $f:ident!($($a:tt)*) $($tail:tt)*) => {
+        compile_error!(concat!(
+            "did you mean to put a comma after `",
+            stringify!($f),
+            "!(",
+            stringify!($($a)*),
+            ")`?",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => $f:ident![$($a:tt)*] $($tail:tt)*) => {
+        compile_error!(concat!(
+            "did you mean to put a comma after `",
+            stringify!($f),
+            "![",
+            stringify!($($a)*),
+            "]`?",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => $f:ident!{$($a:tt)*} $($tail:tt)*) => {
+        compile_error!(concat!(
+            "did you mean to put a comma after `",
+            stringify!($f),
+            "!{",
+            stringify!($($a)*),
+            "}`?",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) => $body:tt $($tail:tt)*) => {
+        compile_error!(concat!(
+            "did you mean to put a comma after `",
+            stringify!($body),
+            "`?",
+        ))
+    };
+    (@parse_list_error3 $case:ident($($args:tt)*) $t:tt $($tail:tt)*) => {
+        compile_error!(concat!(
+            "expected `=>`, found `",
+            stringify!($t),
+            "`",
+        ))
+    };
+    (@parse_list_error3 $case:ident $args:tt $($tail:tt)*) => {
+        compile_error!(concat!(
+            "expected an argument list, found `",
+            stringify!($args),
+            "`",
+        ))
+    };
+    (@parse_list_error3 $($tail:tt)*) => {
+        $crate::select!(@parse_list_error4 $($tail)*)
+    };
+    // Stage 4: fail with a generic error message.
+    (@parse_list_error4 $($tail:tt)*) => {
+        compile_error!("invalid syntax")
+    };
+
+    // Success! all cases were parsed
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases ()
+        labels $labels:tt
+        used_labels $used:tt
+    ) => {
+        $crate::select!(
+            @codegen
+            dones $done
+            nexts $next
+            default $default
+            complete $complete
+            used_labels $used
+        )
+    };
+    // Error: no labels left
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases $cases:tt
+        labels ()
+        used_labels $used:tt
+    ) => {
+        compile_error!("too many cases in a `select!` block")
+    };
+    // Parse `done(future -> foo) => { ... }`
+    (@parse_case
+        dones ($($done:tt)*)
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases (done($fut:ident -> $pat:pat) => $body:tt, $($tail:tt)*)
+        labels ($label:tt $($labels:tt)*)
+        used_labels ($($used:tt)*)
+    ) => {
+        $crate::select!(
+            @parse_case
+            dones ($($done)* $label ($fut -> $pat) => $body,)
+            nexts $next
+            default $default
+            complete $complete
+            cases ($($tail)*)
+            labels ($($labels)*)
+            used_labels ($($used)* $label,)
+        )
+    };
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases (done $t:tt => $body:tt, $($tail:tt)*)
+        labels ($label:tt $($labels:tt)*)
+        used_labels $used:tt
+    ) => {
+        compile_error!(concat!(
+            "invalid syntax to `done`: `",
+            stringify!($t),
+            "`, expected `done(fut -> pat)`",
+        ))
+    };
+    // Parse `next(stream -> foo) => { ... }`
+    (@parse_case
+        dones $done:tt
+        nexts ($($next:tt)*)
+        default $default:tt
+        complete $complete:tt
+        cases (next($stream:ident -> $pat:pat) => $body:tt, $($tail:tt)*)
+        labels ($label:tt $($labels:tt)*)
+        used_labels ($($used:tt)*)
+    ) => {
+        $crate::select!(
+            @parse_case
+            dones $done
+            nexts ($($next)* $label ($stream -> $pat) => $body,)
+            default $default
+            complete $complete
+            cases ($($tail)*)
+            labels ($($labels)*)
+            used_labels ($($used)* $label,)
+        )
+    };
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases (next $t:tt => $body:tt, $($tail:tt)*)
+        labels ($label:tt $($labels:tt)*)
+        used_labels $used:tt
+    ) => {
+        compile_error!(concat!(
+            "invalid syntax to `next`: `",
+            stringify!($t),
+            "`, expected `next(stream -> pat)`",
+        ))
+    };
+    // Parse `default => { ... }`
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default ()
+        complete $complete:tt
+        cases (default() => $body:tt, $($tail:tt)*)
+        labels $labels:tt
+        used_labels $used:tt
+    ) => {
+        $crate::select!(
+            @parse_case
+            dones $done
+            nexts $next
+            default ($body)
+            complete $complete
+            cases ($($tail)*)
+            labels $labels
+            used_labels $used
+        )
+    };
+    // Error on multiple `default`s
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases (default() => $body:tt, $($tail:tt)*)
+        labels $labels:tt
+        used_labels $used:tt
+    ) => {
+        compile_error!("there can only be one `default` case in a `select!` block")
+    };
+    // Parse `complete => { ... }`
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete ()
+        cases (complete() => $body:tt, $($tail:tt)*)
+        labels $labels:tt
+        used_labels $used:tt
+    ) => {
+        $crate::select!(
+            @parse_case
+            dones $done
+            nexts $next
+            default $default
+            complete ($body)
+            cases ($($tail)*)
+            labels $labels
+            used_labels $used
+        )
+    };
+    // Error on multiple `complete`s
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases (complete() => $body:tt, $($tail:tt)*)
+        labels $labels:tt
+        used_labels $used:tt
+    ) => {
+        compile_error!("there can only be one `complete` case in a `select!` block")
+    };
+
+    // Catch errors in case parsing
+    (@parse_case
+        dones $done:tt
+        nexts $next:tt
+        default $default:tt
+        complete $complete:tt
+        cases ($case:ident $args:tt => $body:tt, $($tail:tt)*)
+        labels $labels:tt
+        used_labels $used:tt
+    ) => {
+        compile_error!(concat!(
+            "expected one of `done(fut -> x)`, `next(stream -> x)`, `default`, or `complete`, found `",
+            stringify!($case), stringify!($args),
+            "`",
+        ))
+    };
+
+    // Catches a bug within this macro (should not happen).
+    (@$($tokens:tt)*) => {
+        compile_error!(concat!(
+            "internal error in futures select macro: ",
+            stringify!(@$($tokens)*),
+        ))
+    };
+
+    ($($case:ident $(($($args:tt)*))* => $body:expr $(,)*)*) => {
+        $crate::select!(
+            @parse_list
+            cases()
+            tokens($($case $(($($args)*))* => $body,)*)
+        )
+    };
+
+    ($($tokens:tt)*) => {
+        $crate::select!(
+            @parse_list
+            cases()
+            tokens($($tokens)*)
+        )
     };
 }

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -72,7 +72,7 @@ impl<St: Stream> Fuse<St> {
 
 impl<S> FusedStream for Fuse<S> {
     fn is_terminated(&self) -> bool {
-        !self.done
+        self.done
     }
 }
 

--- a/futures-util/src/stream/next.rs
+++ b/futures-util/src/stream/next.rs
@@ -1,7 +1,7 @@
 use core::marker::Unpin;
 use core::pin::Pin;
-use futures_core::future::Future;
-use futures_core::stream::Stream;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};
 
 /// A future of the next element of a stream.
@@ -16,6 +16,12 @@ impl<St: Stream + Unpin> Unpin for Next<'_, St> {}
 impl<'a, St: Stream + Unpin> Next<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
         Next { stream }
+    }
+}
+
+impl<St: FusedStream> FusedFuture for Next<'_, St> {
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }
 

--- a/futures-util/src/try_stream/try_next.rs
+++ b/futures-util/src/try_stream/try_next.rs
@@ -1,5 +1,5 @@
-use futures_core::future::Future;
-use futures_core::stream::TryStream;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{LocalWaker, Poll};
 use core::marker::Unpin;
 use core::pin::Pin;
@@ -18,6 +18,12 @@ impl<St: Unpin> Unpin for TryNext<'_, St> {}
 impl<'a, St: TryStream + Unpin> TryNext<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
         TryNext { stream }
+    }
+}
+
+impl<St: Unpin + FusedStream> FusedFuture for TryNext<'_, St> {
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }
 


### PR DESCRIPTION
This is a WIP revamp of the select! macro, allowing it to take both futures and streams as arguments, adding `default` branches for when no futures are immediately able to make progress, and switching to a tt-muncher approach inspired by the similar [`select!` macro from crossbeam channel](https://github.com/crossbeam-rs/crossbeam-channel), which allows for mixed-order usage of `done` (future), `next` (stream), `default`, and `complete` branches, as well as better error handling (cc @stjepang).

TODO: lots more docs and tests, get feedback and iterate on exact syntax.