### PR TITLE
Fix Atom feed links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: Futures-rs
 baseurl: "/futures-rs"
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://rust-lang-nursery.github.io"
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
As noted here https://github.com/rust-lang-nursery/wg-net/issues/70 the atom feed links are missing url.

`site.url`

By default, this variable is only used in page head for the canonical header and the RSS link. It's also used in the xml feed to point to site resources as the software that will manage this feed doesn't know resource's urls. (https://stackoverflow.com/a/27400343/145434)

So, this change should help fix generated Atom feed urls without changing Jekyll version. As digged from various jekyll discussions (e.g. https://github.com/jekyll/jekyll/pull/5338) removing `url:` field altogether might also help.

Also, http://downtothewire.io/2015/08/15/configuring-jekyll-for-user-and-project-github-pages/ notes:
Exception: Start hyperlinks with {{ site.url }}{{ site.baseurl }} in feed pages, like atom.xml.

This is what jekyll-feed plugin does, by using absolute_url liqiud tag. (see https://github.com/jekyll/jekyll/pull/5339)

Unfortunately it's not easy to test without actually deploying it to Github Pages.