### PR TITLE
Replace if_std! macro with explicit #[cfg(feature = "std")]

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -12,15 +12,9 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.9/futures_channel")]
 
-macro_rules! if_std {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "std")]
-        $i
-    )*)
-}
-
-if_std! {
-    mod lock;
-    pub mod mpsc;
-    pub mod oneshot;
-}
+#[cfg(feature = "std")]
+mod lock;
+#[cfg(feature = "std")]
+pub mod mpsc;
+#[cfg(feature = "std")]
+pub mod oneshot;

--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -190,8 +190,9 @@ where
     unsafe fn drop(_ptr: *mut ()) {}
 }
 
-if_std! {
-    use std::boxed::Box;
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
     use std::mem;
 
     unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Box<F>

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -33,7 +33,9 @@ impl<F: FusedFuture + ?Sized> FusedFuture for &mut F {
     }
 }
 
-if_std! {
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
     impl<F: FusedFuture + ?Sized> FusedFuture for Box<F> {
         fn is_terminated(&self) -> bool {
             <F as FusedFuture>::is_terminated(&**self)

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -9,13 +9,6 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.9/futures_core")]
 
-macro_rules! if_std {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "std")]
-        $i
-    )*)
-}
-
 pub mod future;
 #[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};
 

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -145,8 +145,10 @@ impl<S, T, E> TryStream for S
     }
 }
 
-if_std! {
+#[cfg(feature = "std")]
+mod if_std {
     use std::boxed::Box;
+    use super::*;
 
     impl<S: ?Sized + Stream + Unpin> Stream for Box<S> {
         type Item = S::Item;

--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -193,8 +193,10 @@ where
     unsafe fn drop(_ptr: *mut ()) {}
 }
 
-if_std! {
+#[cfg(feature = "std")]
+mod if_std {
     use std::boxed::Box;
+    use super::*;
 
     unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for Box<F>
         where F: Stream<Item = T> + 'a

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -4,6 +4,5 @@ mod spawn;
 pub use self::spawn::{Spawn, LocalSpawn, SpawnError};
 
 pub use core::task::{Poll, Waker, LocalWaker, UnsafeWake};
-if_std! {
-    pub use std::task::{Wake, local_waker, local_waker_from_nonlocal};
-}
+#[cfg(feature = "std")]
+pub use std::task::{Wake, local_waker, local_waker_from_nonlocal};

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -9,21 +9,19 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.9/futures_executor")]
 
-macro_rules! if_std {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "std")]
-        $i
-    )*)
-}
+#[cfg(feature = "std")]
+mod local_pool;
+#[cfg(feature = "std")]
+pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
 
-if_std! {
-    mod local_pool;
-    pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
+#[cfg(feature = "std")]
+mod unpark_mutex;
+#[cfg(feature = "std")]
+mod thread_pool;
+#[cfg(feature = "std")]
+pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 
-    mod unpark_mutex;
-    mod thread_pool;
-    pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
-
-    mod enter;
-    pub use crate::enter::{enter, Enter, EnterError};
-}
+#[cfg(feature = "std")]
+mod enter;
+#[cfg(feature = "std")]
+pub use crate::enter::{enter, Enter, EnterError};

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -13,14 +13,8 @@
 
 #![feature(futures_api)]
 
-macro_rules! if_std {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "std")]
-        $i
-    )*)
-}
-
-if_std! {
+#[cfg(feature = "std")]
+mod if_std {
     use futures_core::task::{LocalWaker, Poll};
     use std::boxed::Box;
     use std::cmp;
@@ -32,9 +26,9 @@ if_std! {
 
     // Re-export io::Error so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
-    pub use crate::StdIo::Error as Error;
-    pub use crate::StdIo::ErrorKind as ErrorKind;
-    pub use crate::StdIo::Result as Result;
+    pub use self::StdIo::Error as Error;
+    pub use self::StdIo::ErrorKind as ErrorKind;
+    pub use self::StdIo::Result as Result;
 
     /// A type used to conditionally initialize buffers passed to `AsyncRead`
     /// methods, modeled after `std`.
@@ -385,3 +379,6 @@ if_std! {
         delegate_async_write_to_stdio!();
     }
 }
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -9,13 +9,6 @@
 
 #![feature(pin, arbitrary_self_types, futures_api)]
 
-macro_rules! if_std {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "std")]
-        $i
-    )*)
-}
-
 use futures_core::task::{LocalWaker, Poll};
 use core::marker::Unpin;
 use core::pin::Pin;
@@ -159,8 +152,12 @@ impl<'a, S: ?Sized + Sink> Sink for Pin<&'a mut S> {
     }
 }
 
-if_std! {
-    mod channel_impls;
+#[cfg(feature = "std")]
+mod channel_impls;
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
 
     /// The error type for `Vec` and `VecDequeue` when used as `Sink`s.
     /// Values of this type can never be created.
@@ -234,6 +231,9 @@ if_std! {
         }
     }
 }
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;
 
 #[cfg(feature = "either")]
 use either::Either;

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -64,29 +64,41 @@ pub use self::unit_error::UnitError;
 mod chain;
 pub(crate) use self::chain::Chain;
 
-if_std! {
-    mod abortable;
-    pub use self::abortable::{abortable, Abortable, AbortHandle, AbortRegistration, Aborted};
+#[cfg(feature = "std")]
+mod abortable;
+#[cfg(feature = "std")]
+pub use self::abortable::{abortable, Abortable, AbortHandle, AbortRegistration, Aborted};
 
-    mod catch_unwind;
-    pub use self::catch_unwind::CatchUnwind;
+#[cfg(feature = "std")]
+mod catch_unwind;
+#[cfg(feature = "std")]
+pub use self::catch_unwind::CatchUnwind;
 
-    mod remote_handle;
-    pub use self::remote_handle::{Remote, RemoteHandle};
+#[cfg(feature = "std")]
+mod remote_handle;
+#[cfg(feature = "std")]
+pub use self::remote_handle::{Remote, RemoteHandle};
 
-    // ToDo
-    // mod join_all;
-    // pub use self::join_all::{join_all, JoinAll};
+// ToDo
+// #[cfg(feature = "std")]
+// mod join_all;
+// #[cfg(feature = "std")]
+// pub use self::join_all::{join_all, JoinAll};
 
-    // mod select_all;
-    // pub use self::select_all::{SelectAll, SelectAllNext, select_all};
+// #[cfg(feature = "std")]
+// mod select_all;
+// #[cfg(feature = "std")]
+// pub use self::select_all::{SelectAll, SelectAllNext, select_all};
 
-    // mod select_ok;
-    // pub use self::select_ok::{SelectOk, select_ok};
+// #[cfg(feature = "std")]
+// mod select_ok;
+// #[cfg(feature = "std")]
+// pub use self::select_ok::{SelectOk, select_ok};
 
-    mod shared;
-    pub use self::shared::Shared;
-}
+#[cfg(feature = "std")]
+mod shared;
+#[cfg(feature = "std")]
+pub use self::shared::Shared;
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -11,25 +11,17 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.9/futures_util")]
 
-macro_rules! if_std {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "std")]
-        $i
-    )*)
-}
-
 #[macro_use]
 mod macros;
 
-if_std! {
-    // FIXME: currently async/await is only available with std
-    #[macro_use]
-    pub mod async_await;
+#[cfg(feature = "std")]
+#[macro_use]
+pub mod async_await;
 
-    #[doc(hidden)]
-    pub mod rand_reexport { // used by select!
-        pub use rand::*;
-    }
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub mod rand_reexport { // used by select!
+    pub use rand::*;
 }
 
 #[doc(hidden)]
@@ -89,12 +81,14 @@ pub mod task;
 #[cfg(feature = "compat")]
 pub mod compat;
 
-if_std! {
-    pub mod io;
-    #[doc(hidden)] pub use crate::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(feature = "std")]
+pub mod io;
+#[cfg(feature = "std")]
+#[doc(hidden)] pub use crate::io::{AsyncReadExt, AsyncWriteExt};
 
-    #[cfg(any(test, feature = "bench"))]
-    pub mod lock;
-    #[cfg(not(any(test, feature = "bench")))]
-    mod lock;
-}
+#[cfg(feature = "std")]
+#[cfg(any(test, feature = "bench"))]
+pub mod lock;
+#[cfg(feature = "std")]
+#[cfg(not(any(test, feature = "bench")))]
+mod lock;

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -42,10 +42,10 @@ pub use self::with::With;
 mod with_flat_map;
 pub use self::with_flat_map::WithFlatMap;
 
-if_std! {
-    mod buffer;
-    pub use self::buffer::Buffer;
-}
+#[cfg(feature = "std")]
+mod buffer;
+#[cfg(feature = "std")]
+pub use self::buffer::Buffer;
 
 impl<T: ?Sized> SinkExt for T where T: Sink {}
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -92,41 +92,61 @@ pub use self::unfold::{unfold, Unfold};
 mod zip;
 pub use self::zip::Zip;
 
-if_std! {
-    use std;
-    use std::iter::Extend;
+#[cfg(feature = "std")]
+use std;
+#[cfg(feature = "std")]
+use std::iter::Extend;
 
-    mod buffer_unordered;
-    pub use self::buffer_unordered::BufferUnordered;
+#[cfg(feature = "std")]
+mod buffer_unordered;
+#[cfg(feature = "std")]
+pub use self::buffer_unordered::BufferUnordered;
 
-    mod buffered;
-    pub use self::buffered::Buffered;
+#[cfg(feature = "std")]
+mod buffered;
+#[cfg(feature = "std")]
+pub use self::buffered::Buffered;
 
-    mod catch_unwind;
-    pub use self::catch_unwind::CatchUnwind;
+#[cfg(feature = "std")]
+mod catch_unwind;
+#[cfg(feature = "std")]
+pub use self::catch_unwind::CatchUnwind;
 
-    mod chunks;
-    pub use self::chunks::Chunks;
+#[cfg(feature = "std")]
+mod chunks;
+#[cfg(feature = "std")]
+pub use self::chunks::Chunks;
 
-    mod collect;
-    pub use self::collect::Collect;
+#[cfg(feature = "std")]
+mod collect;
+#[cfg(feature = "std")]
+pub use self::collect::Collect;
 
-    mod for_each_concurrent;
-    pub use self::for_each_concurrent::ForEachConcurrent;
+#[cfg(feature = "std")]
+mod for_each_concurrent;
+#[cfg(feature = "std")]
+pub use self::for_each_concurrent::ForEachConcurrent;
 
-    mod futures_ordered;
-    pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
+#[cfg(feature = "std")]
+mod futures_ordered;
+#[cfg(feature = "std")]
+pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
 
-    mod futures_unordered;
-    pub use self::futures_unordered::{futures_unordered, FuturesUnordered};
+#[cfg(feature = "std")]
+mod futures_unordered;
+#[cfg(feature = "std")]
+pub use self::futures_unordered::{futures_unordered, FuturesUnordered};
 
-    mod split;
-    pub use self::split::{SplitStream, SplitSink, ReuniteError};
+#[cfg(feature = "std")]
+mod split;
+#[cfg(feature = "std")]
+pub use self::split::{SplitStream, SplitSink, ReuniteError};
 
-    // ToDo
-    // mod select_all;
-    // pub use self::select_all::{select_all, SelectAll};
-}
+// ToDo
+// #[cfg(feature = "std")]
+// mod select_all;
+// #[cfg(feature = "std")]
+// pub use self::select_all::{select_all, SelectAll};
 
 impl<T: ?Sized> StreamExt for T where T: Stream {}
 

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -6,10 +6,10 @@ pub use self::noop_waker::{noop_local_waker, noop_local_waker_ref};
 mod spawn;
 pub use self::spawn::{SpawnExt, LocalSpawnExt};
 
-if_std! {
-    mod local_waker_ref;
-    pub use self::local_waker_ref::{local_waker_ref, local_waker_ref_from_nonlocal, LocalWakerRef};
-}
+#[cfg(feature = "std")]
+mod local_waker_ref;
+#[cfg(feature = "std")]
+pub use self::local_waker_ref::{local_waker_ref, local_waker_ref_from_nonlocal, LocalWakerRef};
 
 #[cfg_attr(
     feature = "nightly",

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -2,11 +2,12 @@ use futures_core::task::{LocalSpawn, Spawn};
 
 #[cfg(feature = "compat")] use crate::compat::Compat;
 
-if_std! {
-    use crate::future::{FutureExt, RemoteHandle};
-    use futures_core::future::{Future, FutureObj, LocalFutureObj};
-    use futures_core::task::SpawnError;
-}
+#[cfg(feature = "std")]
+use crate::future::{FutureExt, RemoteHandle};
+#[cfg(feature = "std")]
+use futures_core::future::{Future, FutureObj, LocalFutureObj};
+#[cfg(feature = "std")]
+use futures_core::task::SpawnError;
 
 impl<Sp: ?Sized> SpawnExt for Sp where Sp: Spawn {}
 impl<Sp: ?Sized> LocalSpawnExt for Sp where Sp: LocalSpawn {}

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -15,14 +15,18 @@ mod select;
 pub use self::join::{Join, Join3, Join4, Join5};
 pub use self::select::Select;
 
-if_std! {
+#[cfg(feature = "std")]
 mod join_all;
+#[cfg(feature = "std")]
 mod select_all;
+#[cfg(feature = "std")]
 mod select_ok;
+#[cfg(feature = "std")]
 pub use self::join_all::{join_all, JoinAll};
+#[cfg(feature = "std")]
 pub use self::select_all::{SelectAll, SelectAllNext, select_all};
+#[cfg(feature = "std")]
 pub use self::select_ok::{SelectOk, select_ok};
-}
 */
 
 // Combinators

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -37,17 +37,22 @@ pub use self::try_fold::TryFold;
 mod try_skip_while;
 pub use self::try_skip_while::TrySkipWhile;
 
-if_std! {
-    mod try_buffer_unordered;
-    pub use self::try_buffer_unordered::TryBufferUnordered;
+#[cfg(feature = "std")]
+mod try_buffer_unordered;
+#[cfg(feature = "std")]
+pub use self::try_buffer_unordered::TryBufferUnordered;
 
-    mod try_collect;
-    pub use self::try_collect::TryCollect;
+#[cfg(feature = "std")]
+mod try_collect;
+#[cfg(feature = "std")]
+pub use self::try_collect::TryCollect;
 
-    mod try_for_each_concurrent;
-    pub use self::try_for_each_concurrent::TryForEachConcurrent;
-    use futures_core::future::Future;
-}
+#[cfg(feature = "std")]
+mod try_for_each_concurrent;
+#[cfg(feature = "std")]
+pub use self::try_for_each_concurrent::TryForEachConcurrent;
+#[cfg(feature = "std")]
+use futures_core::future::Future;
 
 impl<S: TryStream> TryStreamExt for S {}
 


### PR DESCRIPTION
`if_std` hurts intellij-rust development experience: navigation,
completion work half of the time.

In Idea with code like this:

```
macro_rules! if_std {
    ($($i:item)*) => ($(
        $i
    )*)
}

if_std! {
    struct Foo;

    impl Foo {
        fn bar(&self) {}
    }
}

fn main() {
    let baz = Foo;
    baz.bar();
}
```

cmd-click on `baz.bar()` won't navigate to function definitions.

This is an issue not only when developing future-rs, but also when
developing a project which uses futures-rs.