### PR TITLE
Add a new ManualResetEvent synchronization primitive

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -18,3 +18,5 @@ mod lock;
 pub mod mpsc;
 #[cfg(feature = "std")]
 pub mod oneshot;
+#[cfg(feature = "std")]
+pub mod manual_reset_event;

--- a/futures-channel/src/manual_reset_event.rs
+++ b/futures-channel/src/manual_reset_event.rs
@@ -2,7 +2,7 @@
 
 use futures_core::future::{Future, FusedFuture};
 use futures_core::task::{LocalWaker, Poll, Waker};
-use std::marker::{Pinned};
+use std::marker::{PhantomPinned};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -30,7 +30,7 @@ struct WaitHandleRegistration {
     terminated: bool,
     /// Prevents the WaitHandleRegistration from being moved.
     /// This is important, since the address of the WaitHandleRegistration must be stable once polled.
-    _pin: Pinned,
+    _pin: PhantomPinned,
 }
 
 impl WaitHandleRegistration {
@@ -41,7 +41,7 @@ impl WaitHandleRegistration {
             next: null_mut(),
             state: PollState::New,
             terminated: false,
-            _pin: Pinned,
+            _pin: PhantomPinned,
         }
     }
 }

--- a/futures-channel/src/manual_reset_event.rs
+++ b/futures-channel/src/manual_reset_event.rs
@@ -46,7 +46,9 @@ impl WaitHandleRegistration {
     }
 }
 
+/// A Future that is resolved once the corresponding ManualResetEvent has been set
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 struct WaitHandle {
     /// The ManualResetEvent this is associated with this WaitHandle
     event: Arc<Mutex<InnerEventState>>,
@@ -54,7 +56,9 @@ struct WaitHandle {
     reg: WaitHandleRegistration,
 }
 
+/// A Future that is resolved once the corresponding LocalManualResetEvent has been set
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 struct LocalWaitHandle<'a> {
     /// The LocalManualResetEvent this is associated with this WaitHandle
     event: &'a RefCell<InnerEventState>,

--- a/futures-channel/src/manual_reset_event.rs
+++ b/futures-channel/src/manual_reset_event.rs
@@ -132,7 +132,7 @@ impl InnerEventState {
     }
 
     fn is_set(&self) -> bool {
-        return self.is_set;
+        self.is_set
     }
 
     /// Polls one WaitHandle for completion. If the event isn't set, the WaitHandle gets registered
@@ -318,13 +318,13 @@ impl Future for WaitHandle {
 
 impl FusedFuture for WaitHandle {
     fn is_terminated(&self) -> bool {
-        return self.reg.terminated;
+        self.reg.terminated
     }
 }
 
 impl<'a> FusedFuture for LocalWaitHandle<'a> {
     fn is_terminated(&self) -> bool {
-        return self.reg.terminated;
+        self.reg.terminated
     }
 }
 

--- a/futures-channel/src/manual_reset_event.rs
+++ b/futures-channel/src/manual_reset_event.rs
@@ -1,0 +1,348 @@
+//! An event for signalization between tasks
+
+use futures_core::future::{Future, FusedFuture};
+use futures_core::task::{LocalWaker, Poll, Waker};
+use std::marker::{Pinned};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::ptr::null_mut;
+use std::cell::RefCell;
+
+#[derive(Debug, PartialEq)]
+enum PollState {
+    New,
+    Waiting,
+    Done,
+}
+
+/// Tracks the WaitHandle registration state.
+/// Access to this struct is synchronized through the mutex in the Event.
+#[derive(Debug)]
+struct WaitHandleRegistration {
+    /// The task handle of the waiting task
+    task: Option<Waker>,
+    /// Next WaitHandleRegistration in the intrusive list
+    next: *mut WaitHandleRegistration,
+    /// Current polling state
+    state: PollState,
+    /// Whether WaitHandle has been polled to completion
+    terminated: bool,
+    /// Prevents the WaitHandleRegistration from being moved.
+    /// This is important, since the address of the WaitHandleRegistration must be stable once polled.
+    _pin: Pinned,
+}
+
+impl WaitHandleRegistration {
+    /// Creates a new WaitHandleRegistration
+    fn new() -> WaitHandleRegistration {
+        WaitHandleRegistration {
+            task: None,
+            next: null_mut(),
+            state: PollState::New,
+            terminated: false,
+            _pin: Pinned,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct WaitHandle {
+    /// The ManualResetEvent this is associated with this WaitHandle
+    event: Arc<Mutex<InnerEventState>>,
+    /// Registration at the event
+    reg: WaitHandleRegistration,
+}
+
+#[derive(Debug)]
+struct LocalWaitHandle<'a> {
+    /// The LocalManualResetEvent this is associated with this WaitHandle
+    event: &'a RefCell<InnerEventState>,
+    /// Registration at the event
+    reg: WaitHandleRegistration,
+}
+
+/// A synchronization primitive which can be either in the set or reset state.
+///
+/// Tasks can wait for the event to get set by obtaining a Future via poll_set.
+/// This Future will get fulfilled when the event had been set.
+#[derive(Debug, Clone)]
+pub struct ManualResetEvent {
+    inner: Arc<Mutex<InnerEventState>>,
+}
+
+// Automatic derive doesn't work due to the unsafe pointer in WaitHandleRegistration
+unsafe impl Send for ManualResetEvent {}
+unsafe impl Sync for ManualResetEvent {}
+
+/// A synchronization primitive which can be either in the set or reset state.
+///
+/// Tasks can wait for the event to get set by obtaining a Future via poll_set.
+/// This Future will get fulfilled when the event had been set.
+#[derive(Debug)]
+pub struct LocalManualResetEvent {
+    inner: RefCell<InnerEventState>,
+}
+
+/// Internal state of the `ManualResetEvent` pair above
+#[derive(Debug)]
+struct InnerEventState {
+    is_set: bool,
+    waiters: *mut WaitHandleRegistration,
+}
+
+impl InnerEventState {
+    fn new(is_set: bool) -> InnerEventState {
+        InnerEventState {
+            is_set,
+            waiters: null_mut(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.is_set = false;
+    }
+
+    fn set(&mut self) {
+        if self.is_set != true {
+            self.is_set = true;
+
+            // Wakeup all waiters
+            // This happens inside the lock to make cancellation reliable
+            // If we would access waiters outside of the lock, the pointers
+            // may no longer be valid.
+            // Typically this shouldn't be an issue, since waking a task should
+            // only move it from the blocked into the ready state and not have
+            // further side effects.
+
+            let mut waiter = self.waiters;
+            self.waiters = null_mut();
+
+            unsafe {
+                while waiter != null_mut() {
+                    let task = (*waiter).task.take();
+                    if let Some(ref handle) = task {
+                        handle.wake();
+                    }
+                    (*waiter).state = PollState::Done;
+                    waiter = (*waiter).next;
+                }
+            }
+        }
+    }
+
+    fn is_set(&self) -> bool {
+        return self.is_set;
+    }
+
+    /// Polls one WaitHandle for completion. If the event isn't set, the WaitHandle gets registered
+    /// at the event, and will be signalled once ready.
+    fn poll_waiter(
+        &mut self,
+        wait_handle: Pin<&mut WaitHandleRegistration>,
+        lw: &LocalWaker,
+    ) -> Poll<()> {
+        let wait_handle: &mut WaitHandleRegistration = unsafe { Pin::get_mut_unchecked(wait_handle) };
+        let addr = wait_handle as *mut WaitHandleRegistration;
+
+        match wait_handle.state {
+            PollState::New => {
+                if self.is_set {
+                    // The event is already signaled
+                    wait_handle.state = PollState::Done;
+                    wait_handle.terminated = true;
+                    Poll::Ready(())
+                }
+                else {
+                    // Register the WaitHandle at the event
+                    wait_handle.task = Some(lw.clone().into_waker());
+                    wait_handle.state = PollState::Waiting;
+                    wait_handle.next = self.waiters;
+                    self.waiters = addr;
+                    Poll::Pending
+                }
+            },
+            PollState::Waiting => {
+                // The WaitHandle is already registered.
+                // The event can't have been set, since this would change the
+                // waitstate inside the mutex.
+                Poll::Pending
+            },
+            PollState::Done => {
+                // We had been woken up by the event.
+                // This does not guarantee that the event is still set. It could
+                // have been reset it in the meantime.
+                wait_handle.terminated = true;
+                Poll::Ready(())
+            },
+        }
+    }
+
+    fn remove_waiter(&mut self, wait_handle: &mut WaitHandleRegistration) {
+        let addr = wait_handle as *mut WaitHandleRegistration;
+
+        match wait_handle.state {
+            PollState::Waiting => {
+                // Remove the WaitHandle from the linked list
+                if self.waiters == addr {
+                    self.waiters = wait_handle.next;
+                } else {
+                    // Find the WaitHandle before us and link it to the one
+                    // behind us
+                    let mut iter = self.waiters;
+                    let mut found_addr = false;
+
+                    unsafe {
+                        while iter != null_mut() {
+                            if (*iter).next == addr {
+                                (*iter).next = wait_handle.next;
+                                found_addr = true;
+                                break;
+                            } else {
+                                iter = (*iter).next;
+                            }
+                        }
+                    }
+
+                    // Panic if the address isn't found. This can only happen if the contract was
+                    // violated, e.g. the WaitHandle got moved after the initial poll.
+                    assert!(found_addr, "Future could not be unregistered");
+                }
+                wait_handle.next = null_mut();
+                wait_handle.state = PollState::Done;
+            },
+            _ => {},
+        }
+    }
+}
+
+/// Creates a new LocalManualResetEvent in the given state
+pub fn local_manual_reset_event(is_set: bool) -> LocalManualResetEvent {
+    LocalManualResetEvent {
+        inner: RefCell::new(InnerEventState::new(is_set)),
+    }
+}
+
+impl<'a> LocalManualResetEvent {
+    /// Sets the event.
+    ///
+    /// Setting the event will notify all pending waiters.
+    pub fn set(&self) {
+        self.inner.borrow_mut().set()
+    }
+
+    /// Resets the event.
+    pub fn reset(&self) {
+        self.inner.borrow_mut().reset()
+    }
+
+    /// Returns whether the event is set
+    pub fn is_set(&self) -> bool {
+        self.inner.borrow().is_set()
+    }
+
+    /// Returns a future that gets fulfilled when the event is set.
+    pub fn poll_set(&'a self) -> impl Future<Output = ()> + FusedFuture + 'a {
+        LocalWaitHandle {
+            event: &self.inner,
+            reg: WaitHandleRegistration::new(),
+        }
+    }
+}
+
+
+/// Creates a new ManualResetEvent in the given state
+pub fn manual_reset_event(is_set: bool) -> ManualResetEvent {
+    let inner = Arc::new(Mutex::new(InnerEventState::new(is_set)));
+    ManualResetEvent {
+        inner,
+    }
+}
+
+impl ManualResetEvent {
+    /// Sets the event.
+    ///
+    /// Setting the event will notify all pending waiters.
+    pub fn set(&self) {
+        let mut ev_state = self.inner.lock().unwrap();
+        ev_state.set()
+    }
+
+    /// Resets the event.
+    pub fn reset(&self) {
+        let mut ev_state = self.inner.lock().unwrap();
+        ev_state.reset()
+    }
+
+    /// Returns whether the event is set
+    pub fn is_set(&self) -> bool {
+        let ev_state = self.inner.lock().unwrap();
+        ev_state.is_set()
+    }
+
+    /// Returns a future that gets fulfilled when the event is set.
+    pub fn poll_set(&self) -> impl Future<Output = ()> + FusedFuture {
+        WaitHandle {
+            event: self.inner.clone(),
+            reg: WaitHandleRegistration::new(),
+        }
+    }
+}
+
+impl<'a> Future for LocalWaitHandle<'a> {
+    type Output = ();
+
+    fn poll(
+        self: Pin<&mut Self>,
+        lw: &LocalWaker,
+    ) -> Poll<()> {
+        // It might be possible to use Pin::map_unchecked here instead of the two unsafe APIs.
+        // However this didn't seem to work for some borrow checker reasons
+        let mut_self: &mut LocalWaitHandle = unsafe { Pin::get_mut_unchecked(self) };
+        mut_self.event.borrow_mut().poll_waiter(unsafe { Pin::new_unchecked(&mut mut_self.reg) }, lw)
+    }
+}
+
+impl Future for WaitHandle {
+    type Output = ();
+
+    fn poll(
+        self: Pin<&mut Self>,
+        lw: &LocalWaker,
+    ) -> Poll<()> {
+        let mut_self: &mut WaitHandle = unsafe { Pin::get_mut_unchecked(self) };
+        let mut ev_state = mut_self.event.lock().unwrap();
+        ev_state.poll_waiter(unsafe { Pin::new_unchecked(&mut mut_self.reg) }, lw)
+    }
+}
+
+impl FusedFuture for WaitHandle {
+    fn is_terminated(&self) -> bool {
+        return self.reg.terminated;
+    }
+}
+
+impl<'a> FusedFuture for LocalWaitHandle<'a> {
+    fn is_terminated(&self) -> bool {
+        return self.reg.terminated;
+    }
+}
+
+impl Drop for WaitHandle {
+    fn drop(&mut self) {
+        // If this WaitHandle has been polled and it was registered at the
+        // event, it must be unregistered before dropping. Otherwise the
+        // event would access invalid memory.
+        let mut ev_state = self.event.lock().unwrap();
+        ev_state.remove_waiter(&mut self.reg);
+    }
+}
+
+impl<'a> Drop for LocalWaitHandle<'a> {
+    fn drop(&mut self) {
+        // If this WaitHandle has been polled and it was registered at the
+        // event, it must be unregistered before dropping. Otherwise the
+        // event would access invalid memory.
+        self.event.borrow_mut().remove_waiter(&mut self.reg);
+    }
+}

--- a/futures-channel/src/manual_reset_event.rs
+++ b/futures-channel/src/manual_reset_event.rs
@@ -68,7 +68,7 @@ struct LocalWaitHandle<'a> {
 
 /// A synchronization primitive which can be either in the set or reset state.
 ///
-/// Tasks can wait for the event to get set by obtaining a Future via poll_set.
+/// Tasks can wait for the event to get set by obtaining a Future via get_awaiter.
 /// This Future will get fulfilled when the event had been set.
 #[derive(Debug, Clone)]
 pub struct ManualResetEvent {
@@ -81,7 +81,7 @@ unsafe impl Sync for ManualResetEvent {}
 
 /// A synchronization primitive which can be either in the set or reset state.
 ///
-/// Tasks can wait for the event to get set by obtaining a Future via poll_set.
+/// Tasks can wait for the event to get set by obtaining a Future via get_awaiter.
 /// This Future will get fulfilled when the event had been set.
 #[derive(Debug)]
 pub struct LocalManualResetEvent {
@@ -245,7 +245,7 @@ impl<'a> LocalManualResetEvent {
     }
 
     /// Returns a future that gets fulfilled when the event is set.
-    pub fn poll_set(&'a self) -> impl Future<Output = ()> + FusedFuture + 'a {
+    pub fn get_awaiter(&'a self) -> impl Future<Output = ()> + FusedFuture + 'a {
         LocalWaitHandle {
             event: &self.inner,
             reg: WaitHandleRegistration::new(),
@@ -284,7 +284,7 @@ impl ManualResetEvent {
     }
 
     /// Returns a future that gets fulfilled when the event is set.
-    pub fn poll_set(&self) -> impl Future<Output = ()> + FusedFuture {
+    pub fn get_awaiter(&self) -> impl Future<Output = ()> + FusedFuture {
         WaitHandle {
             event: self.inner.clone(),
             reg: WaitHandleRegistration::new(),

--- a/futures-channel/tests/manual_reset_event.rs
+++ b/futures-channel/tests/manual_reset_event.rs
@@ -1,0 +1,201 @@
+#![feature(async_await, await_macro, pin, arbitrary_self_types, futures_api)]
+
+use futures::future::{Future};
+use futures_core::future::{ FusedFuture };
+use futures::channel::manual_reset_event::{manual_reset_event, local_manual_reset_event};
+use futures::executor::block_on;
+use futures_test::task::{WakeCounter, panic_local_waker};
+use pin_utils::pin_mut;
+use std::thread;
+use std::time;
+
+#[test]
+fn synchronous() {
+    let event = manual_reset_event(false);
+
+    assert!(!event.is_set());
+    event.set();
+    assert!(event.is_set());
+    event.reset();
+    assert!(!event.is_set());
+}
+
+#[test]
+fn smoke() {
+    let event = manual_reset_event(false);
+
+    let waiters: Vec<thread::JoinHandle<time::Instant>> =
+        [1..4].iter().map(|_| {
+            let ev = event.clone();
+            thread::spawn(move || {
+                block_on(ev.poll_set());
+                time::Instant::now()
+            })
+        }).collect();
+
+    let start = time::Instant::now();
+
+    thread::sleep(time::Duration::from_millis(100));
+    event.set();
+
+    for waiter in waiters.into_iter() {
+        let end_time = waiter.join().unwrap();
+        let diff = end_time - start;
+        assert!(diff > time::Duration::from_millis(50));
+    }
+}
+
+#[test]
+fn immediately_ready_event() {
+    let event = manual_reset_event(true);
+    let lw = &panic_local_waker();
+
+    assert!(event.is_set());
+
+    let poll = event.poll_set();
+    pin_mut!(poll);
+    assert!(!poll.as_mut().is_terminated());
+
+    assert!(poll.as_mut().poll(lw).is_ready());
+    assert!(poll.as_mut().is_terminated());
+}
+
+#[test]
+fn cancel_mid_wait() {
+    let event = manual_reset_event(false);
+    let wake_counter = WakeCounter::new();
+    let lw = &wake_counter.local_waker();
+
+    {
+        // Cancel a wait in between other waits
+        // In order to arbitrarily drop a non movable future we have to box and pin it
+        let mut poll1 = Box::pinned(event.poll_set());
+        let mut poll2 = Box::pinned(event.poll_set());
+        let mut poll3 = Box::pinned(event.poll_set());
+        let mut poll4 = Box::pinned(event.poll_set());
+        let mut poll5 = Box::pinned(event.poll_set());
+
+        assert!(poll1.as_mut().poll(lw).is_pending());
+        assert!(poll2.as_mut().poll(lw).is_pending());
+        assert!(poll3.as_mut().poll(lw).is_pending());
+        assert!(poll4.as_mut().poll(lw).is_pending());
+        assert!(poll5.as_mut().poll(lw).is_pending());
+        assert!(!poll1.is_terminated());
+        assert!(!poll2.is_terminated());
+        assert!(!poll3.is_terminated());
+        assert!(!poll4.is_terminated());
+        assert!(!poll5.is_terminated());
+
+        // Cancel 2 futures. Only the remaining ones should get completed
+        drop(poll2);
+        drop(poll4);
+
+        assert!(poll1.as_mut().poll(lw).is_pending());
+        assert!(poll3.as_mut().poll(lw).is_pending());
+        assert!(poll5.as_mut().poll(lw).is_pending());
+
+        assert_eq!(0, wake_counter.count());
+        event.set();
+
+        assert!(poll1.as_mut().poll(lw).is_ready());
+        assert!(poll3.as_mut().poll(lw).is_ready());
+        assert!(poll5.as_mut().poll(lw).is_ready());
+        assert!(poll1.is_terminated());
+        assert!(poll3.is_terminated());
+        assert!(poll5.is_terminated());
+    }
+
+    assert_eq!(3, wake_counter.count());
+}
+
+#[test]
+fn cancel_end_wait() {
+    let event = manual_reset_event(false);
+    let wake_counter = WakeCounter::new();
+    let lw = &wake_counter.local_waker();
+
+    let poll1 = event.poll_set();
+    let poll2 = event.poll_set();
+    let poll3 = event.poll_set();
+    let poll4 = event.poll_set();
+
+    pin_mut!(poll1);
+    pin_mut!(poll2);
+    pin_mut!(poll3);
+    pin_mut!(poll4);
+
+    assert!(poll1.as_mut().poll(lw).is_pending());
+    assert!(poll2.as_mut().poll(lw).is_pending());
+
+    // Start polling some wait handles which get cancelled
+    // before new ones are attached
+    {
+        let poll5 = event.poll_set();
+        let poll6 = event.poll_set();
+        pin_mut!(poll5);
+        pin_mut!(poll6);
+        assert!(poll5.as_mut().poll(lw).is_pending());
+        assert!(poll6.as_mut().poll(lw).is_pending());
+    }
+
+    assert!(poll3.as_mut().poll(lw).is_pending());
+    assert!(poll4.as_mut().poll(lw).is_pending());
+
+    event.set();
+
+    assert!(poll1.as_mut().poll(lw).is_ready());
+    assert!(poll2.as_mut().poll(lw).is_ready());
+    assert!(poll3.as_mut().poll(lw).is_ready());
+    assert!(poll4.as_mut().poll(lw).is_ready());
+
+    assert_eq!(4, wake_counter.count());
+}
+
+#[test]
+fn local_event() {
+    let event = local_manual_reset_event(false);
+
+    let wake_counter = WakeCounter::new();
+    let lw = &wake_counter.local_waker();
+
+    {
+        // Cancel a wait in between other waits
+        // In order to arbitrarily drop a non movable future we have to box and pin it
+        let mut poll1 = Box::pinned(event.poll_set());
+        let mut poll2 = Box::pinned(event.poll_set());
+        let mut poll3 = Box::pinned(event.poll_set());
+        let mut poll4 = Box::pinned(event.poll_set());
+        let mut poll5 = Box::pinned(event.poll_set());
+
+        assert!(poll1.as_mut().poll(lw).is_pending());
+        assert!(poll2.as_mut().poll(lw).is_pending());
+        assert!(poll3.as_mut().poll(lw).is_pending());
+        assert!(poll4.as_mut().poll(lw).is_pending());
+        assert!(poll5.as_mut().poll(lw).is_pending());
+        assert!(!poll1.is_terminated());
+        assert!(!poll2.is_terminated());
+        assert!(!poll3.is_terminated());
+        assert!(!poll4.is_terminated());
+        assert!(!poll5.is_terminated());
+
+        // Cancel 2 futures. Only the remaining ones should get completed
+        drop(poll2);
+        drop(poll4);
+
+        assert!(poll1.as_mut().poll(lw).is_pending());
+        assert!(poll3.as_mut().poll(lw).is_pending());
+        assert!(poll5.as_mut().poll(lw).is_pending());
+
+        assert_eq!(0, wake_counter.count());
+        event.set();
+
+        assert!(poll1.as_mut().poll(lw).is_ready());
+        assert!(poll3.as_mut().poll(lw).is_ready());
+        assert!(poll5.as_mut().poll(lw).is_ready());
+        assert!(poll1.is_terminated());
+        assert!(poll3.is_terminated());
+        assert!(poll5.is_terminated());
+    }
+
+    assert_eq!(3, wake_counter.count());
+}

--- a/futures-channel/tests/manual_reset_event.rs
+++ b/futures-channel/tests/manual_reset_event.rs
@@ -28,7 +28,7 @@ fn smoke() {
         [1..4].iter().map(|_| {
             let ev = event.clone();
             thread::spawn(move || {
-                block_on(ev.poll_set());
+                block_on(ev.get_awaiter());
                 time::Instant::now()
             })
         }).collect();
@@ -52,7 +52,7 @@ fn immediately_ready_event() {
 
     assert!(event.is_set());
 
-    let poll = event.poll_set();
+    let poll = event.get_awaiter();
     pin_mut!(poll);
     assert!(!poll.as_mut().is_terminated());
 
@@ -69,11 +69,11 @@ fn cancel_mid_wait() {
     {
         // Cancel a wait in between other waits
         // In order to arbitrarily drop a non movable future we have to box and pin it
-        let mut poll1 = Box::pinned(event.poll_set());
-        let mut poll2 = Box::pinned(event.poll_set());
-        let mut poll3 = Box::pinned(event.poll_set());
-        let mut poll4 = Box::pinned(event.poll_set());
-        let mut poll5 = Box::pinned(event.poll_set());
+        let mut poll1 = Box::pinned(event.get_awaiter());
+        let mut poll2 = Box::pinned(event.get_awaiter());
+        let mut poll3 = Box::pinned(event.get_awaiter());
+        let mut poll4 = Box::pinned(event.get_awaiter());
+        let mut poll5 = Box::pinned(event.get_awaiter());
 
         assert!(poll1.as_mut().poll(lw).is_pending());
         assert!(poll2.as_mut().poll(lw).is_pending());
@@ -114,10 +114,10 @@ fn cancel_end_wait() {
     let wake_counter = WakeCounter::new();
     let lw = &wake_counter.local_waker();
 
-    let poll1 = event.poll_set();
-    let poll2 = event.poll_set();
-    let poll3 = event.poll_set();
-    let poll4 = event.poll_set();
+    let poll1 = event.get_awaiter();
+    let poll2 = event.get_awaiter();
+    let poll3 = event.get_awaiter();
+    let poll4 = event.get_awaiter();
 
     pin_mut!(poll1);
     pin_mut!(poll2);
@@ -130,8 +130,8 @@ fn cancel_end_wait() {
     // Start polling some wait handles which get cancelled
     // before new ones are attached
     {
-        let poll5 = event.poll_set();
-        let poll6 = event.poll_set();
+        let poll5 = event.get_awaiter();
+        let poll6 = event.get_awaiter();
         pin_mut!(poll5);
         pin_mut!(poll6);
         assert!(poll5.as_mut().poll(lw).is_pending());
@@ -161,11 +161,11 @@ fn local_event() {
     {
         // Cancel a wait in between other waits
         // In order to arbitrarily drop a non movable future we have to box and pin it
-        let mut poll1 = Box::pinned(event.poll_set());
-        let mut poll2 = Box::pinned(event.poll_set());
-        let mut poll3 = Box::pinned(event.poll_set());
-        let mut poll4 = Box::pinned(event.poll_set());
-        let mut poll5 = Box::pinned(event.poll_set());
+        let mut poll1 = Box::pinned(event.get_awaiter());
+        let mut poll2 = Box::pinned(event.get_awaiter());
+        let mut poll3 = Box::pinned(event.get_awaiter());
+        let mut poll4 = Box::pinned(event.get_awaiter());
+        let mut poll5 = Box::pinned(event.get_awaiter());
 
         assert!(poll1.as_mut().poll(lw).is_pending());
         assert!(poll2.as_mut().poll(lw).is_pending());

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -73,7 +73,7 @@ pub mod channel {
     //!   channel for sending values between tasks, analogous to the
     //!   similarly-named structure in the standard library.
 
-    pub use futures_channel::{oneshot, mpsc};
+    pub use futures_channel::{oneshot, mpsc, manual_reset_event};
 }
 
 #[cfg(feature = "compat")]

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -222,9 +222,6 @@ fn test_manual_reset_event() {
         // !Unpin for select
         pin_mut!(wait1);
         pin_mut!(wait2);
-        // This is currently necessary since FusedFuture is not propagated through Pin
-        let mut wait1 = wait1.fuse();
-        let mut wait2 = wait2.fuse();
 
         while nr_selects != 2 {
             select! {
@@ -263,12 +260,10 @@ fn test_local_manual_reset_event() {
         let cancel_ev = local_manual_reset_event(false);
         let mut rx1 = rx1.fuse();
 
-        let sub1_done = sub(&cancel_ev);
-        let sub2_done = sub(&cancel_ev);
+        let sub1_done = sub(&cancel_ev).fuse();
+        let sub2_done = sub(&cancel_ev).fuse();
         pin_mut!(sub1_done);
         pin_mut!(sub2_done);
-        let mut sub1_done = sub1_done.fuse();
-        let mut sub2_done = sub2_done.fuse();
 
         let mut nr_selects = 0;
         while nr_selects != 3 {

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -213,13 +213,13 @@ fn test_manual_reset_event() {
     });
 
     block_on(async {
-        let wait1 = ev.poll_set();
-        let wait2 = ev2.poll_set();
+        let wait1 = ev.get_awaiter();
+        let wait2 = ev2.get_awaiter();
 
         let mut nr_selects = 0;
 
-        // Since the futures from poll_set are Unpin, they must be alias by a reference which is
-        // !Unpin for select
+        // Since the futures from get_awaiter are !Unpin, they must be pinned on
+        // the stack to make them usable for select!, which requires Unpin
         pin_mut!(wait1);
         pin_mut!(wait2);
 
@@ -252,7 +252,7 @@ fn test_local_manual_reset_event() {
 
     /// An async subroutine which only resolves after cancel_event has been set
     async fn sub(cancel_event: &LocalManualResetEvent) -> i32 {
-        await!(cancel_event.poll_set());
+        await!(cancel_event.get_awaiter());
         32
     }
 


### PR DESCRIPTION
The primitive can be used to let one or multiple tasks wait for a certain event.
Compared to the existing oneshot channel, the difference is that the ManualResetEvent doesn't carry a value, and is reusable.

In addition to the thread-safe ManualResetEvent a non-allocating LocalManualResetEvent variant is provided. This can be e.g. used as a cancellation token in nested asynchronous functions.

This CR is currently a bit raw and mostly about asking for feedback. The goal was not only to implement the primitive, but also to try to see how far one get with non-allocating futures by exploiting Pinning (as described in #1272). This turned out to work quite well. Even though the synchronous cancellation requirement for `Drop()` requires the usage of a `Mutex` and thereby makes things more complicated compared to the C++ implementation at https://lewissbaker.github.io/2017/11/17/understanding-operator-co-await.

For simplicity things have been added into the channel module and into some async/await tests. However another module might be better suited. Also better documentation is missing. And the usage of the pinning APIs could certainly be improved.

Some use-cases for the primitive:
- Using it for implementing poll_ready() on higher level streams, e.g. TCP/HTTP/TLS/etc streams
- Using it as a cancellation token