### PR TITLE
Add AtomicWaker::take method

### DIFF
--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -340,7 +340,7 @@ impl AtomicWaker {
                 // Release the lock
                 self.state.fetch_and(!(WAKING | HOLDS), Release);
 
-                return waker;
+                waker
             }
             state => {
                 // There is a concurrent thread currently updating the
@@ -356,7 +356,7 @@ impl AtomicWaker {
                     state == WAKING ||
                     state == WAKING | HOLDS);
 
-                return None;
+                None
             }
         }
     }


### PR DESCRIPTION
This allows the user to take the waker from an AtomicWaker without waking it immediately, making taking the waker and waking it non-atomic if desired.

This has empirical use cases in the ecosystem; for example, tokio has forked `AtomicTask` (the previous version of this API) and added this method (missing out on later optimizations because of the fork).