### PR TITLE
Remove the usage of LocalPool for block_on.

### DIFF
--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -203,13 +203,13 @@ lazy_static! {
 /// Run a future to completion on the current thread.
 ///
 /// This function will block the caller until the given future has completed.
-/// The default spawner for the future is a global `ThreadPool`.
+/// The default spawner for the future is a thread-local executor.
 ///
 /// Use a [`LocalPool`](LocalPool) if you need finer-grained control over
 /// spawned tasks.
 pub fn block_on<F: Future>(f: F) -> F::Output {
-    let mut pool = LocalPool::new();
-    pool.run_until(f)
+    pin_mut!(f);
+    run_executor(|local_waker| f.as_mut().poll(local_waker))
 }
 
 /// Turn a stream into a blocking iterator.


### PR DESCRIPTION
It should be no longer necessary, since there is no Spawner passed along the poll chain anymore.
This makes `block_on` cheaper, by avoiding the allocation for `LocalPool`. It should be allocation free after the first usage.