### PR TITLE
impl Default for Futures*ordered

### DIFF
--- a/src/stream/futures_ordered.rs
+++ b/src/stream/futures_ordered.rs
@@ -114,6 +114,12 @@ pub fn futures_ordered<I>(futures: I) -> FuturesOrdered<<I::Item as IntoFuture>:
     return queue
 }
 
+impl<T> Default for FuturesOrdered<T> where T: Future {
+    fn default() -> Self {
+        FuturesOrdered::new()
+    }
+}
+
 impl<T> FuturesOrdered<T>
     where T: Future
 {

--- a/src/stream/futures_unordered.rs
+++ b/src/stream/futures_unordered.rs
@@ -113,6 +113,12 @@ enum Dequeue<T> {
     Inconsistent,
 }
 
+impl<T> Default for FuturesUnordered<T> where T: Future {
+    fn default() -> Self {
+        FuturesUnordered::new()
+    }
+}
+
 impl<T> FuturesUnordered<T>
     where T: Future,
 {


### PR DESCRIPTION
This implements `Default` for both `FuturesUnordered` and `FuturesOrdered`, which already have a `new` method that takes no argument.