### PR TITLE
Future is now object safe

### DIFF
--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -12,11 +12,6 @@ use core::{
 /// This custom trait object was introduced for two reasons:
 /// - Currently it is not possible to take `dyn Trait` by value and
 ///   `Box<dyn Trait>` is not available in no_std contexts.
-/// - The `Future` trait is currently not object safe: The `Future::poll`
-///   method makes uses the arbitrary self types feature and traits in which
-///   this feature is used are currently not object safe due to current compiler
-///   limitations. (See tracking issue for arbitrary self types for more
-///   information #44874)
 pub struct LocalFutureObj<'a, T> {
     ptr: *mut (),
     poll_fn: unsafe fn(*mut (), &LocalWaker) -> Poll<T>,

--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -11,11 +11,6 @@ use core::pin::Pin;
 /// This custom trait object was introduced for two reasons:
 /// - Currently it is not possible to take `dyn Trait` by value and
 ///   `Box<dyn Trait>` is not available in no_std contexts.
-/// - The `Stream` trait is currently not object safe: The `Stream::poll_next`
-///   method makes uses the arbitrary self types feature and traits in which
-///   this feature is used are currently not object safe due to current compiler
-///   limitations. (See tracking issue for arbitrary self types for more
-///   information #44874)
 pub struct LocalStreamObj<'a, T> {
     ptr: *mut (),
     poll_next_fn: unsafe fn(*mut (), &LocalWaker) -> Poll<Option<T>>,


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/54383 was merged the `Future` and `Stream` traits have become object safe 🎉, here's a [test playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=6413e3242dfe9161c81d7dab39673b4b) showing that `Pin<Box<dyn Future>>` works.

The only remaining reason for having `FutureObj` exist is to support storing futures that are being spawned in custom "heap" allocations while keeping `Spawn` a non-generic trait.

I think `StreamObj` can probably be dropped, it seems likely that all current use-cases should work fine with using an explicit storage type, `Box<dyn Stream>`, `Pin<Box<dyn Stream>>` or `SomeCustomHeapStore<dyn Stream>` should all work, and if a user does need to be abstract over storage they likely already have some way to do this themselves.

r? @cramertj 