### PR TITLE
Add Sink01As03 compat shim

### DIFF
--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -72,7 +72,7 @@ pub trait Sink01CompatExt: Sink01 {
     /// [`Sink<SinkItem = T, SinkError = E>`](futures::sink::Sink)
     /// into a futures 0.3
     /// [`Sink<SinkItem = T, SinkError = E>`](futures_sink::sink::Sink).
-    fn compat(self) -> Compat01As03Sink<Self, Self::SinkItem>
+    fn compat_sink(self) -> Compat01As03Sink<Self, Self::SinkItem>
     where
         Self: Sized,
     {
@@ -80,24 +80,6 @@ pub trait Sink01CompatExt: Sink01 {
     }
 }
 impl<Si: Sink01> Sink01CompatExt for Si {}
-
-/// Extension trait for futures 0.1 [`Stream`](futures::stream::Stream) and
-///  [`Sink`](futures::sink::Sink) combos
-pub trait StreamSink01CompatExt: Stream01 + Sink01 {
-    /// Converts a futures 0.1
-    /// [`Stream<Item = T, Error = E`](futures::stream::Stream) +
-    /// [`Sink<SinkItem = T, SinkError = E>`](futures::sink::Sink)
-    /// into a futures 0.3
-    /// [`Stream<Item = T, Error = E>`](futures_core::stream::Stream) +
-    /// [`Sink<SinkItem = T, SinkError = E>`](futures_sink::sink::Sink).
-    fn compat(self) -> Compat01As03Sink<Self, <Self as Sink01>::SinkItem>
-    where
-        Self: Sized,
-    {
-        Compat01As03Sink::new(self)
-    }
-}
-impl<S: Stream01 + Sink01> StreamSink01CompatExt for S {}
 
 fn poll_01_to_03<T, E>(x: Result<Async01<T>, E>) -> task03::Poll<Result<T, E>> {
     match x {

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -72,7 +72,7 @@ pub trait Sink01CompatExt: Sink01 {
     /// [`Sink<SinkItem = T, SinkError = E>`](futures::sink::Sink)
     /// into a futures 0.3
     /// [`Sink<SinkItem = T, SinkError = E>`](futures_sink::sink::Sink).
-    fn compat_sink(self) -> Compat01As03Sink<Self, Self::SinkItem>
+    fn sink_compat(self) -> Compat01As03Sink<Self, Self::SinkItem>
     where
         Self: Sized,
     {

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -6,7 +6,7 @@ mod executor;
 pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 
 mod compat01as03;
-pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt};
+pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt, Sink01CompatExt};
 
 mod compat03as01;
 pub use self::compat03as01::Compat;

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -6,7 +6,7 @@ mod executor;
 pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 
 mod compat01as03;
-pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt, Sink01CompatExt};
+pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt, Sink01CompatExt, StreamSink01CompatExt};
 
 mod compat03as01;
 pub use self::compat03as01::Compat;

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -6,7 +6,7 @@ mod executor;
 pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 
 mod compat01as03;
-pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt, Sink01CompatExt, StreamSink01CompatExt};
+pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt, Sink01CompatExt};
 
 mod compat03as01;
 pub use self::compat03as01::Compat;

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -6,7 +6,7 @@ mod executor;
 pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 
 mod compat01as03;
-pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt, Sink01CompatExt};
+pub use self::compat01as03::{Compat01As03, Compat01As03Sink, Future01CompatExt, Stream01CompatExt, Sink01CompatExt};
 
 mod compat03as01;
 pub use self::compat03as01::Compat;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -89,6 +89,7 @@ pub mod compat {
         Executor01CompatExt,
         Future01CompatExt,
         Stream01CompatExt,
+        Sink01CompatExt
     };
 }
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -84,6 +84,7 @@ pub mod compat {
     pub use futures_util::compat::{
         Compat,
         Compat01As03,
+        Compat01As03Sink,
         Executor01Future,
         Executor01As03,
         Executor01CompatExt,

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -89,7 +89,8 @@ pub mod compat {
         Executor01CompatExt,
         Future01CompatExt,
         Stream01CompatExt,
-        Sink01CompatExt
+        Sink01CompatExt,
+        StreamSink01CompatExt,
     };
 }
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -90,7 +90,6 @@ pub mod compat {
         Future01CompatExt,
         Stream01CompatExt,
         Sink01CompatExt,
-        StreamSink01CompatExt,
     };
 }
 


### PR DESCRIPTION
This adds a compat shim to go from a 0.1 Sink to a 0.3 Sink. This follows, roughly how the stream compat works with the exception that it stores an internal buffer of one item. This is due to the fact that there is no `LocalWaker` passed to `Sink01::start_send`, so we can only actually write the item in the sink on the next `Sink03::poll_read` which gets a `LocalWaker`.

This PR is related to #1362 and cc @Nemo157.