### PR TITLE
Remove now-deprecated "rename-dependency" cargo feature

### DIFF
--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["rename-dependency"]
-
 [package]
 name = "futures-core-preview"
 edition = "2018"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["rename-dependency"]
-
 [package]
 name = "futures-util-preview"
 edition = "2018"


### PR DESCRIPTION
This feature was stablized in cargo 1.31.