### PR TITLE
Rename Pinned to PhantomPinned

### DIFF
--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -1,7 +1,7 @@
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::marker::Pinned;
+use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr;
 
@@ -13,7 +13,7 @@ use std::ptr;
 pub struct AssertUnmoved<Fut> {
     future: Fut,
     this_ptr: *const AssertUnmoved<Fut>,
-    _pinned: Pinned,
+    _pinned: PhantomPinned,
 }
 
 impl<Fut> AssertUnmoved<Fut> {
@@ -24,7 +24,7 @@ impl<Fut> AssertUnmoved<Fut> {
         Self {
             future,
             this_ptr: ptr::null(),
-            _pinned: Pinned,
+            _pinned: PhantomPinned,
         }
     }
 }


### PR DESCRIPTION
This is to keep futures-rs updated with the nightly changes that are causing CI to fail on master.

Reference commit https://github.com/rust-lang/rust/commit/0076f58d5333f24f709aa46b4bad760ffb51b9b0