### PR TITLE
Update select_all.

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -145,11 +145,10 @@ mod split;
 #[cfg(feature = "std")]
 pub use self::split::{SplitStream, SplitSink, ReuniteError};
 
-// ToDo
-// #[cfg(feature = "std")]
-// mod select_all;
-// #[cfg(feature = "std")]
-// pub use self::select_all::{select_all, SelectAll};
+#[cfg(feature = "std")]
+mod select_all;
+#[cfg(feature = "std")]
+pub use self::select_all::{select_all, SelectAll};
 
 impl<T: ?Sized> StreamExt for T where T: Stream {}
 

--- a/futures-util/tests/select_all.rs
+++ b/futures-util/tests/select_all.rs
@@ -1,0 +1,33 @@
+#![feature(async_await, await_macro, futures_api, pin)]
+
+use futures::future;
+use futures::FutureExt;
+use futures::task::Poll;
+use futures::stream::FusedStream;
+use futures::stream::{SelectAll, StreamExt};
+use futures_test::task::noop_local_waker_ref;
+
+#[test]
+fn is_terminated() {
+    let lw = noop_local_waker_ref();
+    let mut tasks = SelectAll::new();
+
+    assert_eq!(tasks.is_terminated(), false);
+    assert_eq!(tasks.poll_next_unpin(lw), Poll::Ready(None));
+    assert_eq!(tasks.is_terminated(), true);
+
+    // Test that the sentinel value doesn't leak
+    assert_eq!(tasks.is_empty(), true);
+    assert_eq!(tasks.len(), 0);
+
+    tasks.push(future::ready(1).into_stream());
+
+    assert_eq!(tasks.is_empty(), false);
+    assert_eq!(tasks.len(), 1);
+
+    assert_eq!(tasks.is_terminated(), false);
+    assert_eq!(tasks.poll_next_unpin(lw), Poll::Ready(Some(1)));
+    assert_eq!(tasks.is_terminated(), false);
+    assert_eq!(tasks.poll_next_unpin(lw), Poll::Ready(None));
+    assert_eq!(tasks.is_terminated(), true);
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -330,7 +330,7 @@ pub mod stream {
         BufferUnordered, Buffered, CatchUnwind, Chunks, Collect, SplitStream,
         SplitSink, ReuniteError,
 
-        // ToDo: select_all, SelectAll,
+        select_all, SelectAll,
     };
 
     pub use futures_util::try_stream::{


### PR DESCRIPTION
This updates select_all to work with the new API. It is implemented in this commit for `Stream + Unpin`.