### PR TITLE
[WIP] Update to latest Pin API

### DIFF
--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -1,4 +1,4 @@
-#![feature(test, futures_api, pin, arbitrary_self_types)]
+#![feature(test, futures_api, arbitrary_self_types)]
 
 extern crate test;
 use crate::test::Bencher;

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides channels that can be used to communicate between
 //! asynchronous tasks.
 
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,4 +1,4 @@
-#![feature(futures_api, async_await, await_macro, pin)]
+#![feature(futures_api, async_await, await_macro)]
 
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -1,4 +1,4 @@
-#![feature(futures_api, arbitrary_self_types, pin)]
+#![feature(futures_api, arbitrary_self_types)]
 
 use futures::channel::oneshot::{self, Sender};
 use futures::executor::block_on;

--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -173,7 +173,7 @@ where
     F: Future<Output = T> + 'a
 {
     fn into_raw(mut self) -> *mut () {
-        let mut_ref: &mut F = unsafe { Pin::get_mut_unchecked(Pin::as_mut(&mut self)) };
+        let mut_ref: &mut F = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self)) };
         mut_ref as *mut F as *mut ()
     }
 
@@ -213,7 +213,7 @@ mod if_std {
         F: Future<Output = T> + 'a
     {
         fn into_raw(mut self) -> *mut () {
-            let mut_ref: &mut F = unsafe { Pin::get_mut_unchecked(Pin::as_mut(&mut self)) };
+            let mut_ref: &mut F = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self)) };
             let ptr = mut_ref as *mut F as *mut ();
             mem::forget(self); // Don't drop the box
             ptr

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,6 +1,6 @@
 //! Core traits and types for asynchronous operations in Rust.
 
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -93,7 +93,7 @@ impl<A, B> Stream for Either<A, B>
 
     fn poll_next(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Option<A::Item>> {
         unsafe {
-            match Pin::get_mut_unchecked(self) {
+            match Pin::get_unchecked_mut(self) {
                 Either::Left(a) => Pin::new_unchecked(a).poll_next(lw),
                 Either::Right(b) => Pin::new_unchecked(b).poll_next(lw),
             }

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -71,7 +71,7 @@ impl<'a, S: ?Sized + Stream + Unpin> Stream for &'a mut S {
 
 impl<P> Stream for Pin<P>
 where
-    P: ops::DerefMut,
+    P: ops::DerefMut + Unpin,
     P::Target: Stream,
 {
     type Item = <P::Target as Stream>::Item;

--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -175,7 +175,7 @@ where
     F: Stream<Item = T> + 'a,
 {
     fn into_raw(self) -> *mut () {
-        unsafe { Pin::get_mut_unchecked(self) as *mut F as *mut () }
+        unsafe { Pin::get_unchecked_mut(self) as *mut F as *mut () }
     }
 
     unsafe fn poll_next(
@@ -215,7 +215,7 @@ mod if_std {
         where F: Stream<Item = T> + 'a
     {
         fn into_raw(mut self) -> *mut () {
-            let mut_ref: &mut F = unsafe { Pin::get_mut_unchecked(Pin::as_mut(&mut self)) };
+            let mut_ref: &mut F = unsafe { Pin::get_unchecked_mut(Pin::as_mut(&mut self)) };
             let ptr = mut_ref as *mut F as *mut ();
             mem::forget(self); // Don't drop the box
             ptr

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -1,4 +1,4 @@
-#![feature(test, futures_api, pin, arbitrary_self_types)]
+#![feature(test, futures_api, arbitrary_self_types)]
 
 extern crate test;
 use crate::test::Bencher;

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -1,6 +1,6 @@
 //! Built-in executors and related tools.
 
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -42,7 +42,7 @@ fn run_until_single_future() {
 fn run_until_ignores_spawned() {
     let mut pool = LocalPool::new();
     let mut spawn = pool.spawner();
-    spawn.spawn_local_obj(Box::pinned(pending()).into()).unwrap();
+    spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
     assert_eq!(pool.run_until(lazy(|_| ())), ());
 }
 
@@ -51,7 +51,7 @@ fn run_until_executes_spawned() {
     let (tx, rx) = oneshot::channel();
     let mut pool = LocalPool::new();
     let mut spawn = pool.spawner();
-    spawn.spawn_local_obj(Box::pinned(lazy(move |_| {
+    spawn.spawn_local_obj(Box::pin(lazy(move |_| {
         tx.send(()).unwrap();
         ()
     })).into()).unwrap();
@@ -67,8 +67,8 @@ fn run_executes_spawned() {
     let mut spawn = pool.spawner();
     let mut spawn2 = pool.spawner();
 
-    spawn.spawn_local_obj(Box::pinned(lazy(move |_| {
-        spawn2.spawn_local_obj(Box::pinned(lazy(move |_| {
+    spawn.spawn_local_obj(Box::pin(lazy(move |_| {
+        spawn2.spawn_local_obj(Box::pin(lazy(move |_| {
             cnt2.set(cnt2.get() + 1);
             ()
         })).into()).unwrap();
@@ -92,7 +92,7 @@ fn run_spawn_many() {
 
     for _ in 0..ITER {
         let cnt = cnt.clone();
-        spawn.spawn_local_obj(Box::pinned(lazy(move |_| {
+        spawn.spawn_local_obj(Box::pin(lazy(move |_| {
             cnt.set(cnt.get() + 1);
             ()
         })).into()).unwrap();
@@ -109,7 +109,7 @@ fn nesting_run() {
     let mut pool = LocalPool::new();
     let mut spawn = pool.spawner();
 
-    spawn.spawn_obj(Box::pinned(lazy(|_| {
+    spawn.spawn_obj(Box::pin(lazy(|_| {
         let mut pool = LocalPool::new();
         pool.run();
     })).into()).unwrap();
@@ -155,12 +155,12 @@ fn tasks_are_scheduled_fairly() {
     let mut pool = LocalPool::new();
     let mut spawn = pool.spawner();
 
-    spawn.spawn_local_obj(Box::pinned(Spin {
+    spawn.spawn_local_obj(Box::pin(Spin {
         state: state.clone(),
         idx: 0,
     }).into()).unwrap();
 
-    spawn.spawn_local_obj(Box::pinned(Spin {
+    spawn.spawn_local_obj(Box::pin(Spin {
         state: state,
         idx: 1,
     }).into()).unwrap();

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::executor::LocalPool;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.10/futures_sink")]
 
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures_core::task::{LocalWaker, Poll};
 use core::marker::Unpin;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -174,7 +174,7 @@ mod if_std {
 
         fn start_send(self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
             // TODO: impl<T> Unpin for Vec<T> {}
-            unsafe { Pin::get_mut_unchecked(self) }.push(item);
+            unsafe { Pin::get_unchecked_mut(self) }.push(item);
             Ok(())
         }
 
@@ -197,7 +197,7 @@ mod if_std {
 
         fn start_send(self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
             // TODO: impl<T> Unpin for Vec<T> {}
-            unsafe { Pin::get_mut_unchecked(self) }.push_back(item);
+            unsafe { Pin::get_unchecked_mut(self) }.push_back(item);
             Ok(())
         }
 
@@ -248,7 +248,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn poll_ready(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match Pin::get_mut_unchecked(self) {
+            match Pin::get_unchecked_mut(self) {
                 Either::Left(x) => Pin::new_unchecked(x).poll_ready(lw),
                 Either::Right(x) => Pin::new_unchecked(x).poll_ready(lw),
             }
@@ -257,7 +257,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn start_send(self: Pin<&mut Self>, item: Self::SinkItem) -> Result<(), Self::SinkError> {
         unsafe {
-            match Pin::get_mut_unchecked(self) {
+            match Pin::get_unchecked_mut(self) {
                 Either::Left(x) => Pin::new_unchecked(x).start_send(item),
                 Either::Right(x) => Pin::new_unchecked(x).start_send(item),
             }
@@ -266,7 +266,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn poll_flush(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match Pin::get_mut_unchecked(self) {
+            match Pin::get_unchecked_mut(self) {
                 Either::Left(x) => Pin::new_unchecked(x).poll_flush(lw),
                 Either::Right(x) => Pin::new_unchecked(x).poll_flush(lw),
             }
@@ -275,7 +275,7 @@ impl<A, B> Sink for Either<A, B>
 
     fn poll_close(self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Result<(), Self::SinkError>> {
         unsafe {
-            match Pin::get_mut_unchecked(self) {
+            match Pin::get_unchecked_mut(self) {
                 Either::Left(x) => Pin::new_unchecked(x).poll_close(lw),
                 Either::Right(x) => Pin::new_unchecked(x).poll_close(lw),
             }

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -18,7 +18,8 @@ name = "futures_test"
 futures-core-preview = { version = "0.3.0-alpha.2", path = "../futures-core", default-features = false }
 futures-util-preview = { version = "0.3.0-alpha.2", path = "../futures-util", default-features = false }
 futures-executor-preview = { version = "0.3.0-alpha.2", path = "../futures-executor", default-features = false }
-pin-utils = { version = "0.1.0-alpha.3", default-features = false }
+# FIXME(taiki-e): When a new version of pin-utils is released, fix this line.
+pin-utils = { version = "0.1.0-alpha.3", default-features = false, git = "https://github.com/taiki-e/pin-utils", branch = "update-pin" }
 
 [dev-dependencies]
 futures-preview = { version = "0.3.0-alpha.2", path = "../futures", default-features = false, features = ["std"] }

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -5,7 +5,6 @@
     async_await,
     await_macro,
     futures_api,
-    pin,
 )]
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -36,7 +36,8 @@ slab = { version = "0.4", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-executor = { version = "0.1.2", optional = true }
 tokio-io = { version = "0.1.9", optional = true }
-pin-utils = "0.1.0-alpha.3"
+# FIXME(taiki-e): When a new version of pin-utils is released, fix this line.
+pin-utils = { version = "0.1.0-alpha.3", git = "https://github.com/taiki-e/pin-utils", branch = "update-pin" }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "0.3.0-alpha.10" }

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -7,7 +7,8 @@ use futures_01::executor::{
 use futures_01::{Async as Async01, Future as Future01, Stream as Stream01};
 use futures_core::{task as task03, Future as Future03, Stream as Stream03};
 use std::task::LocalWaker;
-use std::pin::{Pin, Unpin};
+use std::pin::Pin;
+use std::marker::Unpin;
 
 /// Converts a futures 0.1 Future, Stream, AsyncRead, or AsyncWrite
 /// object to a futures 0.3-compatible version,

--- a/futures-util/src/future/chain.rs
+++ b/futures-util/src/future/chain.rs
@@ -33,8 +33,8 @@ impl<Fut1, Fut2, Data> Chain<Fut1, Fut2, Data>
     {
         let mut f = Some(f);
 
-        // Safe to call `get_mut_unchecked` because we won't move the futures.
-        let this = unsafe { Pin::get_mut_unchecked(self) };
+        // Safe to call `get_unchecked_mut` because we won't move the futures.
+        let this = unsafe { Pin::get_unchecked_mut(self) };
 
         loop {
             let (output, data) = match this {

--- a/futures-util/src/future/flatten_stream.rs
+++ b/futures-util/src/future/flatten_stream.rs
@@ -61,7 +61,7 @@ impl<Fut> Stream for FlattenStream<Fut>
     fn poll_next(mut self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Option<Self::Item>> {
         loop {
             // safety: data is never moved via the resulting &mut reference
-            let stream = match &mut unsafe { Pin::get_mut_unchecked(self.as_mut()) }.state {
+            let stream = match &mut unsafe { Pin::get_unchecked_mut(self.as_mut()) }.state {
                 State::Future(f) => {
                     // safety: the future we're re-pinning here will never be moved;
                     // it will just be polled, then dropped in place
@@ -88,7 +88,7 @@ impl<Fut> Stream for FlattenStream<Fut>
             unsafe {
                 // safety: we use the &mut only for an assignment, which causes
                 // only an in-place drop
-                Pin::get_mut_unchecked(self.as_mut()).state = State::Stream(stream);
+                Pin::get_unchecked_mut(self.as_mut()).state = State::Stream(stream);
             }
         }
     }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -5,7 +5,8 @@ use std::fmt;
 use std::future::Future;
 use std::iter::FromIterator;
 use std::mem;
-use std::pin::{Pin, Unpin};
+use std::pin::Pin;
+use std::marker::Unpin;
 use std::prelude::v1::*;
 use std::task::Poll;
 

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -54,7 +54,7 @@ impl<Fut: Future> MaybeDone<Fut> {
     #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn output_mut<'a>(self: Pin<&'a mut Self>) -> Option<&'a mut Fut::Output> {
         unsafe {
-            let this = Pin::get_mut_unchecked(self);
+            let this = Pin::get_unchecked_mut(self);
             match this {
                 MaybeDone::Done(res) => Some(res),
                 _ => None,
@@ -67,7 +67,7 @@ impl<Fut: Future> MaybeDone<Fut> {
     #[inline]
     pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Output> {
         unsafe {
-            let this = Pin::get_mut_unchecked(self);
+            let this = Pin::get_unchecked_mut(self);
             match this {
                 MaybeDone::Done(_) => {},
                 MaybeDone::Future(_) | MaybeDone::Gone => return None,
@@ -95,7 +95,7 @@ impl<Fut: Future> Future for MaybeDone<Fut> {
 
     fn poll(mut self: Pin<&mut Self>, lw: &LocalWaker) -> Poll<Self::Output> {
         let res = unsafe {
-            match Pin::get_mut_unchecked(self.as_mut()) {
+            match Pin::get_unchecked_mut(self.as_mut()) {
                 MaybeDone::Future(a) => {
                     if let Poll::Ready(res) = Pin::new_unchecked(a).poll(lw) {
                         res

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -654,7 +654,7 @@ pub trait FutureExt: Future {
     fn boxed(self) -> Pin<Box<Self>>
         where Self: Sized
     {
-        Box::pinned(self)
+        Box::pin(self)
     }
 
     /// Turns a `Future` into a `TryFuture` with `Error = ()`.

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -26,7 +26,7 @@ fn lock_and_then<T, U, E, F>(
     match lock.poll_lock(lw) {
         // Safety: the value behind the bilock used by `ReadHalf` and `WriteHalf` is never exposed
         // as a `Pin<&mut T>` anywhere other than here as a way to get to `&mut T`.
-        Poll::Ready(mut l) => f(unsafe { Pin::get_mut_unchecked(l.as_pin_mut()) }, lw),
+        Poll::Ready(mut l) => f(unsafe { Pin::get_unchecked_mut(l.as_pin_mut()) }, lw),
         Poll::Pending => Poll::Pending,
     }
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -1,7 +1,7 @@
 //! Combinators and utilities for working with `Future`s, `Stream`s, `Sink`s,
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
-#![feature(async_await, pin, arbitrary_self_types, futures_api, unsized_locals)]
+#![feature(async_await, arbitrary_self_types, futures_api, unsized_locals)]
 #![cfg_attr(feature = "std", feature(await_macro))]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -66,7 +66,7 @@ impl<Fut, T> State<Fut, T> {
         self: Pin<&'a mut Self>,
     ) -> State<Pin<&'a mut Fut>, Pin<&'a mut T>> {
         unsafe {
-            match Pin::get_mut_unchecked(self) {
+            match Pin::get_unchecked_mut(self) {
                 State::Empty =>
                     State::Empty,
                 State::Process(fut) =>
@@ -130,7 +130,7 @@ impl<Si, U, Fut, F, E> With<Si, U, Fut, F>
         if let Some(buffered) = buffered {
             Pin::set(self.state(), State::Buffered(buffered));
         }
-        if let State::Buffered(item) = unsafe { mem::replace(Pin::get_mut_unchecked(self.state()), State::Empty) } {
+        if let State::Buffered(item) = unsafe { mem::replace(Pin::get_unchecked_mut(self.state()), State::Empty) } {
             Poll::Ready(self.sink().start_send(item).map_err(Into::into))
         } else {
             unreachable!()

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -79,7 +79,7 @@ where
         lw: &LocalWaker,
     ) -> Poll<Result<(), Si::SinkError>> {
         let WithFlatMap { sink, stream, buffer, .. } =
-            unsafe { Pin::get_mut_unchecked(self) };
+            unsafe { Pin::get_unchecked_mut(self) };
         let mut sink = unsafe { Pin::new_unchecked(sink) };
         let mut stream = unsafe { Pin::new_unchecked(stream) };
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -806,7 +806,7 @@ pub trait StreamExt: Stream {
     fn boxed(self) -> Pin<Box<Self>>
         where Self: Sized
     {
-        Box::pinned(self)
+        Box::pin(self)
     }
 
     /// An adaptor for creating a buffered list of pending futures.

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -53,7 +53,7 @@ impl<St1, St2> Stream for Select<St1, St2>
         lw: &LocalWaker
     ) -> Poll<Option<St1::Item>> {
         let Select { flag, stream1, stream2 } =
-            unsafe { Pin::get_mut_unchecked(self) };
+            unsafe { Pin::get_unchecked_mut(self) };
         let stream1 = unsafe { Pin::new_unchecked(stream1) };
         let stream2 = unsafe { Pin::new_unchecked(stream2) };
 

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -64,6 +64,12 @@ impl<St: Stream + Unpin> SelectAll<St> {
     }
 }
 
+impl<St: Stream + Unpin> Default for SelectAll<St> {
+    fn default() -> SelectAll<St> {
+        SelectAll::new()
+    }
+}
+
 impl<St: Stream + Unpin> Stream for SelectAll<St> {
     type Item = St::Item;
 

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -114,5 +114,5 @@ pub fn select_all<I>(streams: I) -> SelectAll<I::Item>
         set.push(stream);
     }
 
-    return set
+    set
 }

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -33,7 +33,7 @@ where
         self: Pin<&'a mut Self>
     ) -> State<Pin<&'a mut Fut>, Pin<&'a mut Si>> {
         unsafe {
-            match &mut Pin::get_mut_unchecked(self).0 {
+            match &mut Pin::get_unchecked_mut(self).0 {
                 Waiting(f) => Waiting(Pin::new_unchecked(f)),
                 Ready(s) => Ready(Pin::new_unchecked(s)),
                 Closed => Closed,

--- a/futures-util/src/try_future/try_chain.rs
+++ b/futures-util/src/try_future/try_chain.rs
@@ -41,8 +41,8 @@ impl<Fut1, Fut2, Data> TryChain<Fut1, Fut2, Data>
     {
         let mut f = Some(f);
 
-        // Safe to call `get_mut_unchecked` because we won't move the futures.
-        let this = unsafe { Pin::get_mut_unchecked(self) };
+        // Safe to call `get_unchecked_mut` because we won't move the futures.
+        let this = unsafe { Pin::get_unchecked_mut(self) };
 
         loop {
             let (output, data) = match this {

--- a/futures-util/src/try_stream/into_async_read.rs
+++ b/futures-util/src/try_stream/into_async_read.rs
@@ -39,7 +39,7 @@ where
 {
     pub(super) fn new(stream: St) -> Self {
         IntoAsyncRead {
-            stream: stream,
+            stream,
             state: ReadState::PendingChunk,
         }
     }

--- a/futures-util/tests/futures_unordered.rs
+++ b/futures-util/tests/futures_unordered.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api, pin)]
+#![feature(async_await, await_macro, futures_api)]
 
 use futures::future;
 use futures::task::Poll;

--- a/futures-util/tests/mutex.rs
+++ b/futures-util/tests/mutex.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api, pin)]
+#![feature(async_await, await_macro, futures_api)]
 
 use futures::channel::mpsc;
 use futures::future::{ready, FutureExt};

--- a/futures-util/tests/select_all.rs
+++ b/futures-util/tests/select_all.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api, pin)]
+#![feature(async_await, await_macro, futures_api)]
 
 use futures::future;
 use futures::FutureExt;

--- a/futures-util/tests/select_next_some.rs
+++ b/futures-util/tests/select_next_some.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, futures_api, pin)]
+#![feature(async_await, await_macro, futures_api)]
 
 use futures::{future, select};
 use futures::future::{FusedFuture, FutureExt};

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -21,7 +21,7 @@
 //! streams and sinks, and then spawned as independent tasks that are run to
 //! completion, but *do not block* the thread running them.
 
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/futures/tests/abortable.rs
+++ b/futures/tests/abortable.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::executor::block_on;

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -1,5 +1,5 @@
 #![recursion_limit="128"]
-#![feature(async_await, await_macro, pin, arbitrary_self_types, futures_api)]
+#![feature(async_await, await_macro, arbitrary_self_types, futures_api)]
 
 use futures::{Poll, pending, poll, join, try_join, select};
 use futures::channel::{mpsc, oneshot};

--- a/futures/tests/basic_combinators.rs
+++ b/futures/tests/basic_combinators.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::future::{self, FutureExt, TryFutureExt};
 use futures_test::future::FutureTestExt;

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::future::{self, Future, FutureExt, TryFutureExt};

--- a/futures/tests/fuse.rs
+++ b/futures/tests/fuse.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::future::{self, FutureExt};
 use futures_test::task::panic_local_waker;

--- a/futures/tests/future_obj.rs
+++ b/futures/tests/future_obj.rs
@@ -1,4 +1,4 @@
-#![feature(pin, async_await, arbitrary_self_types, futures_api)]
+#![feature(async_await, arbitrary_self_types, futures_api)]
 
 use futures::future::{Future, FutureExt, FutureObj};
 use std::pin::Pin;

--- a/futures/tests/futures_ordered.rs
+++ b/futures/tests/futures_ordered.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::executor::{block_on, block_on_stream};

--- a/futures/tests/futures_unordered.rs
+++ b/futures/tests/futures_unordered.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::executor::{block_on, block_on_stream};

--- a/futures/tests/inspect.rs
+++ b/futures/tests/inspect.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::executor::block_on;
 use futures::future::{self, FutureExt};

--- a/futures/tests/io_read_exact.rs
+++ b/futures/tests/io_read_exact.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::executor::block_on;
 use futures::io::AsyncReadExt;

--- a/futures/tests/join_all.rs
+++ b/futures/tests/join_all.rs
@@ -7,7 +7,7 @@ use futures_util::future::*;
 use std::future::Future;
 use futures::executor::block_on;
 use std::fmt::Debug;
-use std::pin::Unpin;
+use std::marker::Unpin;
 
 fn assert_done<T: PartialEq + Debug, F: FnOnce() -> Box<Future<Output=T> + Unpin>>(actual_fut: F, expected: T) {
     let output = block_on(actual_fut());

--- a/futures/tests/join_all.rs
+++ b/futures/tests/join_all.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, pin, arbitrary_self_types, futures_api)]
+#![feature(async_await, arbitrary_self_types, futures_api)]
 
 extern crate futures_util;
 extern crate futures;

--- a/futures/tests/oneshot.rs
+++ b/futures/tests/oneshot.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::future::{FutureExt, TryFutureExt};

--- a/futures/tests/recurse.rs
+++ b/futures/tests/recurse.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::executor::block_on;
 use futures::future::{self, FutureExt, FutureObj};

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::channel::oneshot;
 use futures::executor::{block_on, LocalPool};

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::executor::block_on;
 use futures::sink::{Sink, SinkExt};

--- a/futures/tests/unfold.rs
+++ b/futures/tests/unfold.rs
@@ -1,4 +1,4 @@
-#![feature(pin, arbitrary_self_types, futures_api)]
+#![feature(arbitrary_self_types, futures_api)]
 
 use futures::future;
 use futures::stream;


### PR DESCRIPTION
This is an alternative to #1375.

This depends on rust-lang-nursery/pin-utils#13

Also, it includes fix to clippy errors that occurred with [#1372](https://github.com/rust-lang-nursery/futures-rs/pull/1372).