### PR TITLE
impl Default for SelectAll

### DIFF
--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -37,7 +37,6 @@ impl<St: Stream + Unpin> SelectAll<St> {
     ///
     /// The returned `SelectAll` does not contain any streams and, in this
     /// state, `SelectAll::poll` will return `Poll::Ready(None)`.
-    #[allow(clippy::new_without_default_derive)]
     pub fn new() -> SelectAll<St> {
         SelectAll { inner: FuturesUnordered::new() }
     }
@@ -62,6 +61,12 @@ impl<St: Stream + Unpin> SelectAll<St> {
     /// notifications.
     pub fn push(&mut self, stream: St) {
         self.inner.push(stream.into_future());
+    }
+}
+
+impl<St: Stream + Unpin> Default for SelectAll<St> {
+    fn default() -> SelectAll<St> {
+        SelectAll::new()
     }
 }
 


### PR DESCRIPTION
This implements `Default` for `SelectAll`, which already has a new method that takes no argument.

Also, `FuturesUnordered` and `FuturesOrdered` are already implementing `Default` in #1343.