### PR TITLE
Remove unused mut in futures-util documentation

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -567,10 +567,10 @@ pub trait FutureExt: Future {
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt, Ready};
     ///
-    /// let mut future = future::ready(2);
+    /// let future = future::ready(2);
     /// assert!(await!(future.catch_unwind()).is_ok());
     ///
-    /// let mut future = future::lazy(|_| -> Ready<i32> {
+    /// let future = future::lazy(|_| -> Ready<i32> {
     ///     unimplemented!()
     /// });
     /// assert!(await!(future.catch_unwind()).is_err());

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -93,7 +93,7 @@ pub trait SinkExt: Sink {
     /// use futures::stream::StreamExt;
     /// use std::collections::VecDeque;
     ///
-    /// let (mut tx, rx) = mpsc::channel(5);
+    /// let (tx, rx) = mpsc::channel(5);
     ///
     /// let mut tx = tx.with_flat_map(|x| {
     ///     VecDeque::from(vec![Ok(42); x])

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -358,7 +358,7 @@ pub trait StreamExt: Stream {
     /// use futures::stream::StreamExt;
     /// use std::thread;
     ///
-    /// let (mut tx, rx) = mpsc::unbounded();
+    /// let (tx, rx) = mpsc::unbounded();
     ///
     /// thread::spawn(move || {
     ///     for i in (1..=5) {
@@ -394,7 +394,7 @@ pub trait StreamExt: Stream {
     /// use futures::stream::StreamExt;
     /// use std::thread;
     ///
-    /// let (mut tx, rx) = mpsc::unbounded();
+    /// let (tx, rx) = mpsc::unbounded();
     ///
     /// thread::spawn(move || {
     ///     for i in (0..3).rev() {
@@ -883,8 +883,8 @@ pub trait StreamExt: Stream {
     /// use futures::executor::block_on;
     /// use futures::stream::{self, StreamExt};
     ///
-    /// let mut stream1 = stream::iter(1..=3);
-    /// let mut stream2 = stream::iter(5..=10);
+    /// let stream1 = stream::iter(1..=3);
+    /// let stream2 = stream::iter(5..=10);
     ///
     /// let vec = block_on(stream1.zip(stream2)
     ///                           .collect::<Vec<_>>());


### PR DESCRIPTION
This removes unused mut in futures-util documentation.