### PR TITLE
Add the minimum required version to README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ matrix:
         - cargo update -Zminimal-versions
         - cargo test --all --all-features
 
+    # When updating this, the reminder to update the minimum required version in README.md.
+    - name: cargo test (minimum required version)
+      rust: nightly-2018-12-26
+
     - name: cargo clippy
       rust: nightly
       script:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Now, you can use futures-rs:
 use futures::future::Future; // Note: It's not `futures_preview`
 ```
 
+The current version of futures-rs requires Rust nightly 2018-12-26 or later.
+
 ### Feature `std`
 
 Futures-rs works without the standard library, such as in bare metal environments.


### PR DESCRIPTION
I think that it is preferable to display the minimum required version.

Related: rust-lang-nursery/pin-utils#19