### PR TITLE
Allow joining !Unpin futures in JoinAll

### DIFF
--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -1,7 +1,7 @@
 //! Combinators and utilities for working with `Future`s, `Stream`s, `Sink`s,
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
-#![feature(futures_api)]
+#![feature(futures_api, box_into_pin)]
 #![cfg_attr(feature = "std", feature(async_await, await_macro))]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 


### PR DESCRIPTION
2 things I want to do before merging:

1. ~~Add a new `Box<T> -> Pin<Box<T>>` API to `std` to remove one use of `Pin::new_unchecked`.~~ EDIT: Possible via `<Pin<Box<T>> as From<Box<T>>>::from`, not very discoverable however...
2. Try and throw a minimal wrapper around `Pin<Box<[T]>>` to provide a safe API to iterate over it.

Just opening this up now in case anyone has any examples of doing something like the second already.