### PR TITLE
impl Default for Mutex

### DIFF
--- a/futures-util/src/lock/mutex.rs
+++ b/futures-util/src/lock/mutex.rs
@@ -25,6 +25,12 @@ impl<T> fmt::Debug for Mutex<T> {
     }
 }
 
+impl<T: Default> Default for Mutex<T> {
+    fn default() -> Mutex<T> {
+        Mutex::new(Default::default())
+    }
+}
+
 enum Waiter {
     Waiting(Waker),
     Woken,


### PR DESCRIPTION
Implements `Default` for `Mutex<T>`.