### PR TITLE
Add a new futures-intrusive crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "futures-channel",
   "futures-executor",
   "futures-io",
+  "futures-intrusive",
   "futures-sink",
   "futures-util",
   "futures-test",

--- a/futures-intrusive/Cargo.toml
+++ b/futures-intrusive/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "futures-intrusive-preview"
+edition = "2018"
+version = "0.3.0-alpha.11"
+authors = ["Matthias Einwag <matthias.einwag@live.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang-nursery/futures-rs"
+homepage = "https://rust-lang-nursery.github.io/futures-rs"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.11/futures_intrusive"
+description = """
+Futures based on intrusive data structures.
+"""
+
+[lib]
+name = "futures_intrusive"
+
+[features]
+std = ["futures-core-preview/std"]
+default = ["std"]
+
+[dependencies]
+futures-core-preview = { path = "../futures-core", version = "0.3.0-alpha.11", default-features = false }
+
+[dev-dependencies]
+futures-preview = { path = "../futures", version = "0.3.0-alpha.11", default-features = true }
+futures-test-preview = { path = "../futures-test", version = "0.3.0-alpha.11", default-features = true }
+pin-utils = "0.1.0-alpha.3"

--- a/futures-intrusive/Cargo.toml
+++ b/futures-intrusive/Cargo.toml
@@ -24,4 +24,4 @@ futures-core-preview = { path = "../futures-core", version = "0.3.0-alpha.11", d
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "0.3.0-alpha.11", default-features = true }
 futures-test-preview = { path = "../futures-test", version = "0.3.0-alpha.11", default-features = true }
-pin-utils = "0.1.0-alpha.3"
+pin-utils = "0.1.0-alpha.4"

--- a/futures-intrusive/LICENSE-APACHE
+++ b/futures-intrusive/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright (c) 2016 Alex Crichton
+Copyright (c) 2017 The Tokio Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/futures-intrusive/LICENSE-MIT
+++ b/futures-intrusive/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2018 The futures-rs Authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/futures-intrusive/src/channel/mod.rs
+++ b/futures-intrusive/src/channel/mod.rs
@@ -1,0 +1,15 @@
+//! Asynchronous channels.
+//!
+//! This module provides various channels that can be used to communicate between
+//! asynchronous tasks.
+
+mod oneshot;
+
+pub use self::oneshot::{
+    LocalOneshotChannel, LocalOneshotReceiveFuture,
+};
+
+#[cfg(feature = "std")]
+pub use self::oneshot::{
+    OneshotChannel, OneshotReceiveFuture,
+};

--- a/futures-intrusive/src/channel/oneshot.rs
+++ b/futures-intrusive/src/channel/oneshot.rs
@@ -1,0 +1,375 @@
+//! An asynchronously awaitable oneshot channel
+
+use futures_core::future::{Future, FusedFuture};
+use futures_core::task::{LocalWaker, Poll, Waker};
+use core::pin::Pin;
+use core::cell::RefCell;
+use crate::intrusive_list::{LinkedList, ListNode};
+
+/// Tracks how the future had interacted with the channel
+#[derive(PartialEq)]
+enum PollState {
+    /// The task is not registered at the wait queue at the channel
+    Unregistered,
+    /// The task was added to the wait queue at the channel.
+    Registered,
+}
+
+/// Tracks the oneshot channel futures waiting state.
+/// Access to this struct is synchronized through the mutex in the channel.
+struct WaitQueueEntry {
+    /// The task handle of the waiting task
+    task: Option<Waker>,
+    /// Current polling state
+    state: PollState,
+}
+
+impl WaitQueueEntry {
+    /// Creates a new WaitQueueEntry
+    fn new() -> WaitQueueEntry {
+        WaitQueueEntry {
+            task: None,
+            state: PollState::Unregistered,
+        }
+    }
+}
+
+/// Internal state of the oneshot channel
+struct ChannelState<T> {
+    /// Whether the channel had been fulfilled before
+    is_fulfilled: bool,
+    /// The value which is stored inside the channel
+    value: Option<T>,
+    /// The list of waiters, which are waiting for the channel to get fulfilled
+    waiters: LinkedList<WaitQueueEntry>,
+}
+
+impl<T> ChannelState<T> {
+    fn new() -> ChannelState<T> {
+        ChannelState::<T> {
+            is_fulfilled: false,
+            value: None,
+            waiters: LinkedList::new(),
+        }
+    }
+
+    /// Writes a single value to the channel.
+    /// If a value had been written to the channel before, the new value will be rejected.
+    fn send(&mut self, value: T) -> Result<(), T> {
+        if self.is_fulfilled {
+            return Err(value);
+        }
+
+        self.value = Some(value);
+        self.is_fulfilled = true;
+
+        // Wakeup all waiters
+        let mut waiters = self.waiters.take();
+
+        unsafe {
+            // Reverse the waiter list, so that the oldest waker (which is
+            // at the end of the list), gets woken first and has the best
+            // chance to grab the channel value.
+            waiters.reverse();
+
+            for waiter in waiters.into_iter() {
+                let task = (*waiter).task.take();
+                if let Some(ref handle) = task {
+                    handle.wake();
+                }
+                (*waiter).state = PollState::Unregistered;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Tries to read the value from the channel.
+    /// If the value isn't available yet, the LocalOneshotReceiveFuture gets added to the
+    /// wait queue at the channel, and will be signalled once ready.
+    /// This function is only safe as long as the `wait_node`s address is guaranteed
+    /// to be stable until it gets removed from the queue.
+    unsafe fn try_receive(
+        &mut self,
+        wait_node: &mut ListNode<WaitQueueEntry>,
+        lw: &LocalWaker,
+    ) -> Poll<Option<T>> {
+        match wait_node.state {
+            PollState::Unregistered => {
+                let maybe_val = self.value.take();
+                match maybe_val {
+                    Some(v) => {
+                        // A value was available inside the channel and was fetched
+                        Poll::Ready(Some(v))
+                    },
+                    None => {
+                        // Check if something was written into the channel before
+                        if self.is_fulfilled {
+                            Poll::Ready(None)
+                        }
+                        else {
+                            // Added the task to the wait queue
+                            wait_node.task = Some(lw.clone().into_waker());
+                            wait_node.state = PollState::Registered;
+                            self.waiters.add_front(wait_node);
+                            Poll::Pending
+                        }
+                    },
+                }
+            },
+            PollState::Registered => {
+                // Since the channel wakes up all waiters and moves their states to unregistered
+                // there can't be any value in the channel in this state.
+                Poll::Pending
+            },
+        }
+    }
+
+    fn remove_waiter(&mut self, wait_node: &mut ListNode<WaitQueueEntry>) {
+        // LocalOneshotReceiveFuture only needs to get removed if it had been added to
+        // the wait queue of the channel. This has happened in the PollState::Waiting case.
+        if let PollState::Registered = wait_node.state {
+            if ! unsafe { self.waiters.remove(wait_node) } {
+                // Panic if the address isn't found. This can only happen if the contract was
+                // violated, e.g. the WaitQueueEntry got moved after the initial poll.
+                panic!("Future could not be removed from wait queue");
+            }
+            wait_node.state = PollState::Unregistered;
+        }
+    }
+}
+
+/// A channel which can be used to exchange a single value between two
+/// concurrent tasks.
+///
+/// Tasks can wait for the value to get delivered via `receive`.
+/// The returned Future will get fulfilled when a value is sent into the channel.
+pub struct LocalOneshotChannel<T> {
+    inner: RefCell<ChannelState<T>>,
+}
+
+// The channel can be sent to other threads as long as it's not borrowed and the
+// value in it can be sent to other threads.
+unsafe impl<T: Send> Send for LocalOneshotChannel<T> {}
+
+impl<T> core::fmt::Debug for LocalOneshotChannel<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalOneshotChannel")
+            .finish()
+    }
+}
+
+impl<T> LocalOneshotChannel<T> {
+    /// Creates a new LocalOneshotChannel in the given state
+    pub fn new() -> LocalOneshotChannel<T> {
+        LocalOneshotChannel {
+            inner: RefCell::new(ChannelState::new()),
+        }
+    }
+
+    /// Writes a single value to the channel.
+    ///
+    /// This will notify waiters about the availability of the value.
+    /// If a value had been written to the channel before, the new value will be rejected
+    /// and returned inside the error variant.
+    pub fn send(&self, value: T) -> Result<(), T> {
+        self.inner.borrow_mut().send(value)
+    }
+
+    /// Returns a future that gets fulfilled when a value is written to the channel.
+    pub fn receive(&self) -> LocalOneshotReceiveFuture<T> {
+        LocalOneshotReceiveFuture {
+            channel: Some(&self),
+            wait_node: ListNode::new(WaitQueueEntry::new()),
+        }
+    }
+}
+
+/// A Future that is resolved once the corresponding LocalOneshotChannel has been set
+#[must_use = "futures do nothing unless polled"]
+pub struct LocalOneshotReceiveFuture<'a, T> {
+    /// The LocalOneshotChannel that is associated with this LocalOneshotReceiveFuture
+    channel: Option<&'a LocalOneshotChannel<T>>,
+    /// Node for waiting on the channel
+    wait_node: ListNode<WaitQueueEntry>,
+}
+
+impl<'a, T> core::fmt::Debug for LocalOneshotReceiveFuture<'a, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalOneshotReceiveFuture")
+            .finish()
+    }
+}
+
+impl<'a, T> Future for LocalOneshotReceiveFuture<'a, T> {
+    type Output = Option<T>;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        lw: &LocalWaker,
+    ) -> Poll<Option<T>> {
+        // It might be possible to use Pin::map_unchecked here instead of the two unsafe APIs.
+        // However this didn't seem to work for some borrow checker reasons
+
+        // Safety: The next operations are safe, because Pin promises us that
+        // the address of the wait queue entry inside LocalOneshotReceiveFuture is stable,
+        // and we don't move any fields inside the future until it gets dropped.
+        let mut_self: &mut LocalOneshotReceiveFuture<T> = unsafe {
+            Pin::get_unchecked_mut(self)
+        };
+
+        let channel = mut_self.channel.expect("polled LocalOneshotReceiveFuture after completion");
+
+        let poll_res = unsafe {
+            channel.inner.borrow_mut().try_receive(
+                &mut mut_self.wait_node,
+                lw)
+        };
+
+        if poll_res.is_ready() {
+            // A value was available
+            mut_self.channel = None;
+        }
+
+        poll_res
+    }
+}
+
+impl<'a, T> FusedFuture for LocalOneshotReceiveFuture<'a, T> {
+    fn is_terminated(&self) -> bool {
+        self.channel.is_none()
+    }
+}
+
+impl<'a, T> Drop for LocalOneshotReceiveFuture<'a, T> {
+    fn drop(&mut self) {
+        // If this LocalOneshotReceiveFuture has been polled and it was added to the
+        // wait queue at the channel, it must be removed before dropping.
+        // Otherwise the channel would access invalid memory.
+        if let Some(channel) = self.channel {
+            channel.inner.borrow_mut().remove_waiter(&mut self.wait_node);
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A channel which can be used to exchange a single value between two
+    /// concurrent tasks.
+    ///
+    /// Tasks can wait for the value to get delivered via `receive`.
+    /// The returned Future will get fulfilled when a value is sent into the channel.
+    pub struct OneshotChannel<T> {
+        inner: Mutex<ChannelState<T>>,
+    }
+
+    // The channel can be sent to other threads as long as it's not borrowed and the
+    // value in it can be sent to other threads.
+    unsafe impl<T: Send> Send for OneshotChannel<T> {}
+
+    impl<T> core::fmt::Debug for OneshotChannel<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("OneshotChannel")
+                .finish()
+        }
+    }
+
+    impl<T> OneshotChannel<T> {
+        /// Creates a new OneshotChannel in the given state
+        pub fn new() -> OneshotChannel<T> {
+            OneshotChannel {
+                inner: Mutex::new(ChannelState::new()),
+            }
+        }
+
+        /// Writes a single value to the channel.
+        ///
+        /// This will notify waiters about the availability of the value.
+        /// If a value had been written to the channel before, the new value will be rejected
+        /// and returned inside the error variant.
+        pub fn send(&self, value: T) -> Result<(), T> {
+            self.inner.lock().unwrap().send(value)
+        }
+
+        /// Returns a future that gets fulfilled when a value is written to the channel.
+        pub fn receive(&self) -> OneshotReceiveFuture<T> {
+            OneshotReceiveFuture {
+                channel: Some(&self),
+                wait_node: ListNode::new(WaitQueueEntry::new()),
+            }
+        }
+    }
+
+    /// A Future that is resolved once the corresponding OneshotChannel has been set
+    #[must_use = "futures do nothing unless polled"]
+    pub struct OneshotReceiveFuture<'a, T> {
+        /// The OneshotChannel that is associated with this OneshotReceiveFuture
+        channel: Option<&'a OneshotChannel<T>>,
+        /// Node for waiting on the channel
+        wait_node: ListNode<WaitQueueEntry>,
+    }
+
+    impl<'a, T> core::fmt::Debug for OneshotReceiveFuture<'a, T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("OneshotReceiveFuture")
+                .finish()
+        }
+    }
+
+    impl<'a, T> Future for OneshotReceiveFuture<'a, T> {
+        type Output = Option<T>;
+
+        fn poll(
+            self: Pin<&mut Self>,
+            lw: &LocalWaker,
+        ) -> Poll<Option<T>> {
+            // It might be possible to use Pin::map_unchecked here instead of the two unsafe APIs.
+            // However this didn't seem to work for some borrow checker reasons
+
+            // Safety: The next operations are safe, because Pin promises us that
+            // the address of the wait queue entry inside OneshotReceiveFuture is stable,
+            // and we don't move any fields inside the future until it gets dropped.
+            let mut_self: &mut OneshotReceiveFuture<T> = unsafe {
+                Pin::get_unchecked_mut(self)
+            };
+
+            let channel = mut_self.channel.expect("polled OneshotReceiveFuture after completion");
+
+            let poll_res = unsafe {
+                channel.inner.lock().unwrap().try_receive(
+                    &mut mut_self.wait_node,
+                    lw)
+            };
+
+            if poll_res.is_ready() {
+                // A value was available
+                mut_self.channel = None;
+            }
+
+            poll_res
+        }
+    }
+
+    impl<'a, T> FusedFuture for OneshotReceiveFuture<'a, T> {
+        fn is_terminated(&self) -> bool {
+            self.channel.is_none()
+        }
+    }
+
+    impl<'a, T> Drop for OneshotReceiveFuture<'a, T> {
+        fn drop(&mut self) {
+            // If this OneshotReceiveFuture has been polled and it was added to the
+            // wait queue at the channel, it must be removed before dropping.
+            // Otherwise the channel would access invalid memory.
+            if let Some(channel) = self.channel {
+                channel.inner.lock().unwrap().remove_waiter(&mut self.wait_node);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/futures-intrusive/src/intrusive_list.rs
+++ b/futures-intrusive/src/intrusive_list.rs
@@ -1,0 +1,380 @@
+//! An intrusive list of data
+
+use core::ops::{Deref, DerefMut};
+use core::ptr::null_mut;
+use core::marker::{PhantomPinned};
+
+/// A node which carries data of type `T` and is stored in an intrusive list
+#[derive(Debug)]
+pub struct ListNode<T> {
+    next: *mut ListNode<T>,
+    /// The data which is associated to this list item
+    data: T,
+    /// Prevents `ListNode`s from being `Unpin`. They may never be moved, since
+    /// the list semantics require addresses to be stable.
+    _pin: PhantomPinned,
+}
+
+impl<T> ListNode<T> {
+    /// Creates a new node with the associated data
+    pub fn new(data: T) -> ListNode<T> {
+        ListNode::<T> {
+            next: null_mut(),
+            data,
+            _pin: PhantomPinned,
+        }
+    }
+}
+
+impl<T> Deref for ListNode<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.data
+    }
+}
+
+impl<T> DerefMut for ListNode<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+}
+
+/// An intrusive linked list of nodes, where each node carries associated data
+/// of type `T`.
+#[derive(Debug)]
+pub struct LinkedList<T> {
+    head: *mut ListNode<T>,
+}
+
+impl<T> LinkedList<T> {
+    /// Creates an empty linked list
+    pub fn new() -> Self {
+        LinkedList::<T> {
+            head: null_mut(),
+        }
+    }
+
+    /// Consumes the list and creates an iterator over the linked list.
+    /// This function is only safe as long as all pointers which are stored inside
+    /// the linked list are valid.
+    pub unsafe fn into_iter(self) -> LinkedListIterator<T> {
+        LinkedListIterator {
+            current: self.head,
+        }
+    }
+
+    /// Adds an item to the front of the linked list.
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the linked list.
+    pub unsafe fn add_front(&mut self, item: *mut ListNode<T>) {
+        assert!(item != null_mut(), "Can not add null pointers");
+        (*item).next = self.head;
+        self.head = item;
+    }
+
+    /// Returns the last item in the linked list without removing it from the list
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the linked list.
+    /// The returned pointer is only guaranteed to be valid as long as the list
+    /// is not mutated
+    pub fn peek_last(&self) -> *mut ListNode<T> {
+        let mut iter = self.head;
+        if iter.is_null() {
+            return null_mut();
+        }
+
+        unsafe {
+            while !iter.is_null() {
+                if (*iter).next.is_null() {
+                    return iter;
+                }
+                iter = (*iter).next;
+            }
+        }
+
+        panic!("No list item found");
+    }
+
+    /// Removes the last item from the linked list and returns it
+    pub fn remove_last(&mut self) -> *mut ListNode<T> {
+        let mut iter = self.head;
+        if iter.is_null() {
+            return null_mut();
+        }
+
+        let mut prev: *mut ListNode<T> = null_mut();
+        unsafe {
+            while !iter.is_null() {
+                if (*iter).next.is_null() {
+                    // This is the last iter in the list.
+                    // Remove it from the list and return it.
+                    if !prev.is_null() {
+                        (*prev).next = null_mut();
+                    }
+                    else {
+                        self.head = null_mut();
+                    }
+
+                    (*iter).next = null_mut();
+
+                    return iter;
+                }
+                prev = iter;
+                iter = (*iter).next;
+            }
+        }
+
+        panic!("No list item found");
+    }
+
+    /// Removes all items from the linked list and returns a LinkedList which
+    /// contains all the items.
+    pub fn take(&mut self) -> LinkedList<T> {
+        let head = self.head;
+        self.head = null_mut();
+        LinkedList::<T>{
+            head,
+        }
+    }
+
+    /// Returns whether the linked list doesn not contain any node
+    pub fn is_empty(&self) -> bool {
+        self.head.is_null()
+    }
+
+    /// Reverses the linked list.
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the linked list.
+    pub unsafe fn reverse(&mut self) {
+        let mut rev_head: *mut ListNode<T> = null_mut();
+        let mut iter = self.head;
+
+        while !iter.is_null() {
+            let curr = iter;
+            iter = (*iter).next;
+
+            (*curr).next = rev_head;
+            rev_head = curr;
+        }
+        self.head = rev_head;
+    }
+
+    /// Removes the given item from the linked list.
+    /// Returns whether the item was removed.
+    /// The function is only safe as long as valid pointers are stored inside
+    /// the linked list.
+    pub unsafe fn remove(&mut self, item: *mut ListNode<T>) -> bool {
+        if item.is_null() {
+            return false;
+        }
+
+        if self.head == item {
+            self.head = (*item).next;
+            (*item).next = null_mut();
+            return true;
+        }
+
+        let mut iter = self.head;
+        while !iter.is_null() {
+            if (*iter).next == item {
+                (*iter).next = (*item).next;
+                (*item).next = null_mut();
+                return true;
+            } else {
+                iter = (*iter).next;
+            }
+        }
+
+        false
+    }
+}
+
+/// An iterator over an intrusively linked list
+pub struct LinkedListIterator<T> {
+    current: *mut ListNode<T>,
+}
+
+impl<T> Iterator for LinkedListIterator<T> {
+    type Item = *mut ListNode<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current.is_null() {
+            return None;
+        }
+
+        let node = self.current;
+        // Safety: This is safe as long as the linked list is intact, which was
+        // already required through the unsafe when creating the iterator.
+        unsafe {
+            self.current = (*self.current).next;
+        }
+        Some(node)
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "std")] // Tests make use of Vec at the moment
+mod tests {
+    use super::*;
+
+    unsafe fn collect_list<T: Copy>(list: LinkedList<T>) -> Vec<T> {
+        list.into_iter().map(|item|(*(*item).deref())).collect()
+    }
+
+    #[test]
+    fn insert_and_iterate() {
+        unsafe {
+            let mut a = ListNode::new(5);
+            let mut b = ListNode::new(7);
+            let mut c = ListNode::new(31);
+
+            let mut list = LinkedList::new();
+            assert_eq!(true, list.is_empty());
+            list.add_front(&mut c);
+            assert_eq!(false, list.is_empty());
+            list.add_front(&mut b);
+            list.add_front(&mut a);
+
+            let items: Vec<i32> = collect_list(list);
+            assert_eq!([5,7,31].to_vec(), items);
+        }
+    }
+
+    #[test]
+    fn take_items() {
+        unsafe {
+            let mut a = ListNode::new(5);
+            let mut b = ListNode::new(7);
+            let mut c = ListNode::new(31);
+
+            let mut list = LinkedList::new();
+            list.add_front(&mut c);
+            list.add_front(&mut b);
+            list.add_front(&mut a);
+
+            let taken = list.take();
+
+            let items: Vec<i32> = collect_list(list);
+            assert!(items.is_empty());
+            let taken_items: Vec<i32> = collect_list(taken);
+            assert_eq!([5,7,31].to_vec(), taken_items);
+        }
+    }
+
+    #[test]
+    fn peek_last() {
+        unsafe {
+            let mut a = ListNode::new(5);
+            let mut b = ListNode::new(7);
+            let mut c = ListNode::new(31);
+
+            let mut list = LinkedList::new();
+            list.add_front(&mut c);
+            list.add_front(&mut b);
+            list.add_front(&mut a);
+
+            let last = list.peek_last();
+            assert_eq!(31, *(*last).deref());
+            list.remove_last();
+
+            let last = list.peek_last();
+            assert_eq!(7, *(*last).deref());
+            list.remove_last();
+
+            let last = list.peek_last();
+            assert_eq!(5, *(*last).deref());
+            list.remove_last();
+
+            let last = list.peek_last();
+            assert!(last.is_null());
+        }
+    }
+
+    #[test]
+    fn remove_last() {
+        unsafe {
+            let mut a = ListNode::new(5);
+            let mut b = ListNode::new(7);
+            let mut c = ListNode::new(31);
+
+            let mut list = LinkedList::new();
+            list.add_front(&mut c);
+            list.add_front(&mut b);
+            list.add_front(&mut a);
+
+            list.remove_last();
+
+            let items: Vec<i32> = collect_list(list);
+            assert_eq!([5,7].to_vec(), items);
+        }
+    }
+
+    #[test]
+    fn remove_by_address() {
+        unsafe {
+            let mut a = ListNode::new(5);
+            let mut b = ListNode::new(7);
+            let mut c = ListNode::new(31);
+
+            {
+                // Remove first
+                let mut list = LinkedList::new();
+                list.add_front(&mut c);
+                list.add_front(&mut b);
+                list.add_front(&mut a);
+
+                assert_eq!(true, list.remove(&mut a));
+                // a should be no longer there and can't be removed twice
+                assert_eq!(false, list.remove(&mut a));
+
+                let items: Vec<i32> = collect_list(list);
+                assert_eq!([7, 31].to_vec(), items);
+            }
+
+            {
+                // Remove middle
+                let mut list = LinkedList::new();
+                list.add_front(&mut c);
+                list.add_front(&mut b);
+                list.add_front(&mut a);
+
+                assert_eq!(true, list.remove(&mut b));
+
+                let items: Vec<i32> = collect_list(list);
+                assert_eq!([5, 31].to_vec(), items);
+            }
+
+            {
+                // Remove last
+                let mut list = LinkedList::new();
+                list.add_front(&mut c);
+                list.add_front(&mut b);
+                list.add_front(&mut a);
+
+                assert_eq!(true, list.remove(&mut c));
+
+                let items: Vec<i32> = collect_list(list);
+                assert_eq!([5, 7].to_vec(), items);
+            }
+
+            {
+                // Remove missing
+                let mut list = LinkedList::new();
+                list.add_front(&mut b);
+                list.add_front(&mut a);
+
+                assert_eq!(false, list.remove(&mut c));
+            }
+
+            {
+                // Remove null
+                let mut list = LinkedList::new();
+                list.add_front(&mut b);
+                list.add_front(&mut a);
+
+                assert_eq!(false, list.remove(null_mut()));
+            }
+        }
+    }
+}

--- a/futures-intrusive/src/lib.rs
+++ b/futures-intrusive/src/lib.rs
@@ -1,0 +1,17 @@
+//! Asynchronous channels.
+//!
+//! This crate provides channels that can be used to communicate between
+//! asynchronous tasks.
+
+#![feature(futures_api)]
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#![warn(missing_docs, missing_debug_implementations)]
+#![deny(bare_trait_objects)]
+
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.11/futures_intrusive")]
+
+mod intrusive_list;
+
+pub mod sync;

--- a/futures-intrusive/src/lib.rs
+++ b/futures-intrusive/src/lib.rs
@@ -15,3 +15,4 @@
 mod intrusive_list;
 
 pub mod sync;
+pub mod channel;

--- a/futures-intrusive/src/sync/manual_reset_event.rs
+++ b/futures-intrusive/src/sync/manual_reset_event.rs
@@ -1,0 +1,391 @@
+//! An asynchronously awaitable event for signalization between tasks
+
+use futures_core::future::{Future, FusedFuture};
+use futures_core::task::{LocalWaker, Poll, Waker};
+use core::pin::Pin;
+use core::cell::RefCell;
+use crate::intrusive_list::{LinkedList, ListNode};
+
+/// Tracks how the future had interacted with the event
+#[derive(PartialEq)]
+enum PollState {
+    /// The task has never interacted with the event.
+    New,
+    /// The task was added to the wait queue at the event.
+    Waiting,
+    /// The task had been polled to completion.
+    Done,
+}
+
+/// Tracks the WaitForEventFuture waiting state.
+/// Access to this struct is synchronized through the mutex in the Event.
+struct WaitQueueEntry {
+    /// The task handle of the waiting task
+    task: Option<Waker>,
+    /// Current polling state
+    state: PollState,
+}
+
+impl WaitQueueEntry {
+    /// Creates a new WaitQueueEntry
+    fn new() -> WaitQueueEntry {
+        WaitQueueEntry {
+            task: None,
+            state: PollState::New,
+        }
+    }
+}
+
+/// Internal state of the `ManualResetEvent` pair above
+struct EventState {
+    is_set: bool,
+    waiters: LinkedList<WaitQueueEntry>,
+}
+
+impl EventState {
+    fn new(is_set: bool) -> EventState {
+        EventState {
+            is_set,
+            waiters: LinkedList::new(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.is_set = false;
+    }
+
+    fn set(&mut self) {
+        if self.is_set != true {
+            self.is_set = true;
+
+            // Wakeup all waiters
+            // This happens inside the lock to make cancellation reliable
+            // If we would access waiters outside of the lock, the pointers
+            // may no longer be valid.
+            // Typically this shouldn't be an issue, since waking a task should
+            // only move it from the blocked into the ready state and not have
+            // further side effects.
+
+            let mut waiters = self.waiters.take();
+
+            unsafe {
+                // Reverse the waiter list, so that the oldest waker (which is
+                // at the end of the list), gets woken first.
+                waiters.reverse();
+
+                for waiter in waiters.into_iter() {
+                    let task = (*waiter).task.take();
+                    if let Some(ref handle) = task {
+                        handle.wake();
+                    }
+                    (*waiter).state = PollState::Done;
+                }
+            }
+        }
+    }
+
+    fn is_set(&self) -> bool {
+        self.is_set
+    }
+
+    /// Checks if the event is set. If it is this returns immediately.
+    /// If the event isn't set, the WaitForEventFuture gets added to the wait
+    /// queue at the event, and will be signalled once ready.
+    /// This function is only safe as long as the `wait_node`s address is guaranteed
+    /// to be stable until it gets removed from the queue.
+    unsafe fn try_wait(
+        &mut self,
+        wait_node: &mut ListNode<WaitQueueEntry>,
+        lw: &LocalWaker,
+    ) -> Poll<()> {
+        match wait_node.state {
+            PollState::New => {
+                if self.is_set {
+                    // The event is already signaled
+                    wait_node.state = PollState::Done;
+                    Poll::Ready(())
+                }
+                else {
+                    // Added the task to the wait queue
+                    wait_node.task = Some(lw.clone().into_waker());
+                    wait_node.state = PollState::Waiting;
+                    self.waiters.add_front(wait_node);
+                    Poll::Pending
+                }
+            },
+            PollState::Waiting => {
+                // The WaitForEventFuture is already in the queue.
+                // The event can't have been set, since this would change the
+                // waitstate inside the mutex.
+                Poll::Pending
+            },
+            PollState::Done => {
+                // We had been woken up by the event.
+                // This does not guarantee that the event is still set. It could
+                // have been reset it in the meantime.
+                Poll::Ready(())
+            },
+        }
+    }
+
+    fn remove_waiter(&mut self, wait_node: &mut ListNode<WaitQueueEntry>) {
+        // WaitForEventFuture only needs to get removed if it had been added to
+        // the wait queue of the Event. This has happened in the PollState::Waiting case.
+        if let PollState::Waiting = wait_node.state {
+            if ! unsafe { self.waiters.remove(wait_node) } {
+                // Panic if the address isn't found. This can only happen if the contract was
+                // violated, e.g. the WaitQueueEntry got moved after the initial poll.
+                panic!("Future could not be removed from wait queue");
+            }
+            wait_node.state = PollState::Done;
+        }
+    }
+}
+
+/// A synchronization primitive which can be either in the set or reset state.
+///
+/// Tasks can wait for the event to get set by obtaining a Future via `wait`.
+/// This Future will get fulfilled when the event had been set.
+pub struct LocalManualResetEvent {
+    inner: RefCell<EventState>,
+}
+
+// The Event is can be sent to other threads as long as it's not borrowed
+unsafe impl Send for LocalManualResetEvent {}
+
+impl core::fmt::Debug for LocalManualResetEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalManualResetEvent")
+            .finish()
+    }
+}
+
+impl LocalManualResetEvent {
+    /// Creates a new LocalManualResetEvent in the given state
+    pub fn new(is_set: bool) -> LocalManualResetEvent {
+        LocalManualResetEvent {
+            inner: RefCell::new(EventState::new(is_set)),
+        }
+    }
+
+    /// Sets the event.
+    ///
+    /// Setting the event will notify all pending waiters.
+    pub fn set(&self) {
+        self.inner.borrow_mut().set()
+    }
+
+    /// Resets the event.
+    pub fn reset(&self) {
+        self.inner.borrow_mut().reset()
+    }
+
+    /// Returns whether the event is set
+    pub fn is_set(&self) -> bool {
+        self.inner.borrow().is_set()
+    }
+
+    /// Returns a future that gets fulfilled when the event is set.
+    pub fn wait<'a>(&'a self) -> LocalWaitForEventFuture {
+        LocalWaitForEventFuture {
+            event: Some(&self),
+            wait_node: ListNode::new(WaitQueueEntry::new()),
+        }
+    }
+}
+
+/// A Future that is resolved once the corresponding LocalManualResetEvent has been set
+#[must_use = "futures do nothing unless polled"]
+pub struct LocalWaitForEventFuture<'a> {
+    /// The LocalManualResetEvent that is associated with this WaitForEventFuture
+    event: Option<&'a LocalManualResetEvent>,
+    /// Node for waiting at the event
+    wait_node: ListNode<WaitQueueEntry>,
+}
+
+impl<'a> core::fmt::Debug for LocalWaitForEventFuture<'a> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalWaitForEventFuture")
+            .finish()
+    }
+}
+
+impl<'a> Future for LocalWaitForEventFuture<'a> {
+    type Output = ();
+
+    fn poll(
+        self: Pin<&mut Self>,
+        lw: &LocalWaker,
+    ) -> Poll<()> {
+        // It might be possible to use Pin::map_unchecked here instead of the two unsafe APIs.
+        // However this didn't seem to work for some borrow checker reasons
+
+        // Safety: The next operations are safe, because Pin promises us that
+        // the address of the wait queue entry inside MutexLocalFuture is stable,
+        // and we don't move any fields inside the future until it gets dropped.
+        let mut_self: &mut LocalWaitForEventFuture = unsafe {
+            
+            Pin::get_unchecked_mut(self)
+        };
+
+        let event = mut_self.event.expect("polled LocalWaitForEventFuture after completion");
+
+        let poll_res = unsafe {
+            event.inner.borrow_mut().try_wait(
+                &mut mut_self.wait_node,
+                lw)
+        };
+
+        if let Poll::Ready(()) = poll_res {
+            // The event was set
+            mut_self.event = None;
+        }
+
+        poll_res
+    }
+}
+
+impl<'a> FusedFuture for LocalWaitForEventFuture<'a> {
+    fn is_terminated(&self) -> bool {
+        self.event.is_none()
+    }
+}
+
+impl<'a> Drop for LocalWaitForEventFuture<'a> {
+    fn drop(&mut self) {
+        // If this WaitForEventFuture has been polled and it was added to the
+        // wait queue at the event, it must be removed before dropping.
+        // Otherwise the event would access invalid memory.
+        if let Some(ev) = self.event {
+            ev.inner.borrow_mut().remove_waiter(&mut self.wait_node);
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// A synchronization primitive which can be either in the set or reset state.
+    ///
+    /// Tasks can wait for the event to get set by obtaining a Future via `wait`.
+    /// This Future will get fulfilled when the event had been set.
+    pub struct ManualResetEvent {
+        inner: Mutex<EventState>,
+    }
+
+    // The Event is thread-safe and can be sent to other threads.
+    // Automatic derive doesn't work due to the unsafe pointer in WaitQueueEntry
+    unsafe impl Send for ManualResetEvent {}
+    unsafe impl Sync for ManualResetEvent {}
+
+    impl core::fmt::Debug for ManualResetEvent {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("ManualResetEvent")
+                .finish()
+        }
+    }
+
+    impl ManualResetEvent {
+        /// Creates a new ManualResetEvent in the given state
+        pub fn new(is_set: bool) -> ManualResetEvent {
+            ManualResetEvent {
+                inner: Mutex::new(EventState::new(is_set)),
+            }
+        }
+
+        /// Sets the event.
+        ///
+        /// Setting the event will notify all pending waiters.
+        pub fn set(&self) {
+            let mut ev_state = self.inner.lock().unwrap();
+            ev_state.set()
+        }
+
+        /// Resets the event.
+        pub fn reset(&self) {
+            let mut ev_state = self.inner.lock().unwrap();
+            ev_state.reset()
+        }
+
+        /// Returns whether the event is set
+        pub fn is_set(&self) -> bool {
+            let ev_state = self.inner.lock().unwrap();
+            ev_state.is_set()
+        }
+
+        /// Returns a future that gets fulfilled when the event is set.
+        pub fn wait(&self) -> WaitForEventFuture {
+            WaitForEventFuture {
+                event: Some(&self),
+                wait_node: ListNode::new(WaitQueueEntry::new()),
+            }
+        }
+    }
+
+    /// A Future that is resolved once the corresponding ManualResetEvent has been set
+    #[must_use = "futures do nothing unless polled"]
+    pub struct WaitForEventFuture<'a> {
+        /// The ManualResetEvent this is associated with this WaitForEventFuture
+        event: Option<&'a ManualResetEvent>,
+        /// Node for waiting at the event
+        wait_node: ListNode<WaitQueueEntry>,
+    }
+
+    impl<'a> core::fmt::Debug for WaitForEventFuture<'a> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("WaitForEventFuture")
+                .finish()
+        }
+    }
+
+    impl<'a> Future for WaitForEventFuture<'a> {
+        type Output = ();
+
+        fn poll(
+            self: Pin<&mut Self>,
+            lw: &LocalWaker,
+        ) -> Poll<()> {
+            // Safety: The next operations are safe, because Pin promises us that
+            // the address of the wait queue entry inside MutexLocalFuture is stable,
+            // and we don't move any fields inside the future until it gets dropped.
+            let mut_self: &mut WaitForEventFuture = unsafe { Pin::get_unchecked_mut(self) };
+            
+            let event = mut_self.event.expect("polled WaitForEventFuture after completion");
+
+            let poll_res = unsafe {
+                event.inner.lock().unwrap().try_wait(
+                    &mut mut_self.wait_node,
+                    lw)
+            };
+
+            if let Poll::Ready(()) = poll_res {
+                // The event was set
+                mut_self.event = None;
+            }
+
+            poll_res
+        }
+    }
+
+    impl<'a> FusedFuture for WaitForEventFuture<'a> {
+        fn is_terminated(&self) -> bool {
+            self.event.is_none()
+        }
+    }
+
+    impl<'a> Drop for WaitForEventFuture<'a> {
+        fn drop(&mut self) {
+            // If this WaitForEventFuture has been polled and it was added to the
+            // wait queue at the event, it must be removed before dropping.
+            // Otherwise the event would access invalid memory.
+            if let Some(ev) = self.event {
+                ev.inner.lock().unwrap().remove_waiter(&mut self.wait_node);
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/futures-intrusive/src/sync/mod.rs
+++ b/futures-intrusive/src/sync/mod.rs
@@ -1,0 +1,27 @@
+//! Asynchronous synchronization primitives based on intrusive collections.
+//!
+//! This module provides various primitives for synchronizing concurrently
+//! executing futures.
+
+mod manual_reset_event;
+
+pub use self::manual_reset_event::{
+    LocalManualResetEvent, LocalWaitForEventFuture,
+};
+
+#[cfg(feature = "std")]
+pub use self::manual_reset_event::{
+    ManualResetEvent, WaitForEventFuture,
+};
+
+mod mutex;
+
+pub use self::mutex::{
+    LocalMutex, LocalMutexLockFuture, LocalMutexGuard,
+};
+
+#[cfg(feature = "std")]
+pub use self::mutex::{
+    Mutex, MutexLockFuture, MutexGuard,
+};
+

--- a/futures-intrusive/src/sync/mutex.rs
+++ b/futures-intrusive/src/sync/mutex.rs
@@ -1,0 +1,542 @@
+//! An asynchronously awaitable mutex for synchronization between concurrently
+//! executing futures.
+
+use futures_core::future::{Future, FusedFuture};
+use futures_core::task::{LocalWaker, Poll, Waker};
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::ptr::null_mut;
+use core::cell::{UnsafeCell, RefCell};
+use crate::intrusive_list::{LinkedList, ListNode};
+
+/// Tracks how the future had interacted with the mutex
+#[derive(PartialEq)]
+enum PollState {
+    /// The task has never interacted with the mutex.
+    New,
+    /// The task was added to the wait queue at the mutex.
+    Waiting,
+    /// The task had previously waited on the mutex, but was notified
+    /// that the mutex was released in the meantime.
+    Notified,
+    /// The task had been polled to completion.
+    Done,
+}
+
+/// Tracks the MutexLockFuture waiting state.
+/// Access to this struct is synchronized through the mutex in the Event.
+struct WaitQueueEntry {
+    /// The task handle of the waiting task
+    task: Option<Waker>,
+    /// Current polling state
+    state: PollState,
+}
+
+impl WaitQueueEntry {
+    /// Creates a new WaitQueueEntry
+    fn new() -> WaitQueueEntry {
+        WaitQueueEntry {
+            task: None,
+            state: PollState::New,
+        }
+    }
+}
+
+/// Internal state of the `Mutex`
+struct MutexState {
+    is_fair: bool,
+    is_locked: bool,
+    waiters: LinkedList<WaitQueueEntry>,
+}
+
+impl MutexState {
+    fn new(is_fair: bool) -> Self {
+        MutexState {
+            is_fair,
+            is_locked: false,
+            waiters: LinkedList::new(),
+        }
+    }
+
+    /// Wakes up the last waiter and removes it from the wait queue
+    fn wakeup_last_waiter(&mut self) {
+        let last_waiter =
+            if self.is_fair {
+                self.waiters.peek_last()
+            } else {
+                self.waiters.remove_last()
+            };
+
+        if last_waiter != null_mut() {
+            // Notify the waiter that it can try to lock the mutex again.
+            // The notification gets tracked inside the waiter.
+            // If the waiter aborts it's wait (drops the future), another task
+            // must be woken.
+            unsafe {
+                (*last_waiter).state = PollState::Notified;
+
+                let task = (*last_waiter).task.take();
+                if let Some(ref handle) = task {
+                    handle.wake();
+                }
+            }
+        }
+    }
+
+    fn is_locked(&self) -> bool {
+        self.is_locked
+    }
+
+    /// Unlocks the mutex. This is expected to be only called from the current holder of the mutex
+    fn unlock(&mut self) {
+        if self.is_locked {
+            self.is_locked = false;
+            // TODO: Does this require a memory barrier for the actual data,
+            // or is this covered by unlocking the mutex which protects the data?
+            // Wakeup the last waiter
+            self.wakeup_last_waiter();
+        }
+    }
+
+    /// Tries to acquire the Mutex from a WaitQueueEntry.
+    /// If it isn't available, the WaitQueueEntry gets added to the wait
+    /// queue at the Mutex, and will be signalled once ready.
+    /// This function is only safe as long as the `wait_node`s address is guaranteed
+    /// to be stable until it gets removed from the queue.
+    unsafe fn try_lock(
+        &mut self,
+        wait_node: &mut ListNode<WaitQueueEntry>,
+        lw: &LocalWaker,
+    ) -> Poll<()> {
+        match wait_node.state {
+            PollState::New => {
+                // The fast path - the Mutex isn't locked by anyone else.
+                // If the mutex is fair, noone must be in the wait list before us.
+                if !self.is_locked && (!self.is_fair || self.waiters.is_empty()) {
+                    self.is_locked = true;
+                    wait_node.state = PollState::Done;
+                    Poll::Ready(())
+                }
+                else {
+                    // Add the task to the wait queue
+                    wait_node.task = Some(lw.clone().into_waker());
+                    wait_node.state = PollState::Waiting;
+                    self.waiters.add_front(wait_node);
+                    Poll::Pending
+                }
+            },
+            PollState::Waiting => {
+                // The MutexLockFuture is already in the queue.
+                if self.is_fair {
+                    // The task needs to wait until it gets notified in order to
+                    // maintain the ordering.
+                    Poll::Pending
+                }
+                else {
+                    // For throughput improvement purposes, grab the lock immediately
+                    // if it's available.
+                    if !self.is_locked {
+                        self.is_locked = true;
+                        wait_node.state = PollState::Done;
+                        // Since this waiter has been registered before, it must
+                        // get removed from the waiter list.
+                        self.force_remove_waiter(wait_node);
+                        Poll::Ready(())
+                    }
+                    else {
+                        Poll::Pending
+                    }
+                }
+            },
+            PollState::Notified => {
+                // We had been woken by the mutex, since the mutex is available again.
+                // The mutex thereby removed us from the waiters list.
+                // Just try to lock again. If the mutex isn't available,
+                // we need to add it to the wait queue again.
+                if !self.is_locked {
+                    if self.is_fair {
+                        // In a fair Mutex, the WaitQueueEntry is kept in the
+                        // linked list and must be removed here
+                        self.force_remove_waiter(wait_node);
+                    }
+                    self.is_locked = true;
+                    wait_node.state = PollState::Done;
+                    Poll::Ready(())
+                }
+                else {
+                    // Add to queue
+                    wait_node.task = Some(lw.clone().into_waker());
+                    wait_node.state = PollState::Waiting;
+                    self.waiters.add_front(wait_node);
+                    Poll::Pending
+                }
+
+            },
+            PollState::Done => {
+                // The future had been polled to completion before
+                panic!("polled Mutex after completion");
+            },
+        }
+    }
+
+    /// Tries to remove a waiter from the wait queue, and panics if the
+    /// waiter is no longer valid.
+    unsafe fn force_remove_waiter(&mut self, wait_node: *mut ListNode<WaitQueueEntry>) {
+        if !self.waiters.remove(wait_node) {
+            // Panic if the address isn't found. This can only happen if the contract was
+            // violated, e.g. the WaitQueueEntry got moved after the initial poll.
+            panic!("Future could not be removed from wait queue");
+        }
+    }
+
+    /// Removes the waiter from the list.
+    /// This function is only safe as long as the reference that is passed here
+    /// equals the reference/address under which the waiter was added.
+    /// The waiter must not have been moved in between.
+    fn remove_waiter(&mut self, wait_node: &mut ListNode<WaitQueueEntry>) {
+        // MutexLockFuture only needs to get removed if it had been added to
+        // the wait queue of the Mutex. This has happened in the PollState::Waiting case.
+        // If the current waiter was notitfied, another waiter must get notified now.
+        match wait_node.state {
+            PollState::Notified => {
+                if self.is_fair {
+                    // In a fair Mutex, the WaitQueueEntry is kept in the
+                    // linked list and must be removed here
+                    unsafe { self.force_remove_waiter(wait_node) };
+                }
+                wait_node.state = PollState::Done;
+                self.wakeup_last_waiter();
+            },
+            PollState::Waiting => {
+                // Remove the WaitQueueEntry from the linked list
+                unsafe { self.force_remove_waiter(wait_node) };
+                wait_node.state = PollState::Done;
+            },
+            PollState::New | PollState::Done => {},
+        }
+    }
+}
+
+/// An RAII guard returned by the `lock` and `try_lock` methods.
+/// When this structure is dropped (falls out of scope), the lock will be
+/// unlocked.
+pub struct LocalMutexGuard<'a, T: 'a> {
+    /// The Mutex which is associated with this Guard
+    mutex: &'a LocalMutex<T>,
+}
+
+impl<T: core::fmt::Debug> core::fmt::Debug for LocalMutexGuard<'_, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalMutexGuard")
+            .finish()
+    }
+}
+
+impl<T> Drop for LocalMutexGuard<'_, T> {
+    fn drop(&mut self) {
+        // Release the mutex
+        self.mutex.state.borrow_mut().unlock();
+    }
+}
+
+impl<T> Deref for LocalMutexGuard<'_, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        unsafe { &*self.mutex.value.get() }
+    }
+}
+
+impl<T> DerefMut for LocalMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.mutex.value.get() }
+    }
+}
+
+/// A future which resolves when the target mutex has been successfully acquired.
+#[must_use = "futures do nothing unless polled"]
+pub struct LocalMutexLockFuture<'a, T: 'a> {
+    /// The Mutex which should get locked trough this Future
+    mutex: Option<&'a LocalMutex<T>>,
+    /// Node for waiting at the mutex
+    wait_node: ListNode<WaitQueueEntry>,
+}
+
+impl<'a, T: core::fmt::Debug> core::fmt::Debug for LocalMutexLockFuture<'a, T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalMutexLockFuture")
+            .finish()
+    }
+}
+
+impl<'a, T> Future for LocalMutexLockFuture<'a, T> {
+    type Output = LocalMutexGuard<'a, T>;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        lw: &LocalWaker,
+    ) -> Poll<Self::Output> {
+        // Safety: The next operations are safe, because Pin promises us that
+        // the address of the wait queue entry inside MutexLocalFuture is stable,
+        // and we don't move any fields inside the future until it gets dropped.
+        let mut_self: &mut LocalMutexLockFuture<T> = unsafe {
+            Pin::get_unchecked_mut(self)
+        };
+
+        let mutex = mut_self.mutex.expect("polled LocalMutexLockFuture after completion");
+        let mut mutex_state = mutex.state.borrow_mut();
+
+        let poll_res = unsafe {
+            mutex_state.try_lock(
+            &mut mut_self.wait_node,
+            lw)
+        };
+
+        match poll_res {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(()) => {
+                // The mutex was acquired
+                mut_self.mutex = None;
+                Poll::Ready(LocalMutexGuard::<'a, T>{
+                    mutex,
+                })
+            },
+        }
+    }
+}
+
+impl<'a, T> FusedFuture for LocalMutexLockFuture<'a, T> {
+   fn is_terminated(&self) -> bool {
+       self.mutex.is_none()
+   }
+}
+
+impl<'a, T> Drop for LocalMutexLockFuture<'a, T> {
+    fn drop(&mut self) {
+        // If this LocalMutexLockFuture has been polled and it was added to the
+        // wait queue at the mutex, it must be removed before dropping.
+        // Otherwise the mutex would access invalid memory.
+        if let Some(mutex) = self.mutex {
+            let mut mutex_state = mutex.state.borrow_mut();
+            mutex_state.remove_waiter(&mut self.wait_node);
+        }
+    }
+}
+
+/// A futures-aware mutex.
+pub struct LocalMutex<T> {
+    value: UnsafeCell<T>,
+    state: RefCell<MutexState>,
+}
+
+// It is safe to send mutexes between threads, as long as they are not used and
+// thereby borrowed
+unsafe impl<T: Send> Send for LocalMutex<T> {}
+
+impl<T: core::fmt::Debug> core::fmt::Debug for LocalMutex<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("LocalMutex")
+            .field("is_locked", &format_args!("{}", self.is_locked()))
+            .finish()
+    }
+}
+
+impl<T> LocalMutex<T> {
+    /// Creates a new futures-aware mutex.
+    ///
+    /// `is_fair` defines whether the `Mutex` should behave be fair regarding the
+    /// order of waiters. A fair `Mutex` will only allow the first waiter which
+    /// tried to lock but failed to lock the `Mutex` once it's available again.
+    /// Other waiters must wait until either this locking attempt completes, and
+    /// the `Mutex` gets unlocked again, or until the `MutexLockFuture` which
+    /// tried to gain the lock is dropped.
+    pub fn new(value: T, is_fair: bool) -> LocalMutex<T> {
+        LocalMutex::<T> {
+            value: UnsafeCell::new(value),
+            state: RefCell::new(MutexState::new(is_fair)),
+        }
+    }
+
+    /// Acquire the mutex asynchronously.
+    ///
+    /// This method returns a future that will resolve once the mutex has been
+    /// successfully acquired.
+    pub fn lock(&self) -> LocalMutexLockFuture<'_, T> {
+        LocalMutexLockFuture {
+            mutex: Some(&self),
+            wait_node: ListNode::new(WaitQueueEntry::new()),
+        }
+    }
+
+    /// Returns whether the mutex is locked.
+    pub fn is_locked(&self) -> bool {
+        self.state.borrow().is_locked()
+    }
+}
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+
+    /// An RAII guard returned by the `lock` and `try_lock` methods.
+    /// When this structure is dropped (falls out of scope), the lock will be
+    /// unlocked.
+    pub struct MutexGuard<'a, T: 'a> {
+        /// The Mutex which is associated with this Guard
+        mutex: &'a Mutex<T>,
+    }
+
+    impl<T: core::fmt::Debug> core::fmt::Debug for MutexGuard<'_, T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("MutexGuard")
+                .finish()
+        }
+    }
+
+    impl<T> Drop for MutexGuard<'_, T> {
+        fn drop(&mut self) {
+            // Release the mutex
+            self.mutex.state.lock().unwrap().unlock();
+        }
+    }
+
+    impl<T> Deref for MutexGuard<'_, T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            unsafe { &*self.mutex.value.get() }
+        }
+    }
+
+    impl<T> DerefMut for MutexGuard<'_, T> {
+        fn deref_mut(&mut self) -> &mut T {
+            unsafe { &mut *self.mutex.value.get() }
+        }
+    }
+
+    /// A future which resolves when the target mutex has been successfully acquired.
+    #[must_use = "futures do nothing unless polled"]
+    pub struct MutexLockFuture<'a, T: 'a> {
+        /// The Mutex which should get locked trough this Future
+        mutex: Option<&'a Mutex<T>>,
+        /// Node for waiting at the mutex
+        wait_node: ListNode<WaitQueueEntry>,
+    }
+
+    impl<'a, T: core::fmt::Debug> core::fmt::Debug for MutexLockFuture<'a, T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("MutexLockFuture")
+                .finish()
+        }
+    }
+
+    impl<'a, T> Future for MutexLockFuture<'a, T> {
+        type Output = MutexGuard<'a, T>;
+
+        fn poll(
+            self: Pin<&mut Self>,
+            lw: &LocalWaker,
+        ) -> Poll<Self::Output> {
+            // Safety: The next operations are safe, because Pin promises us that
+            // the address of the wait queue entry inside MutexLocalFuture is stable,
+            // and we don't move any fields inside the future until it gets dropped.
+            let mut_self: &mut MutexLockFuture<T> = unsafe {
+                Pin::get_unchecked_mut(self)
+            };
+
+            let mutex = mut_self.mutex.expect("polled MutexLockFuture after completion");
+            let mut mutex_state = mutex.state.lock().unwrap();
+
+            let poll_res = unsafe {
+                mutex_state.try_lock(
+                &mut mut_self.wait_node,
+                lw)
+            };
+
+            match poll_res {
+                Poll::Pending => Poll::Pending,
+                Poll::Ready(()) => {
+                    // The mutex was acquired
+                    mut_self.mutex = None;
+                    Poll::Ready(MutexGuard::<'a, T>{
+                        mutex,
+                    })
+                },
+            }
+        }
+    }
+
+    impl<'a, T> FusedFuture for MutexLockFuture<'a, T> {
+        fn is_terminated(&self) -> bool {
+            self.mutex.is_none()
+        }
+    }
+
+    impl<'a, T> Drop for MutexLockFuture<'a, T> {
+        fn drop(&mut self) {
+            // If this MutexLockFuture has been polled and it was added to the
+            // wait queue at the mutex, it must be removed before dropping.
+            // Otherwise the mutex would access invalid memory.
+            if let Some(mutex) = self.mutex {
+                let mut mutex_state = mutex.state.lock().unwrap();
+                mutex_state.remove_waiter(&mut self.wait_node);
+            }
+        }
+    }
+
+    /// A futures-aware mutex.
+    pub struct Mutex<T> {
+        value: UnsafeCell<T>,
+        state: StdMutex<MutexState>,
+    }
+
+    // Mutexes can be moved freely between threads and acquired on any thread so long
+    // as the inner value can be safely sent between threads.
+    // Automatic derive doesn't work due to the unsafe pointer in WaitQueueEntry
+    unsafe impl<T: Send> Send for Mutex<T> {}
+    unsafe impl<T: Send> Sync for Mutex<T> {}
+
+    impl<T: core::fmt::Debug> core::fmt::Debug for Mutex<T> {
+        fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+            f.debug_struct("Mutex")
+                .field("is_locked", &format_args!("{}", self.is_locked()))
+                .finish()
+        }
+    }
+
+    impl<T> Mutex<T> {
+        /// Creates a new futures-aware mutex.
+        ///
+        /// `is_fair` defines whether the `Mutex` should behave be fair regarding the
+        /// order of waiters. A fair `Mutex` will only allow the first waiter which
+        /// tried to lock but failed to lock the `Mutex` once it's available again.
+        /// Other waiters must wait until either this locking attempt completes, and
+        /// the `Mutex` gets unlocked again, or until the `MutexLockFuture` which
+        /// tried to gain the lock is dropped.
+        pub fn new(value: T, is_fair: bool) -> Mutex<T> {
+            Mutex::<T> {
+                value: UnsafeCell::new(value),
+                state: StdMutex::new(MutexState::new(is_fair)),
+            }
+        }
+
+        /// Acquire the mutex asynchronously.
+        ///
+        /// This method returns a future that will resolve once the mutex has been
+        /// successfully acquired.
+        pub fn lock(&self) -> MutexLockFuture<'_, T> {
+            MutexLockFuture {
+                mutex: Some(&self),
+                wait_node: ListNode::new(WaitQueueEntry::new()),
+            }
+        }
+
+        /// Returns whether the mutex is locked.
+        pub fn is_locked(&self) -> bool {
+            self.state.lock().unwrap().is_locked()
+        }
+    }
+
+}
+
+#[cfg(feature = "std")]
+pub use self::if_std::*;

--- a/futures-intrusive/tests/manual_reset_event.rs
+++ b/futures-intrusive/tests/manual_reset_event.rs
@@ -1,0 +1,171 @@
+#![feature(async_await, await_macro, futures_api)]
+
+use futures::future::{Future};
+use futures_core::future::{FusedFuture};
+use futures_intrusive::sync::{LocalManualResetEvent};
+use futures_test::task::{WakeCounter, panic_local_waker};
+use pin_utils::pin_mut;
+
+macro_rules! gen_event_tests {
+    ($mod_name:ident, $event_type:ident) => {
+        mod $mod_name {
+            use super::*;
+
+            #[test]
+            fn synchronous() {
+                let event = $event_type::new(false);
+
+                assert!(!event.is_set());
+                event.set();
+                assert!(event.is_set());
+                event.reset();
+                assert!(!event.is_set());
+            }
+
+            #[test]
+            fn immediately_ready_event() {
+                let event = $event_type::new(true);
+                let lw = &panic_local_waker();
+
+                assert!(event.is_set());
+
+                let poll = event.wait();
+                pin_mut!(poll);
+                assert!(!poll.as_mut().is_terminated());
+
+                assert!(poll.as_mut().poll(lw).is_ready());
+                assert!(poll.as_mut().is_terminated());
+            }
+
+            #[test]
+            fn cancel_mid_wait() {
+                let event = $event_type::new(false);
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+
+                {
+                    // Cancel a wait in between other waits
+                    // In order to arbitrarily drop a non movable future we have to box and pin it
+                    let mut poll1 = Box::pin(event.wait());
+                    let mut poll2 = Box::pin(event.wait());
+                    let mut poll3 = Box::pin(event.wait());
+                    let mut poll4 = Box::pin(event.wait());
+                    let mut poll5 = Box::pin(event.wait());
+
+                    assert!(poll1.as_mut().poll(lw).is_pending());
+                    assert!(poll2.as_mut().poll(lw).is_pending());
+                    assert!(poll3.as_mut().poll(lw).is_pending());
+                    assert!(poll4.as_mut().poll(lw).is_pending());
+                    assert!(poll5.as_mut().poll(lw).is_pending());
+                    assert!(!poll1.is_terminated());
+                    assert!(!poll2.is_terminated());
+                    assert!(!poll3.is_terminated());
+                    assert!(!poll4.is_terminated());
+                    assert!(!poll5.is_terminated());
+
+                    // Cancel 2 futures. Only the remaining ones should get completed
+                    drop(poll2);
+                    drop(poll4);
+
+                    assert!(poll1.as_mut().poll(lw).is_pending());
+                    assert!(poll3.as_mut().poll(lw).is_pending());
+                    assert!(poll5.as_mut().poll(lw).is_pending());
+
+                    assert_eq!(0, wake_counter.count());
+                    event.set();
+
+                    assert!(poll1.as_mut().poll(lw).is_ready());
+                    assert!(poll3.as_mut().poll(lw).is_ready());
+                    assert!(poll5.as_mut().poll(lw).is_ready());
+                    assert!(poll1.is_terminated());
+                    assert!(poll3.is_terminated());
+                    assert!(poll5.is_terminated());
+                }
+
+                assert_eq!(3, wake_counter.count());
+            }
+
+            #[test]
+            fn cancel_end_wait() {
+                let event = $event_type::new(false);
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+
+                let poll1 = event.wait();
+                let poll2 = event.wait();
+                let poll3 = event.wait();
+                let poll4 = event.wait();
+
+                pin_mut!(poll1);
+                pin_mut!(poll2);
+                pin_mut!(poll3);
+                pin_mut!(poll4);
+
+                assert!(poll1.as_mut().poll(lw).is_pending());
+                assert!(poll2.as_mut().poll(lw).is_pending());
+
+                // Start polling some wait handles which get cancelled
+                // before new ones are attached
+                {
+                    let poll5 = event.wait();
+                    let poll6 = event.wait();
+                    pin_mut!(poll5);
+                    pin_mut!(poll6);
+                    assert!(poll5.as_mut().poll(lw).is_pending());
+                    assert!(poll6.as_mut().poll(lw).is_pending());
+                }
+
+                assert!(poll3.as_mut().poll(lw).is_pending());
+                assert!(poll4.as_mut().poll(lw).is_pending());
+
+                event.set();
+
+                assert!(poll1.as_mut().poll(lw).is_ready());
+                assert!(poll2.as_mut().poll(lw).is_ready());
+                assert!(poll3.as_mut().poll(lw).is_ready());
+                assert!(poll4.as_mut().poll(lw).is_ready());
+
+                assert_eq!(4, wake_counter.count());
+            }
+        }
+    }
+}
+
+gen_event_tests!(local_manual_reset_event_tests, LocalManualResetEvent);
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time;
+    use futures::executor::block_on;
+    use futures_intrusive::sync::{ManualResetEvent};
+
+    gen_event_tests!(manual_reset_event_tests, ManualResetEvent);
+
+    #[test]
+    fn multithreaded_smoke() {
+        let event = Arc::new(ManualResetEvent::new(false));
+
+        let waiters: Vec<thread::JoinHandle<time::Instant>> =
+            [1..4].iter().map(|_| {
+                let ev = event.clone();
+                thread::spawn(move || {
+                    block_on(ev.wait());
+                    time::Instant::now()
+                })
+            }).collect();
+
+        let start = time::Instant::now();
+
+        thread::sleep(time::Duration::from_millis(100));
+        event.set();
+
+        for waiter in waiters.into_iter() {
+            let end_time = waiter.join().unwrap();
+            let diff = end_time - start;
+            assert!(diff > time::Duration::from_millis(50));
+        }
+    }
+}

--- a/futures-intrusive/tests/mutex.rs
+++ b/futures-intrusive/tests/mutex.rs
@@ -1,0 +1,405 @@
+#![feature(async_await, await_macro, futures_api)]
+
+use futures::future::{Future};
+use futures_core::future::{FusedFuture};
+use futures_core::task::{Poll};
+use futures_intrusive::sync::{LocalMutex};
+use futures_test::task::{WakeCounter, panic_local_waker};
+use pin_utils::pin_mut;
+
+macro_rules! gen_mutex_tests {
+    ($mod_name:ident, $mutex_type:ident) => {
+        mod $mod_name {
+            use super::*;
+
+            #[test]
+            fn uncontended_lock() {
+                for is_fair in &[true, false] {
+                    let lw = &panic_local_waker();
+                    let mtx = $mutex_type::new(5, *is_fair);
+                    assert_eq!(false, mtx.is_locked());
+
+                    {
+                        let mutex_fut = mtx.lock();
+                        pin_mut!(mutex_fut);
+                        match mutex_fut.as_mut().poll(lw) {
+                            Poll::Pending => panic!("Expect mutex to get locked"),
+                            Poll::Ready(mut guard) => {
+                                assert_eq!(true, mtx.is_locked());
+                                assert_eq!(5, *guard);
+                                *guard += 7;
+                                assert_eq!(12, *guard);
+                            },
+                        };
+                        assert!(mutex_fut.as_mut().is_terminated());
+                    }
+
+                    assert_eq!(false, mtx.is_locked());
+
+                    {
+                        let mutex_fut = mtx.lock();
+                        pin_mut!(mutex_fut);
+                        match mutex_fut.as_mut().poll(lw) {
+                            Poll::Pending => panic!("Expect mutex to get locked"),
+                            Poll::Ready(guard) => {
+                                assert_eq!(true, mtx.is_locked());
+                                assert_eq!(12, *guard);
+                            },
+                        };
+                    }
+
+                    assert_eq!(false, mtx.is_locked());
+                }
+            }
+
+            #[test]
+            #[should_panic]
+            fn poll_after_completion_should_panic() {
+                for is_fair in &[true, false] {
+                    let lw = &panic_local_waker();
+                    let mtx = $mutex_type::new(5, *is_fair);
+
+                    let mutex_fut = mtx.lock();
+                    pin_mut!(mutex_fut);
+                    let guard = match mutex_fut.as_mut().poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard,
+                    };
+                    assert_eq!(5, *guard);
+                    assert!(mutex_fut.as_mut().is_terminated());
+
+                    mutex_fut.poll(lw);
+                }
+            }
+
+            #[test]
+            fn contended_lock() {
+                for is_fair in &[true, false] {
+                    let wake_counter = WakeCounter::new();
+                    let lw = &wake_counter.local_waker();
+                    let mtx = $mutex_type::new(5, *is_fair);
+
+                    let mutex_fut1 = mtx.lock();
+                    pin_mut!(mutex_fut1);
+
+                    // Lock the mutex
+                    let mut guard1 = match mutex_fut1.poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                    *guard1 = 27;
+
+                    // The second and third lock attempt must fail
+                    let mutex_fut2 = mtx.lock();
+                    pin_mut!(mutex_fut2);
+                    assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+                    assert!(!mutex_fut2.as_mut().is_terminated());
+                    let mutex_fut3 = mtx.lock();
+                    pin_mut!(mutex_fut3);
+                    assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+                    assert!(!mutex_fut3.as_mut().is_terminated());
+                    assert_eq!(0, wake_counter.count());
+
+                    // Unlock - mutex should be available again
+                    drop(guard1);
+                    assert_eq!(1, wake_counter.count());
+                    let mut guard2 = match mutex_fut2.as_mut().poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                    assert_eq!(27, *guard2);
+                    *guard2 = 72;
+                    assert!(mutex_fut2.as_mut().is_terminated());
+                    assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+                    assert!(!mutex_fut3.as_mut().is_terminated());
+                    assert_eq!(1, wake_counter.count());
+
+                    // Unlock - mutex should be available again
+                    drop(guard2);
+                    assert_eq!(2, wake_counter.count());
+                    let guard3 = match mutex_fut3.as_mut().poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                    assert_eq!(72, *guard3);
+                    assert!(mutex_fut3.as_mut().is_terminated());
+
+                    drop(guard3);
+                    assert_eq!(2, wake_counter.count());
+                }
+            }
+
+            #[test]
+            fn cancel_wait_for_mutex() {
+                for is_fair in &[true, false] {
+                    let wake_counter = WakeCounter::new();
+                    let lw = &wake_counter.local_waker();
+                    let mtx = $mutex_type::new(5, *is_fair);
+
+                    let mutex_fut1 = mtx.lock();
+                    pin_mut!(mutex_fut1);
+
+                    // Lock the mutex
+                    let mut guard1 = match mutex_fut1.poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                    *guard1 = 27;
+
+                    // The second and third lock attempt must fail
+                    let mut mutex_fut2 = Box::pin(mtx.lock());
+                    let mut mutex_fut3 = Box::pin(mtx.lock());
+
+                    assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+                    assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+
+                    // Before the mutex gets available, cancel one lock attempt
+                    drop(mutex_fut2);
+
+                    // Unlock - mutex should be available again. Mutex2 should have been notified
+                    drop(guard1);
+                    assert_eq!(1, wake_counter.count());
+
+                    // Unlock - mutex should be available again
+                    match mutex_fut3.as_mut().poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                }
+            }
+
+            #[test]
+            fn unlock_next_when_notification_is_not_used() {
+                for is_fair in &[true, false] {
+                    let wake_counter = WakeCounter::new();
+                    let lw = &wake_counter.local_waker();
+                    let mtx = $mutex_type::new(5, *is_fair);
+
+                    let mutex_fut1 = mtx.lock();
+                    pin_mut!(mutex_fut1);
+
+                    // Lock the mutex
+                    let mut guard1 = match mutex_fut1.poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                    *guard1 = 27;
+
+                    // The second and third lock attempt must fail
+                    let mut mutex_fut2 = Box::pin(mtx.lock());
+                    let mut mutex_fut3 = Box::pin(mtx.lock());
+
+                    assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+                    assert!(!mutex_fut2.as_mut().is_terminated());
+
+                    assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+                    assert!(!mutex_fut3.as_mut().is_terminated());
+                    assert_eq!(0, wake_counter.count());
+
+                    // Unlock - mutex should be available again. Mutex2 should have been notified
+                    drop(guard1);
+                    assert_eq!(1, wake_counter.count());
+
+                    // We don't use the notification. Expect the next waiting task to be woken up
+                    drop(mutex_fut2);
+                    assert_eq!(2, wake_counter.count());
+
+                    // Unlock - mutex should be available again
+                    match mutex_fut3.as_mut().poll(lw) {
+                        Poll::Pending => panic!("Expect mutex to get locked"),
+                        Poll::Ready(guard) => guard
+                    };
+                }
+            }
+
+            #[test]
+            fn new_waiters_on_unfair_mutex_can_acquire_future_while_one_task_is_notified() {
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+                let mtx = $mutex_type::new(5, false);
+
+                let mutex_fut1 = mtx.lock();
+                pin_mut!(mutex_fut1);
+
+                // Lock the mutex
+                let mut guard1 = match mutex_fut1.poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(guard) => guard
+                };
+                *guard1 = 27;
+
+                // The second and third lock attempt must fail
+                let mut mutex_fut2 = Box::pin(mtx.lock());
+                let mut mutex_fut3 = Box::pin(mtx.lock());
+
+                assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+
+                // Unlock - mutex should be available again. fut2 should have been notified
+                drop(guard1);
+                assert_eq!(1, wake_counter.count());
+
+                // Lock fut3 in between. This should succeed
+                let guard3 = match mutex_fut3.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(guard) => guard
+                };
+                // Now fut2 can't use it's notification and is still pending
+                assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+
+                // When we drop fut3, the mutex should signal that it's available for fut2,
+                // which needs to have re-registered
+                drop(guard3);
+                assert_eq!(2, wake_counter.count());
+                match mutex_fut2.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(_guard) => {},
+                };
+            }
+
+            #[test]
+            fn waiters_on_unfair_mutex_can_acquire_future_through_repolling_if_one_task_is_notified() {
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+                let mtx = $mutex_type::new(5, false);
+
+                let mutex_fut1 = mtx.lock();
+                pin_mut!(mutex_fut1);
+
+                // Lock the mutex
+                let mut guard1 = match mutex_fut1.poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(guard) => guard
+                };
+                *guard1 = 27;
+
+                // The second and third lock attempt must fail
+                let mut mutex_fut2 = Box::pin(mtx.lock());
+                let mut mutex_fut3 = Box::pin(mtx.lock());
+
+                assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+                assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+
+                // Unlock - mutex should be available again. fut2 should have been notified
+                drop(guard1);
+                assert_eq!(1, wake_counter.count());
+
+                // Lock fut3 in between. This should succeed
+                let guard3 = match mutex_fut3.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(guard) => guard
+                };
+                // Now fut2 can't use it's notification and is still pending
+                assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+
+                // When we drop fut3, the mutex should signal that it's available for fut2,
+                // which needs to have re-registered
+                drop(guard3);
+                assert_eq!(2, wake_counter.count());
+                match mutex_fut2.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(_guard) => {},
+                };
+            }
+
+
+
+            #[test]
+            fn new_waiters_on_fair_mutex_cant_acquire_future_while_one_task_is_notified() {
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+                let mtx = $mutex_type::new(5, true);
+
+                let mutex_fut1 = mtx.lock();
+                pin_mut!(mutex_fut1);
+
+                // Lock the mutex
+                let mut guard1 = match mutex_fut1.poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(guard) => guard
+                };
+                *guard1 = 27;
+
+                // The second and third lock attempt must fail
+                let mut mutex_fut2 = Box::pin(mtx.lock());
+                let mut mutex_fut3 = Box::pin(mtx.lock());
+
+                assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+
+                // Unlock - mutex should be available again. fut2 should have been notified
+                drop(guard1);
+                assert_eq!(1, wake_counter.count());
+
+                // Lock fut3 in between. This should fail
+                assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+
+                // fut2 should be lockable
+                match mutex_fut2.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(_guard) => {},
+                };
+
+                // Now fut3 should have been signaled and be lockable
+                assert_eq!(2, wake_counter.count());
+                match mutex_fut3.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(_guard) => {},
+                };
+            }
+
+            #[test]
+            fn waiters_on_fair_mutex_cant_acquire_future_through_repolling_if_one_task_is_notified() {
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+                let mtx = $mutex_type::new(5, true);
+
+                let mutex_fut1 = mtx.lock();
+                pin_mut!(mutex_fut1);
+
+                // Lock the mutex
+                let mut guard1 = match mutex_fut1.poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(guard) => guard
+                };
+                *guard1 = 27;
+
+                // The second and third lock attempt must fail
+                let mut mutex_fut2 = Box::pin(mtx.lock());
+                let mut mutex_fut3 = Box::pin(mtx.lock());
+
+                assert!(mutex_fut2.as_mut().poll(lw).is_pending());
+                assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+
+                // Unlock - mutex should be available again. fut2 should have been notified
+                drop(guard1);
+                assert_eq!(1, wake_counter.count());
+
+                // Lock fut3 in between. This should fail, since fut2 should get the mutex first
+                assert!(mutex_fut3.as_mut().poll(lw).is_pending());
+
+                // fut2 should be lockable
+                match mutex_fut2.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(_guard) => {},
+                };
+
+                // Now fut3 should be lockable
+                assert_eq!(2, wake_counter.count());
+
+                match mutex_fut3.as_mut().poll(lw) {
+                    Poll::Pending => panic!("Expect mutex to get locked"),
+                    Poll::Ready(_guard) => {},
+                };
+            }
+        }
+    }
+}
+
+gen_mutex_tests!(local_mutex_tests, LocalMutex);
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
+    use futures_intrusive::sync::{Mutex};
+
+    gen_mutex_tests!(mutex_tests, Mutex);
+}

--- a/futures-intrusive/tests/oneshot_channel.rs
+++ b/futures-intrusive/tests/oneshot_channel.rs
@@ -1,0 +1,232 @@
+#![feature(async_await, await_macro, futures_api)]
+
+use futures::future::{Future};
+use futures_core::future::{FusedFuture};
+use futures_core::task::Poll;
+use futures_intrusive::channel::{LocalOneshotChannel};
+use futures_test::task::{WakeCounter, panic_local_waker};
+use pin_utils::pin_mut;
+
+macro_rules! gen_oneshot_tests {
+    ($mod_name:ident, $channel_type:ident) => {
+        mod $mod_name {
+            use super::*;
+
+           #[test]
+            fn receive_after_send() {
+                let channel = $channel_type::<i32>::new();
+                let lw = &panic_local_waker();
+
+                channel.send(5).unwrap();
+
+                let receive_fut = channel.receive();
+                pin_mut!(receive_fut);
+                assert!(!receive_fut.as_mut().is_terminated());
+
+                let res = {
+                    let poll_res = receive_fut.as_mut().poll(lw);
+                    match poll_res {
+                        Poll::Pending => panic!("future is not ready"),
+                        Poll::Ready(res) => res,
+                    }
+                };
+                match res {
+                    None => panic!("Unexpected closed channel"),
+                    Some(5) => {}, // OK
+                    Some(_) => panic!("Unexpected value"),
+                }
+
+                assert!(receive_fut.as_mut().is_terminated());
+
+                // A second receive attempt must yield None, since the
+                // value was taken out of the channel
+                let receive_fut2 = channel.receive();
+                pin_mut!(receive_fut2);
+                match receive_fut2.as_mut().poll(lw) {
+                    Poll::Pending => panic!("future is not ready"),
+                    Poll::Ready(res) => {
+                        match res {
+                            None => {}, // OK. Channel must be closed
+                            Some(_) => panic!("Unexpected value"),
+                        }
+                    }
+                }
+            }
+
+            #[test]
+            fn send_after_receive() {
+                let channel = $channel_type::<i32>::new();
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+
+                let receive_fut1 = channel.receive();
+                let receive_fut2 = channel.receive();
+                pin_mut!(receive_fut1);
+                pin_mut!(receive_fut2);
+                assert!(!receive_fut1.as_mut().is_terminated());
+                assert!(!receive_fut2.as_mut().is_terminated());
+
+                let poll_res1 = receive_fut1.as_mut().poll(lw);
+                let poll_res2 = receive_fut2.as_mut().poll(lw);
+                assert!(poll_res1.is_pending());
+                assert!(poll_res2.is_pending());
+
+                channel.send(5).unwrap();
+
+                match receive_fut1.as_mut().poll(lw) {
+                    Poll::Pending => panic!("future is not ready"),
+                    Poll::Ready(res) => {
+                        match res {
+                            None => panic!("Unexpected closed channel"),
+                            Some(5) => {}, // OK
+                            Some(_) => panic!("Unexpected value"),
+                        }
+                    }
+                }
+
+                assert!(receive_fut1.as_mut().is_terminated());
+                assert!(!receive_fut2.as_mut().is_terminated());
+
+                match receive_fut2.as_mut().poll(lw) {
+                    Poll::Pending => panic!("future is not ready"),
+                    Poll::Ready(res) => {
+                        match res {
+                            None => {}, // OK. Channel must be closed
+                            Some(_) => panic!("Unexpected value"),
+                        }
+                    }
+                }
+
+                assert!(receive_fut1.as_mut().is_terminated());
+                assert!(receive_fut2.as_mut().is_terminated());
+            }
+
+            #[test]
+            fn second_send_rejects_value() {
+                let channel = $channel_type::<i32>::new();
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+
+                let receive_fut1 = channel.receive();
+                pin_mut!(receive_fut1);
+                assert!(!receive_fut1.as_mut().is_terminated());
+                assert!(receive_fut1.as_mut().poll(lw).is_pending());
+
+                // First send
+                channel.send(5).unwrap();
+
+                assert!(receive_fut1.as_mut().poll(lw).is_ready());
+
+                // Second send
+                let send_res = channel.send(7);
+                match send_res {
+                    Err(7) => {}, // expected
+                    _ => panic!("Second second should reject"),
+                }
+
+            }
+
+            #[test]
+            fn cancel_mid_wait() {
+                let channel = $channel_type::new();
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+
+                {
+                    // Cancel a wait in between other waits
+                    // In order to arbitrarily drop a non movable future we have to box and pin it
+                    let mut poll1 = Box::pin(channel.receive());
+                    let mut poll2 = Box::pin(channel.receive());
+                    let mut poll3 = Box::pin(channel.receive());
+                    let mut poll4 = Box::pin(channel.receive());
+                    let mut poll5 = Box::pin(channel.receive());
+
+                    assert!(poll1.as_mut().poll(lw).is_pending());
+                    assert!(poll2.as_mut().poll(lw).is_pending());
+                    assert!(poll3.as_mut().poll(lw).is_pending());
+                    assert!(poll4.as_mut().poll(lw).is_pending());
+                    assert!(poll5.as_mut().poll(lw).is_pending());
+                    assert!(!poll1.is_terminated());
+                    assert!(!poll2.is_terminated());
+                    assert!(!poll3.is_terminated());
+                    assert!(!poll4.is_terminated());
+                    assert!(!poll5.is_terminated());
+
+                    // Cancel 2 futures. Only the remaining ones should get completed
+                    drop(poll2);
+                    drop(poll4);
+
+                    assert!(poll1.as_mut().poll(lw).is_pending());
+                    assert!(poll3.as_mut().poll(lw).is_pending());
+                    assert!(poll5.as_mut().poll(lw).is_pending());
+
+                    assert_eq!(0, wake_counter.count());
+                    channel.send(7).unwrap();
+                    assert_eq!(3, wake_counter.count());
+
+                    assert!(poll1.as_mut().poll(lw).is_ready());
+                    assert!(poll3.as_mut().poll(lw).is_ready());
+                    assert!(poll5.as_mut().poll(lw).is_ready());
+                    assert!(poll1.is_terminated());
+                    assert!(poll3.is_terminated());
+                    assert!(poll5.is_terminated());
+                }
+
+                assert_eq!(3, wake_counter.count());
+            }
+
+            #[test]
+            fn cancel_end_wait() {
+                let channel = $channel_type::new();
+                let wake_counter = WakeCounter::new();
+                let lw = &wake_counter.local_waker();
+
+                let poll1 = channel.receive();
+                let poll2 = channel.receive();
+                let poll3 = channel.receive();
+                let poll4 = channel.receive();
+
+                pin_mut!(poll1);
+                pin_mut!(poll2);
+                pin_mut!(poll3);
+                pin_mut!(poll4);
+
+                assert!(poll1.as_mut().poll(lw).is_pending());
+                assert!(poll2.as_mut().poll(lw).is_pending());
+
+                // Start polling some wait handles which get cancelled
+                // before new ones are attached
+                {
+                    let poll5 = channel.receive();
+                    let poll6 = channel.receive();
+                    pin_mut!(poll5);
+                    pin_mut!(poll6);
+                    assert!(poll5.as_mut().poll(lw).is_pending());
+                    assert!(poll6.as_mut().poll(lw).is_pending());
+                }
+
+                assert!(poll3.as_mut().poll(lw).is_pending());
+                assert!(poll4.as_mut().poll(lw).is_pending());
+
+                channel.send(99).unwrap();
+
+                assert!(poll1.as_mut().poll(lw).is_ready());
+                assert!(poll2.as_mut().poll(lw).is_ready());
+                assert!(poll3.as_mut().poll(lw).is_ready());
+                assert!(poll4.as_mut().poll(lw).is_ready());
+
+                assert_eq!(4, wake_counter.count());
+            }
+        }
+    }
+}
+
+gen_oneshot_tests!(local_oneshot_channel_tests, LocalOneshotChannel);
+
+#[cfg(feature = "std")]
+mod if_std {
+    use super::*;
+    use futures_intrusive::channel::OneshotChannel;
+
+    gen_oneshot_tests!(oneshot_channel_tests, OneshotChannel);
+}


### PR DESCRIPTION
This crate contains a set of future-based primitives which are built on top of intrusive data structures.
The main goal of this crate is to provide types which require no dynamic allocation during runtime, independent of the number of tasks and concurrent paths that are interacting with the future.
The goal should be be to provide all types in a no-std compatible form.

Currently the crate contains a Mutex and a ManualResetEvent type, in both Sync and !Sync fashion. The !Sync variants are already no-std compatible.
Other planned types would include:
- Timers
- Channels
- More primitives (e.g. Semaphores)