### PR TITLE
Support StreamExt::collect in no_std environment

### DIFF
--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -1,11 +1,10 @@
+use core::marker::Unpin;
+use core::mem;
+use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::marker::Unpin;
-use std::mem;
-use std::pin::Pin;
-use std::prelude::v1::*;
 
 /// A future which collects all of the values of a stream into a vector.
 ///

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -20,6 +20,9 @@ pub use self::repeat::{repeat, Repeat};
 mod chain;
 pub use self::chain::Chain;
 
+mod collect;
+pub use self::collect::Collect;
+
 mod concat;
 pub use self::concat::Concat;
 
@@ -97,8 +100,6 @@ pub use self::zip::Zip;
 
 #[cfg(feature = "std")]
 use std;
-#[cfg(feature = "std")]
-use std::iter::Extend;
 
 #[cfg(feature = "std")]
 mod buffer_unordered;
@@ -119,11 +120,6 @@ pub use self::catch_unwind::CatchUnwind;
 mod chunks;
 #[cfg(feature = "std")]
 pub use self::chunks::Chunks;
-
-#[cfg(feature = "std")]
-mod collect;
-#[cfg(feature = "std")]
-pub use self::collect::Collect;
 
 #[cfg(feature = "std")]
 mod for_each_concurrent;
@@ -347,9 +343,6 @@ pub trait StreamExt: Stream {
     ///
     /// The returned future will be resolved when the stream terminates.
     ///
-    /// This method is only available when the `std` feature of this
-    /// library is activated, and it is activated by default.
-    ///
     /// # Examples
     ///
     /// ```
@@ -369,7 +362,6 @@ pub trait StreamExt: Stream {
     /// let output = block_on(rx.collect::<Vec<i32>>());
     /// assert_eq!(output, vec![1, 2, 3, 4, 5]);
     /// ```
-    #[cfg(feature = "std")]
     fn collect<C: Default + Extend<Self::Item>>(self) -> Collect<Self, C>
         where Self: Sized
     {


### PR DESCRIPTION
There is no reason to disallow `collect` here anymore, now that it is generic.