### PR TITLE
Re-export some items for select! macro

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -9,6 +9,10 @@ use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 
+// re-export for `select!`
+#[doc(hidden)]
+pub use futures_core::future::FusedFuture;
+
 // Primitive futures
 mod empty;
 pub use self::empty::{empty, Empty};

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -16,3 +16,7 @@ pub use self::local_waker_ref::{local_waker_ref, local_waker_ref_from_nonlocal, 
     cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
 )]
 pub use futures_core::task::__internal::AtomicWaker;
+
+// re-export for `select!`
+#[doc(hidden)]
+pub use futures_core::task::{LocalWaker, Poll};


### PR DESCRIPTION
Fixes #1404 

`select!` macro will use the item in `futures::{future, task}` if imported from `futures` and the item in `futures_util::{future, task}` if imported from `futures_util`. This error was caused by some items not exported in `futures_util`.

This PR re-exports some items to `futures_util`, and adds a test of the case where `select!` macro is imported from `futures_util`.