### PR TITLE
Make CI successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
     # When updating this, the reminder to update the minimum required version in README.md.
     - name: cargo test (minimum required version)
-      rust: nightly-2018-12-26
+      rust: nightly-2019-01-11
 
     - name: cargo clippy
       rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,10 @@ matrix:
       script:
         - cargo build --manifest-path futures/Cargo.toml --features tokio-compat,io-compat
 
+    # Allow build fail until #1396 is fixed.
     - name: cargo build --target=thumbv6m-none-eabi
       rust: nightly
+      env: ALLOW_FAILURES=true
       install:
         - rustup target add thumbv6m-none-eabi
       script:
@@ -99,6 +101,10 @@ matrix:
         - git add "$TRAVIS_TAG" index.html
         - git commit -m "Add API docs for $TRAVIS_TAG"
         - git push origin master
+
+  allow_failures:
+    - rust: nightly
+      env: ALLOW_FAILURES=true
 
 script:
   - cargo test --all --all-features

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Now, you can use futures-rs:
 use futures::future::Future; // Note: It's not `futures_preview`
 ```
 
-The current version of futures-rs requires Rust nightly 2018-12-26 or later.
+The current version of futures-rs requires Rust nightly 2019-01-11 or later.
 
 ### Feature `std`
 

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -50,7 +50,7 @@ impl<Fut: Future> Future for Fuse<Fut> {
             None => return Poll::Pending,
         };
 
-        Pin::set(self.as_mut().future(), None);
+        Pin::set(&mut self.as_mut().future(), None);
         Poll::Ready(v)
     }
 }

--- a/futures-util/src/future/into_stream.rs
+++ b/futures-util/src/future/into_stream.rs
@@ -36,7 +36,7 @@ impl<Fut: Future> Stream for IntoStream<Fut> {
             None => return Poll::Ready(None),
         };
 
-        Pin::set(self.as_mut().future(), None);
+        Pin::set(&mut self.as_mut().future(), None);
         Poll::Ready(Some(v))
     }
 }

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -107,7 +107,7 @@ impl<Fut: Future> Future for MaybeDone<Fut> {
                 MaybeDone::Gone => panic!("MaybeDone polled after value taken"),
             }
         };
-        Pin::set(self, MaybeDone::Done(res));
+        Pin::set(&mut self, MaybeDone::Done(res));
         Poll::Ready(())
     }
 }

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -102,7 +102,7 @@ where
                 };
             }
         }
-        Pin::set(stream, None);
+        Pin::set(&mut stream, None);
         Poll::Ready(Ok(()))
     }
 }

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -96,7 +96,7 @@ impl<T, F, Fut, It> Stream for Unfold<T, F, Fut>
     ) -> Poll<Option<It>> {
         if let Some(state) = self.as_mut().state().take() {
             let fut = (self.as_mut().f())(state);
-            Pin::set(self.as_mut().fut(), Some(fut));
+            Pin::set(&mut self.as_mut().fut(), Some(fut));
         }
 
         let step = ready!(self.as_mut().fut().as_pin_mut().unwrap().poll(lw));

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -59,7 +59,7 @@ where
             Waiting(f) => try_ready!(f.try_poll(lw)),
             Closed => panic!("poll_ready called after eof"),
         };
-        Pin::set(self.as_mut(), FlattenSink(Ready(resolved_stream)));
+        Pin::set(&mut self.as_mut(), FlattenSink(Ready(resolved_stream)));
         if let Ready(resolved_stream) = self.project_pin() {
             resolved_stream.poll_ready(lw)
         } else {
@@ -99,7 +99,7 @@ where
             Waiting(_) | Closed => Poll::Ready(Ok(())),
         };
         if res.is_ready() {
-            Pin::set(self, FlattenSink(Closed));
+            Pin::set(&mut self, FlattenSink(Closed));
         }
         res
     }

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -49,12 +49,12 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
             if let Some(future) = self.as_mut().future().as_pin_mut() {
                 try_ready!(future.try_poll(lw));
             }
-            Pin::set(self.as_mut().future(), None);
+            Pin::set(&mut self.as_mut().future(), None);
 
             match ready!(self.as_mut().stream().try_poll_next(lw)) {
                 Some(Ok(e)) => {
                     let future = (self.as_mut().f())(e);
-                    Pin::set(self.as_mut().future(), Some(future));
+                    Pin::set(&mut self.as_mut().future(), Some(future));
                 }
                 Some(Err(e)) => return Poll::Ready(Err(e)),
                 None => return Poll::Ready(Ok(())),


### PR DESCRIPTION
- Allow build fail on thumbv6m-none-eabi until #1396 is fixed.

    Related: This [comment](https://github.com/rust-lang-nursery/futures-rs/pull/1402#issuecomment-452854250) in #1402

- Update to latest `Pin::set` (rust-lang/rust#57419)

    With this change, the minimum required version will go up to
    nightly-2019-01-11.

This PR covers #1406.

Fixes #1409