### PR TITLE
Fix `Stream::select`

### DIFF
--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -57,7 +57,7 @@ impl<St1, St2> Stream for Select<St1, St2>
         let stream1 = unsafe { Pin::new_unchecked(stream1) };
         let stream2 = unsafe { Pin::new_unchecked(stream2) };
 
-        if *flag {
+        if !*flag {
             poll_inner(flag, stream1, stream2, lw)
         } else {
             poll_inner(flag, stream2, stream1, lw)
@@ -74,18 +74,17 @@ fn poll_inner<St1, St2>(
     where St1: Stream, St2: Stream<Item = St1::Item>
 {
     let a_done = match a.poll_next(lw) {
-        Poll::Ready(Some(item)) => return Poll::Ready(Some(item)),
+        Poll::Ready(Some(item)) => {
+            // give the other stream a chance to go first next time
+            *flag = !*flag;
+            return Poll::Ready(Some(item))
+        },
         Poll::Ready(None) => true,
         Poll::Pending => false,
     };
 
     match b.poll_next(lw) {
         Poll::Ready(Some(item)) => {
-            // If the other stream isn't finished yet, give them a chance to
-            // go first next time as we pulled something off `b`.
-            if !a_done {
-                *flag = !*flag;
-            }
             Poll::Ready(Some(item))
         }
         Poll::Ready(None) if a_done => Poll::Ready(None),

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -1,0 +1,22 @@
+#![feature(async_await, futures_api)]
+
+extern crate futures;
+extern crate futures_util;
+
+use futures::executor::block_on;
+use futures::stream;
+use futures_util::StreamExt;
+
+#[test]
+fn select() {
+    fn select_and_compare(a: Vec<u32>, b: Vec<u32>, expected: Vec<u32>) {
+        let a = stream::iter(a);
+        let b = stream::iter(b);
+        let vec = block_on(a.select(b).collect::<Vec<_>>());
+        assert_eq!(vec, expected);
+    }
+
+    select_and_compare(vec![1, 2, 3], vec![4, 5, 6], vec![1, 4, 2, 5, 3, 6]);
+    select_and_compare(vec![1, 2, 3], vec![4, 5], vec![1, 4, 2, 5, 3]);
+    select_and_compare(vec![1, 2], vec![4, 5, 6], vec![1, 4, 2, 5, 6]);
+}

--- a/futures/tests_disabled/stream.rs
+++ b/futures/tests_disabled/stream.rs
@@ -329,21 +329,6 @@ fn chunks_panic_on_cap_zero() {
 }
 
 #[test]
-fn select() {
-    let a = iter_ok::<_, u32>(vec![1, 2, 3]);
-    let b = iter_ok(vec![4, 5, 6]);
-    assert_done(|| a.select(b).collect(), Ok(vec![1, 4, 2, 5, 3, 6]));
-
-    let a = iter_ok::<_, u32>(vec![1, 2, 3]);
-    let b = iter_ok(vec![1, 2]);
-    assert_done(|| a.select(b).collect(), Ok(vec![1, 1, 2, 2, 3]));
-
-    let a = iter_ok(vec![1, 2]);
-    let b = iter_ok::<_, u32>(vec![1, 2, 3]);
-    assert_done(|| a.select(b).collect(), Ok(vec![1, 1, 2, 2, 3]));
-}
-
-#[test]
 fn forward() {
     let v = Vec::new();
     let v = block_on(iter_ok::<_, Never>(vec![0, 1]).forward(v)).unwrap().1;


### PR DESCRIPTION
Prevent the situation where one stream is starved.
Corresponding test also re-enabled.