### PR TITLE
Add #[must_use] to Stream and Sink

### DIFF
--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -21,6 +21,7 @@ pub use self::stream_obj::{StreamObj,LocalStreamObj,UnsafeStreamObj};
 /// The trait is modeled after `Future`, but allows `poll_next` to be called
 /// even after a value has been produced, yielding `None` once the stream has
 /// been fully exhausted.
+#[must_use = "streams do nothing unless polled"]
 pub trait Stream {
     /// Values yielded by the stream.
     type Item;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -39,6 +39,7 @@ use core::pin::Pin;
 /// higher-level way. The `Sink::send_all` combinator is of particular
 /// importance: you can use it to send an entire stream to a sink, which is
 /// the simplest way to ultimately consume a stream.
+#[must_use = "sinks do nothing unless polled"]
 pub trait Sink {
     /// The type of value that the sink accepts.
     type SinkItem;

--- a/futures-util/src/sink/wait.rs
+++ b/futures-util/src/sink/wait.rs
@@ -7,7 +7,7 @@ use executor;
 /// Created by the `Sink::wait` method, this function transforms any sink into a
 /// blocking version. This is implemented by blocking the current thread when a
 /// sink is otherwise unable to make progress.
-#[must_use = "sinks do nothing unless used"]
+#[must_use = "sinks do nothing unless polled"]
 #[derive(Debug)]
 pub struct Wait<Si> {
     sink: executor::Spawn<Si>,


### PR DESCRIPTION
This adds `#[must_use]` attribute to `Stream` and `Sink`, and this unifies `#[must_use]` message of Sink.

Related: rust-lang/rust#56677, rust-lang/rust#57549
