### PR TITLE
Remove import of Unpin

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -84,7 +84,6 @@ use futures_core::task::__internal::AtomicWaker;
 use std::any::Any;
 use std::error::Error;
 use std::fmt;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::AtomicUsize;

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -2,7 +2,6 @@
 
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll, Waker};
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;

--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -1,7 +1,7 @@
 use core::{
     fmt,
     future::Future,
-    marker::{PhantomData, Unpin},
+    marker::PhantomData,
     pin::Pin,
     task::{LocalWaker, Poll},
 };

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -1,7 +1,6 @@
 //! Asynchronous streams.
 
 use crate::task::{LocalWaker, Poll};
-use core::marker::Unpin;
 use core::ops;
 use core::pin::Pin;
 

--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -1,7 +1,7 @@
 use super::Stream;
 use crate::task::{LocalWaker, Poll};
 use core::fmt;
-use core::marker::{PhantomData, Unpin};
+use core::marker::PhantomData;
 use core::mem;
 use core::pin::Pin;
 

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -6,7 +6,6 @@ use crate::test::Bencher;
 use futures::executor::block_on;
 use futures::future::Future;
 use futures::task::{Poll, LocalWaker, Waker};
-use std::marker::Unpin;
 use std::pin::Pin;
 
 #[bench]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -10,7 +10,6 @@ use futures_util::stream::StreamExt;
 use lazy_static::lazy_static;
 use pin_utils::pin_mut;
 use std::cell::{RefCell};
-use std::marker::Unpin;
 use std::ops::{Deref, DerefMut};
 use std::prelude::v1::*;
 use std::rc::{Rc, Weak};

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(futures_api)]
 
 use futures_core::task::{LocalWaker, Poll};
-use core::marker::Unpin;
 use core::pin::Pin;
 
 /// A `Sink` is a value into which other values can be sent, asynchronously.

--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -1,5 +1,4 @@
 use futures_core::stream::Stream;
-use std::marker::Unpin;
 
 #[doc(hidden)]
 pub fn assert_is_unpin_stream<S: Stream + Unpin>(_: &mut S) {}

--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -3,7 +3,6 @@
 //! This module contains a number of functions and combinators for working
 //! with `async`/`await` code.
 
-use core::marker::Unpin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -6,7 +6,6 @@ use futures_01::executor::{
 };
 use futures_01::{Async as Async01, Future as Future01, Stream as Stream01};
 use futures_core::{task as task03, Future as Future03, Stream as Stream03};
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::LocalWaker;
 

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -7,7 +7,7 @@ use futures_core::{
     task as task03, TryFuture as TryFuture03, TryStream as TryStream03,
 };
 use futures_sink::Sink as Sink03;
-use std::{marker::{PhantomData, Unpin}, ops::Deref, pin::Pin, ptr::NonNull, sync::Arc};
+use std::{marker::PhantomData, ops::Deref, pin::Pin, ptr::NonNull, sync::Arc};
 
 /// Converts a futures 0.3 [`TryFuture`](futures_core::future::TryFuture),
 /// [`TryStream`](futures_core::stream::TryStream) or

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -2,7 +2,6 @@ use crate::task::AtomicWaker;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::unsafe_pinned;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/futures-util/src/future/inspect.rs
+++ b/futures-util/src/future/inspect.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -4,7 +4,6 @@
 use std::fmt;
 use std::future::Future;
 use std::iter::FromIterator;
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 use std::prelude::v1::*;

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -1,6 +1,5 @@
 //! Definition of the MaybeDone combinator
 
-use core::marker::Unpin;
 use core::mem;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -3,7 +3,6 @@
 //! This module contains a number of functions for working with `Future`s,
 //! including the `FutureExt` trait which adds methods to `Future` types.
 
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -1,6 +1,5 @@
 //! Definition of the `PollFn` adapter combinator
 
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/future/remote_handle.rs
+++ b/futures-util/src/future/remote_handle.rs
@@ -9,7 +9,6 @@ use {
     std::{
         any::Any,
         fmt,
-        marker::Unpin,
         panic::{self, AssertUnwindSafe},
         pin::Pin,
         sync::{

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -4,7 +4,6 @@ use futures_core::task::{LocalWaker, Poll, Wake, Waker};
 use slab::Slab;
 use std::cell::UnsafeCell;
 use std::fmt;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;

--- a/futures-util/src/future/unit_error.rs
+++ b/futures-util/src/future/unit_error.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -2,7 +2,6 @@ use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use futures_io::AsyncWrite;
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// A future used to fully close an I/O object.

--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -3,7 +3,6 @@ use futures_core::task::{LocalWaker, Poll};
 use futures_io::{AsyncRead, AsyncWrite};
 use std::boxed::Box;
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// A future which will copy all data from a reader into a writer.

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -1,7 +1,6 @@
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 use futures_io::AsyncWrite;

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -2,7 +2,6 @@ use crate::io::AsyncRead;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// A future which can be used to easily read available number of bytes to fill

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -2,7 +2,6 @@ use crate::io::AsyncRead;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use std::io;
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 

--- a/futures-util/src/io/read_to_end.rs
+++ b/futures-util/src/io/read_to_end.rs
@@ -2,7 +2,6 @@ use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use futures_io::AsyncRead;
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::vec::Vec;
 

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -2,7 +2,6 @@ use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use futures_io::AsyncWrite;
 use std::io;
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -8,7 +8,6 @@ use std::boxed::Box;
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt;
-use std::marker::Unpin;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -3,7 +3,6 @@ use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::collections::VecDeque;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// Sink for the `Sink::buffer` combinator, which buffers up to some fixed

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -3,7 +3,6 @@
 //! This module contains a number of functions for working with `Sink`s,
 //! including the `SinkExt` trait which adds methods to `Sink` types.
 
-use core::marker::Unpin;
 use either::Either;
 use futures_core::future::Future;
 use futures_core::stream::Stream;

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -1,5 +1,4 @@
 use crate::stream::{StreamExt, Fuse};
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -1,4 +1,4 @@
-use core::marker::{Unpin, PhantomData};
+use core::marker::PhantomData;
 use core::mem;
 use core::pin::Pin;
 use futures_core::future::Future;

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -1,4 +1,4 @@
-use core::marker::{Unpin, PhantomData};
+use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -5,7 +5,6 @@ use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::fmt;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// An adaptor for a stream of futures to execute the futures concurrently, if

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -5,7 +5,6 @@ use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use std::fmt;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// An adaptor for a stream of futures to execute the futures concurrently, if

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -2,7 +2,6 @@ use crate::stream::Fuse;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 use std::prelude::v1::*;

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::mem;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};

--- a/futures-util/src/stream/concat.rs
+++ b/futures-util/src/stream/concat.rs
@@ -1,5 +1,4 @@
 use core::fmt::{Debug, Formatter, Result as FmtResult};
-use core::marker::Unpin;
 use core::pin::Pin;
 use core::default::Default;
 use futures_core::future::Future;

--- a/futures-util/src/stream/empty.rs
+++ b/futures-util/src/stream/empty.rs
@@ -1,4 +1,4 @@
-use core::marker::{Unpin, PhantomData};
+use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/filter.rs
+++ b/futures-util/src/stream/filter.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -1,5 +1,4 @@
 use crate::stream::{FuturesUnordered, StreamExt};
-use core::marker::Unpin;
 use core::pin::Pin;
 use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -1,5 +1,4 @@
 use crate::stream::{StreamExt, Fuse};
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -7,7 +7,6 @@ use std::cmp::{Eq, PartialEq, PartialOrd, Ord, Ordering};
 use std::collections::binary_heap::{BinaryHeap, PeekMut};
 use std::fmt::{self, Debug};
 use std::iter::FromIterator;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 #[must_use = "futures do nothing unless polled"]

--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -1,6 +1,6 @@
 use super::FuturesUnordered;
 use super::task::Task;
-use std::marker::{PhantomData, Unpin};
+use std::marker::PhantomData;
 use std::pin::Pin;
 
 #[derive(Debug)]

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -7,7 +7,7 @@ use futures_core::task::{LocalWaker, Poll, Spawn, LocalSpawn, SpawnError};
 use std::cell::UnsafeCell;
 use std::fmt::{self, Debug};
 use std::iter::FromIterator;
-use std::marker::{PhantomData, Unpin};
+use std::marker::PhantomData;
 use std::mem;
 use std::pin::Pin;
 use std::ptr;

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/into_future.rs
+++ b/futures-util/src/stream/into_future.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;

--- a/futures-util/src/stream/iter.rs
+++ b/futures-util/src/stream/iter.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -3,7 +3,6 @@
 //! This module contains a number of functions for working with `Stream`s,
 //! including the `StreamExt` trait which adds methods to `Stream` types.
 
-use core::marker::Unpin;
 use core::pin::Pin;
 use either::Either;
 use futures_core::future::Future;

--- a/futures-util/src/stream/next.rs
+++ b/futures-util/src/stream/next.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -1,5 +1,4 @@
 use crate::stream::{StreamExt, Fuse};
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/poll_fn.rs
+++ b/futures-util/src/stream/poll_fn.rs
@@ -1,6 +1,5 @@
 //! Definition of the `PollFn` combinator
 
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,5 +1,4 @@
 use crate::stream::{StreamExt, Fuse};
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -2,7 +2,6 @@
 
 use std::fmt::{self, Debug};
 use std::pin::Pin;
-use std::marker::Unpin;
 
 use futures_core::{Poll, Stream, FusedStream};
 use futures_core::task::LocalWaker;

--- a/futures-util/src/stream/select_next_some.rs
+++ b/futures-util/src/stream/select_next_some.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::future::{Future, FusedFuture};

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -4,7 +4,6 @@ use futures_sink::Sink;
 use std::any::Any;
 use std::error::Error;
 use std::fmt;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 use crate::lock::BiLock;

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -1,5 +1,4 @@
 use crate::stream::{StreamExt, Fuse};
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_future/err_into.rs
+++ b/futures-util/src/try_future/err_into.rs
@@ -1,4 +1,4 @@
-use core::marker::{PhantomData, Unpin};
+use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -7,7 +7,6 @@ use futures_core::future::TryFuture;
 use futures_sink::Sink;
 
 #[cfg(feature = "compat")] use crate::compat::Compat;
-#[cfg(feature = "compat")] use core::marker::Unpin;
 
 /* TODO
 mod join;

--- a/futures-util/src/try_future/unwrap_or_else.rs
+++ b/futures-util/src/try_future/unwrap_or_else.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_stream/err_into.rs
+++ b/futures-util/src/try_stream/err_into.rs
@@ -1,4 +1,4 @@
-use core::marker::{PhantomData, Unpin};
+use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_stream/into_async_read.rs
+++ b/futures-util/src/try_stream/into_async_read.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::TryStream;
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{LocalWaker, Poll};

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -3,7 +3,6 @@
 //! This module contains a number of functions for working with `Streams`s
 //! that return `Result`s, allowing for short-circuiting computations.
 
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::stream::TryStream;

--- a/futures-util/src/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/try_stream/try_buffer_unordered.rs
@@ -5,7 +5,6 @@ use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// A stream returned by the

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -2,7 +2,6 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 use std::prelude::v1::*;

--- a/futures-util/src/try_stream/try_concat.rs
+++ b/futures-util/src/try_stream/try_concat.rs
@@ -1,5 +1,4 @@
 use core::default::Default;
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::TryStream;

--- a/futures-util/src/try_stream/try_filter_map.rs
+++ b/futures-util/src/try_stream/try_filter_map.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{TryFuture};
 use futures_core::stream::{Stream, TryStream};

--- a/futures-util/src/try_stream/try_fold.rs
+++ b/futures-util/src/try_stream/try_fold.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::stream::TryStream;

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::stream::TryStream;

--- a/futures-util/src/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/try_stream/try_for_each_concurrent.rs
@@ -1,6 +1,5 @@
 use crate::stream::{FuturesUnordered, StreamExt};
 use core::mem;
-use core::marker::Unpin;
 use core::pin::Pin;
 use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};

--- a/futures-util/src/try_stream/try_next.rs
+++ b/futures-util/src/try_stream/try_next.rs
@@ -1,7 +1,6 @@
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{LocalWaker, Poll};
-use core::marker::Unpin;
 use core::pin::Pin;
 
 /// A future which attempts to collect all of the values of a stream.

--- a/futures-util/src/try_stream/try_skip_while.rs
+++ b/futures-util/src/try_stream/try_skip_while.rs
@@ -1,4 +1,3 @@
-use core::marker::Unpin;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream};

--- a/futures/tests/join_all.rs
+++ b/futures/tests/join_all.rs
@@ -4,7 +4,6 @@ use futures_util::future::*;
 use std::future::Future;
 use futures::executor::block_on;
 use std::fmt::Debug;
-use std::marker::Unpin;
 
 fn assert_done<T: PartialEq + Debug, F: FnOnce() -> Box<dyn Future<Output=T> + Unpin>>(actual_fut: F, expected: T) {
     let output = block_on(actual_fut());


### PR DESCRIPTION
`Unpin` was added to std prelude.

Related: rust-lang/rust#57137.