### PR TITLE
Update dependencies

### DIFF
--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -20,7 +20,7 @@ std = ["either/use_std"]
 nightly = []
 
 [dependencies]
-either = { version = "1.4", default-features = false, optional = true }
+either = { version = "1.5", default-features = false, optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "=0.3.0-alpha.12" }

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -22,8 +22,8 @@ default = ["std"]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.12", default-features = false}
 futures-util-preview = { path = "../futures-util", version = "=0.3.0-alpha.12", default-features = false}
 futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.12", default-features = false}
-num_cpus = { version = "1.8.0", optional = true }
-lazy_static = { version = "1.1.0", optional = true }
+num_cpus = { version = "1.9", optional = true }
+lazy_static = { version = "1.2", optional = true }
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]

--- a/futures-select-macro/Cargo.toml
+++ b/futures-select-macro/Cargo.toml
@@ -22,4 +22,4 @@ std = []
 proc-macro2 = "0.4"
 proc-macro-hack = "0.5.3"
 quote = "0.6"
-syn = { version = "0.15.22", features = ["full"] }
+syn = { version = "0.15.25", features = ["full"] }

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -19,6 +19,6 @@ std = ["either/use_std", "futures-core-preview/std", "futures-channel-preview/st
 default = ["std"]
 
 [dependencies]
-either = { version = "1.4", default-features = false, optional = true }
+either = { version = "1.5", default-features = false, optional = true }
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.12", default-features = false }
 futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.12", default-features = false }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -29,7 +29,7 @@ futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha
 futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.12", default-features = false }
 futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.12", default-features = false}
 futures-select-macro-preview = { path = "../futures-select-macro", version = "=0.3.0-alpha.12", default-features = false }
-either = { version = "1.4", default-features = false }
+either = { version = "1.5", default-features = false }
 proc-macro-hack = "0.5"
 proc-macro-nested = "0.1.2"
 rand = { version = "0.5.5", optional = true }


### PR DESCRIPTION
* either 1.4 -> 1.5
* num_cpus 1.8.0 -> 1.9
* lazy_static 1.1.0 -> 1.2
* syn 0.15.22 -> 0.15.25

This PR mainly updates minor versions of dependencies.
`num_cpus` and `lazy_static` seem to be stable enough, so I think that it is probably OK without specifying a patch version.
Also, `non_camel_case_type` warning was allowed in dtolnay/syn#563, so I would like to include updating `syn`.