### PR TITLE
Update badge on README to point to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <a href="https://travis-ci.org/rust-lang-nursery/futures-rs">
-    <img alt="Build Status" src="https://travis-ci.org/rust-lang-nursery/futures-rs.svg?branch=master">
+  <a href="https://travis-ci.com/rust-lang-nursery/futures-rs">
+    <img alt="Build Status" src="https://travis-ci.com/rust-lang-nursery/futures-rs.svg?branch=master">
   </a>
 
   <a href="https://crates.io/crates/futures-preview">


### PR DESCRIPTION
The current travis badge shows the old build result when using travis-ci.org.

Related: https://internals.rust-lang.org/t/migration-of-all-the-rust-lang-repositories-over-to-travis-ci-com/9171