### PR TITLE
[WIP] Add no_std + alloc support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,14 @@ matrix:
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features
 
+    - name: cargo build (alloc)
+      rust: nightly
+      script:
+        - cargo build --manifest-path futures/Cargo.toml --no-default-features --features=alloc,nightly
+        - cargo build --manifest-path futures-core/Cargo.toml --no-default-features --features=alloc,nightly
+        - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features --features=alloc,nightly
+        - cargo build --manifest-path futures-util/Cargo.toml --no-default-features --features=alloc,nightly
+
     - name: cargo build (default features)
       rust: nightly
       script:

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -16,11 +16,13 @@ name = "futures_core"
 
 [features]
 default = ["std"]
-std = ["either/use_std"]
+std = ["alloc", "either/use_std", "alloc-shim/std"]
 nightly = []
+alloc = ["alloc-shim/alloc"]
 
 [dependencies]
 either = { version = "1.4", default-features = false, optional = true }
+alloc-shim = { version = "0.3.0", features = ["futures"], optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "=0.3.0-alpha.12" }

--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -185,10 +185,11 @@ where
     unsafe fn drop(_ptr: *mut ()) {}
 }
 
-#[cfg(feature = "std")]
-mod if_std {
+#[cfg(feature = "alloc")]
+mod if_alloc {
     use super::*;
-    use std::mem;
+    use core::mem;
+    use alloc::boxed::Box;
 
     unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Box<F>
         where F: Future<Output = T> + 'a

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -33,9 +33,11 @@ impl<F: FusedFuture + ?Sized> FusedFuture for &mut F {
     }
 }
 
-#[cfg(feature = "std")]
-mod if_std {
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use alloc::boxed::Box;
     use super::*;
+
     impl<F: FusedFuture + ?Sized> FusedFuture for Box<F> {
         fn is_terminated(&self) -> bool {
             <F as FusedFuture>::is_terminated(&**self)
@@ -48,6 +50,7 @@ mod if_std {
         }
     }
 
+    #[cfg(feature = "std")]
     impl<F: FusedFuture> FusedFuture for std::panic::AssertUnwindSafe<F> {
         fn is_terminated(&self) -> bool {
             <F as FusedFuture>::is_terminated(&**self)

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![feature(futures_api)]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -9,6 +10,9 @@
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_core")]
+
+#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
+compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
 
 pub mod future;
 #[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};

--- a/futures-core/src/stream/mod.rs
+++ b/futures-core/src/stream/mod.rs
@@ -145,9 +145,9 @@ impl<S, T, E> TryStream for S
     }
 }
 
-#[cfg(feature = "std")]
-mod if_std {
-    use std::boxed::Box;
+#[cfg(feature = "alloc")]
+mod if_alloc {
+    use alloc::boxed::Box;
     use super::*;
 
     impl<S: ?Sized + Stream + Unpin> Stream for Box<S> {
@@ -161,6 +161,7 @@ mod if_std {
         }
     }
 
+    #[cfg(feature = "std")]
     impl<S: Stream> Stream for ::std::panic::AssertUnwindSafe<S> {
         type Item = S::Item;
 
@@ -172,7 +173,7 @@ mod if_std {
         }
     }
 
-    impl<T: Unpin> Stream for ::std::collections::VecDeque<T> {
+    impl<T: Unpin> Stream for ::alloc::collections::VecDeque<T> {
         type Item = T;
 
         fn poll_next(

--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -2,7 +2,6 @@ use super::Stream;
 use crate::task::{LocalWaker, Poll};
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem;
 use core::pin::Pin;
 
 /// A custom trait object for polling streams, roughly akin to
@@ -188,10 +187,11 @@ where
     unsafe fn drop(_ptr: *mut ()) {}
 }
 
-#[cfg(feature = "std")]
-mod if_std {
-    use std::boxed::Box;
+#[cfg(feature = "alloc")]
+mod if_alloc {
     use super::*;
+    use core::mem;
+    use alloc::boxed::Box;
 
     unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for Box<F>
         where F: Stream<Item = T> + 'a

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -6,5 +6,5 @@ pub mod __internal;
 pub use self::spawn::{Spawn, LocalSpawn, SpawnError};
 
 pub use core::task::{Poll, Waker, LocalWaker, UnsafeWake};
-#[cfg(feature = "std")]
-pub use std::task::{Wake, local_waker, local_waker_from_nonlocal};
+#[cfg(feature = "alloc")]
+pub use alloc::task::{Wake, local_waker, local_waker_from_nonlocal};

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -15,10 +15,13 @@ The asynchronous `Sink` trait for the futures-rs library.
 name = "futures_sink"
 
 [features]
-std = ["either/use_std", "futures-core-preview/std", "futures-channel-preview/std"]
+std = ["alloc", "either/use_std", "futures-core-preview/std", "futures-channel-preview/std", "alloc-shim/std"]
 default = ["std"]
+nightly = ["futures-core-preview/nightly"]
+alloc = ["futures-core-preview/alloc", "alloc-shim/alloc"]
 
 [dependencies]
 either = { version = "1.4", default-features = false, optional = true }
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.12", default-features = false }
 futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.12", default-features = false }
+alloc-shim = { version = "0.3.0", features = ["futures"], optional = true }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -8,6 +8,10 @@
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_sink")]
 
 #![feature(futures_api)]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+
+#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
+compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
 
 use futures_core::task::{LocalWaker, Poll};
 use core::pin::Pin;
@@ -155,8 +159,8 @@ impl<'a, S: ?Sized + Sink> Sink for Pin<&'a mut S> {
 #[cfg(feature = "std")]
 mod channel_impls;
 
-#[cfg(feature = "std")]
-mod if_std {
+#[cfg(feature = "alloc")]
+mod if_alloc {
     use super::*;
 
     /// The error type for `Vec` and `VecDequeue` when used as `Sink`s.
@@ -164,7 +168,7 @@ mod if_std {
     #[derive(Copy, Clone, Debug)]
     pub enum VecSinkError {}
 
-    impl<T> Sink for ::std::vec::Vec<T> {
+    impl<T> Sink for ::alloc::vec::Vec<T> {
         type SinkItem = T;
         type SinkError = VecSinkError;
 
@@ -187,7 +191,7 @@ mod if_std {
         }
     }
 
-    impl<T> Sink for ::std::collections::VecDeque<T> {
+    impl<T> Sink for ::alloc::collections::VecDeque<T> {
         type SinkItem = T;
         type SinkError = VecSinkError;
 
@@ -210,7 +214,7 @@ mod if_std {
         }
     }
 
-    impl<S: ?Sized + Sink + Unpin> Sink for ::std::boxed::Box<S> {
+    impl<S: ?Sized + Sink + Unpin> Sink for ::alloc::boxed::Box<S> {
         type SinkItem = S::SinkItem;
         type SinkError = S::SinkError;
 
@@ -232,8 +236,8 @@ mod if_std {
     }
 }
 
-#[cfg(feature = "std")]
-pub use self::if_std::*;
+#[cfg(feature = "alloc")]
+pub use self::if_alloc::*;
 
 #[cfg(feature = "either")]
 use either::Either;

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -15,12 +15,13 @@ Common utilities and extension traits for the futures-rs library.
 name = "futures_util"
 
 [features]
-std = ["futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-select-macro-preview/std", "either/use_std", "rand", "rand_core", "slab"]
+std = ["alloc", "futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-select-macro-preview/std", "either/use_std", "rand", "rand_core", "slab", "alloc-shim/std"]
 default = ["std", "futures-core-preview/either", "futures-sink-preview/either"]
 compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
-nightly = []
+nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly"]
+alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "alloc-shim/alloc"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.12", default-features = false }
@@ -37,6 +38,7 @@ slab = { version = "0.4", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0-alpha.4"
+alloc-shim = { version = "0.3.0", features = ["futures"], optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "=0.3.0-alpha.12" }

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -2,9 +2,9 @@ use crate::task::AtomicWaker;
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::unsafe_pinned;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use alloc::sync::Arc;
 
 /// A future which can be remotely short-circuited using an `AbortHandle`.
 #[derive(Debug, Clone)]

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -1,13 +1,13 @@
 //! Definition of the `JoinAll` combinator, waiting for all of a list of futures
 //! to finish.
 
-use std::fmt;
-use std::future::Future;
-use std::iter::FromIterator;
-use std::mem;
-use std::pin::Pin;
-use std::prelude::v1::*;
-use std::task::Poll;
+use core::fmt;
+use core::future::Future;
+use core::iter::FromIterator;
+use core::mem;
+use core::pin::Pin;
+use alloc::prelude::*;
+use alloc::task::Poll;
 
 #[derive(Debug)]
 enum ElemState<F>
@@ -129,7 +129,7 @@ where
 
     fn poll(
         mut self: Pin<&mut Self>,
-        lw: &::std::task::LocalWaker,
+        lw: &::alloc::task::LocalWaker,
     ) -> Poll<Self::Output> {
         let mut all_done = true;
 

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -7,6 +7,8 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
+#[cfg(feature = "alloc")]
+use alloc::prelude::*;
 
 // re-export for `select!`
 #[doc(hidden)]
@@ -67,9 +69,9 @@ pub use self::unit_error::UnitError;
 mod chain;
 pub(crate) use self::chain::Chain;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod abortable;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::abortable::{abortable, Abortable, AbortHandle, AbortRegistration, Aborted};
 
 #[cfg(feature = "std")]
@@ -82,10 +84,10 @@ mod remote_handle;
 #[cfg(feature = "std")]
 pub use self::remote_handle::{Remote, RemoteHandle};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod join_all;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::join_all::{join_all, JoinAll};
 
 // #[cfg(feature = "std")]
@@ -653,7 +655,7 @@ pub trait FutureExt: Future {
     }
 
     /// Wrap the future in a Box, pinning it.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn boxed(self) -> Pin<Box<Self>>
         where Self: Sized
     {

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -4,12 +4,16 @@
 #![feature(futures_api, box_into_pin)]
 #![cfg_attr(feature = "std", feature(async_await, await_macro))]
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_util")]
+
+#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
+compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
 
 #[macro_use]
 mod macros;
@@ -89,5 +93,5 @@ pub mod io;
 #[cfg(feature = "std")]
 #[doc(hidden)] pub use crate::io::{AsyncReadExt, AsyncWriteExt};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod lock;

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -3,17 +3,19 @@
 
 use futures_core::future::Future;
 use futures_core::task::{LocalWaker, Poll, Waker};
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::mem;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering::SeqCst;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+#[cfg(feature = "std")]
 use std::any::Any;
-use std::boxed::Box;
-use std::cell::UnsafeCell;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
 
 /// A type of futures-powered synchronization primitive which is a mutex between
 /// two possible owners.
@@ -210,6 +212,7 @@ impl<T> fmt::Display for ReuniteError<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Any> Error for ReuniteError<T> {
     fn description(&self) -> &str {
         "tried to reunite two BiLocks that don't form a pair"

--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -1,6 +1,8 @@
 //! Futures-powered synchronization primitives.
 
+#[cfg(feature = "std")]
 mod mutex;
+#[cfg(feature = "std")]
 pub use self::mutex::{Mutex, MutexLockFuture, MutexGuard};
 
 mod bilock;

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -2,8 +2,8 @@ use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::collections::VecDeque;
-use std::pin::Pin;
+use core::pin::Pin;
+use alloc::collections::VecDeque;
 
 /// Sink for the `Sink::buffer` combinator, which buffers up to some fixed
 /// number of values when the underlying sink is unable to accept them.

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -41,9 +41,9 @@ pub use self::with::With;
 mod with_flat_map;
 pub use self::with_flat_map::WithFlatMap;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod buffer;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::buffer::Buffer;
 
 impl<T: ?Sized> SinkExt for T where T: Sink {}
@@ -156,7 +156,7 @@ pub trait SinkExt: Sink {
     ///
     /// This method is only available when the `std` feature of this
     /// library is activated, and it is activated by default.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn buffer(self, capacity: usize) -> Buffer<Self>
         where Self: Sized,
     {

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -4,8 +4,8 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::fmt;
-use std::pin::Pin;
+use core::fmt;
+use core::pin::Pin;
 
 /// An adaptor for a stream of futures to execute the futures concurrently, if
 /// possible, delivering results as they become available.

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -4,8 +4,8 @@ use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::fmt;
-use std::pin::Pin;
+use core::fmt;
+use core::pin::Pin;
 
 /// An adaptor for a stream of futures to execute the futures concurrently, if
 /// possible.

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -2,9 +2,9 @@ use crate::stream::Fuse;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::mem;
-use std::pin::Pin;
-use std::prelude::v1::*;
+use core::mem;
+use core::pin::Pin;
+use alloc::prelude::*;
 
 /// An adaptor that chunks up elements in a vector.
 ///

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -3,11 +3,11 @@ use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::unsafe_pinned;
-use std::cmp::{Eq, PartialEq, PartialOrd, Ord, Ordering};
-use std::collections::binary_heap::{BinaryHeap, PeekMut};
-use std::fmt::{self, Debug};
-use std::iter::FromIterator;
-use std::pin::Pin;
+use core::cmp::{Eq, PartialEq, PartialOrd, Ord, Ordering};
+use core::fmt::{self, Debug};
+use core::iter::FromIterator;
+use core::pin::Pin;
+use alloc::collections::binary_heap::{BinaryHeap, PeekMut};
 
 #[must_use = "futures do nothing unless polled"]
 #[derive(Debug)]

--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -1,7 +1,7 @@
 use super::FuturesUnordered;
 use super::task::Task;
-use std::marker::PhantomData;
-use std::pin::Pin;
+use core::marker::PhantomData;
+use core::pin::Pin;
 
 #[derive(Debug)]
 /// Mutable iterator over all futures in the unordered set.

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -4,17 +4,17 @@ use crate::task::AtomicWaker;
 use futures_core::future::{Future, FutureObj, LocalFutureObj};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll, Spawn, LocalSpawn, SpawnError};
-use std::cell::UnsafeCell;
-use std::fmt::{self, Debug};
-use std::iter::FromIterator;
-use std::marker::PhantomData;
-use std::mem;
-use std::pin::Pin;
-use std::ptr;
-use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicPtr, AtomicBool};
-use std::sync::{Arc, Weak};
-use std::usize;
+use core::cell::UnsafeCell;
+use core::fmt::{self, Debug};
+use core::iter::FromIterator;
+use core::marker::PhantomData;
+use core::mem;
+use core::pin::Pin;
+use core::ptr;
+use core::sync::atomic::Ordering::SeqCst;
+use core::sync::atomic::{AtomicPtr, AtomicBool};
+use core::usize;
+use alloc::sync::{Arc, Weak};
 
 mod abort;
 

--- a/futures-util/src/stream/futures_unordered/ready_to_run_queue.rs
+++ b/futures-util/src/stream/futures_unordered/ready_to_run_queue.rs
@@ -1,9 +1,9 @@
 use crate::task::AtomicWaker;
-use std::cell::UnsafeCell;
-use std::ptr;
-use std::sync::Arc;
-use std::sync::atomic::AtomicPtr;
-use std::sync::atomic::Ordering::{Relaxed, Acquire, Release, AcqRel};
+use core::cell::UnsafeCell;
+use core::ptr;
+use core::sync::atomic::AtomicPtr;
+use core::sync::atomic::Ordering::{Relaxed, Acquire, Release, AcqRel};
+use alloc::sync::Arc;
 
 use super::abort::abort;
 use super::task::Task;

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -1,10 +1,10 @@
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
-use std::mem;
-use std::ptr::{self, NonNull};
-use std::sync::{Arc, Weak};
-use std::sync::atomic::{AtomicPtr, AtomicBool};
-use std::sync::atomic::Ordering::SeqCst;
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+use core::mem;
+use core::ptr::{self, NonNull};
+use core::sync::atomic::{AtomicPtr, AtomicBool};
+use core::sync::atomic::Ordering::SeqCst;
+use alloc::sync::{Arc, Weak};
 
 use futures_core::task::{UnsafeWake, Waker, LocalWaker};
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -9,6 +9,8 @@ use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
+#[cfg(feature = "alloc")]
+use alloc::prelude::*;
 
 mod iter;
 pub use self::iter::{iter, Iter};
@@ -100,14 +102,14 @@ pub use self::zip::Zip;
 #[cfg(feature = "std")]
 use std;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod buffer_unordered;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::buffer_unordered::BufferUnordered;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod buffered;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::buffered::Buffered;
 
 #[cfg(feature = "std")]
@@ -115,34 +117,34 @@ mod catch_unwind;
 #[cfg(feature = "std")]
 pub use self::catch_unwind::CatchUnwind;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod chunks;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::chunks::Chunks;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod for_each_concurrent;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::for_each_concurrent::ForEachConcurrent;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod futures_ordered;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::futures_ordered::{futures_ordered, FuturesOrdered};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod futures_unordered;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::futures_unordered::{futures_unordered, FuturesUnordered};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod split;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::split::{SplitStream, SplitSink, ReuniteError};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod select_all;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::select_all::{select_all, SelectAll};
 
 impl<T: ?Sized> StreamExt for T where T: Stream {}
@@ -614,7 +616,7 @@ pub trait StreamExt: Stream {
     /// await!(fut);
     /// # })
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn for_each_concurrent<Fut, F>(
         self,
         limit: impl Into<Option<usize>>,
@@ -791,7 +793,7 @@ pub trait StreamExt: Stream {
     }
 
     /// Wrap the stream in a Box, pinning it.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn boxed(self) -> Pin<Box<Self>>
         where Self: Sized
     {
@@ -810,7 +812,7 @@ pub trait StreamExt: Stream {
     ///
     /// This method is only available when the `std` feature of this
     /// library is activated, and it is activated by default.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn buffered(self, n: usize) -> Buffered<Self>
         where Self::Item: Future,
               Self: Sized
@@ -854,7 +856,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(await!(buffered.next()), None);
     /// # })
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn buffer_unordered(self, n: usize) -> BufferUnordered<Self>
         where Self::Item: Future,
               Self: Sized
@@ -945,7 +947,7 @@ pub trait StreamExt: Stream {
     /// # Panics
     ///
     /// This method will panic of `capacity` is zero.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn chunks(self, capacity: usize) -> Chunks<Self>
         where Self: Sized
     {
@@ -999,7 +1001,7 @@ pub trait StreamExt: Stream {
     ///
     /// This method is only available when the `std` feature of this
     /// library is activated, and it is activated by default.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn split(self) -> (SplitSink<Self>, SplitStream<Self>)
         where Self: Sink + Sized
     {

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -1,7 +1,7 @@
 //! An unbounded set of streams
 
-use std::fmt::{self, Debug};
-use std::pin::Pin;
+use core::fmt::{self, Debug};
+use core::pin::Pin;
 
 use futures_core::{Poll, Stream, FusedStream};
 use futures_core::task::LocalWaker;

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -1,10 +1,12 @@
 use futures_core::stream::Stream;
 use futures_core::task::{LocalWaker, Poll};
 use futures_sink::Sink;
+use core::fmt;
+use core::pin::Pin;
+#[cfg(feature = "std")]
 use std::any::Any;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
-use std::pin::Pin;
 
 use crate::lock::BiLock;
 
@@ -139,6 +141,7 @@ impl<T: Sink> fmt::Display for ReuniteError<T> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Any + Sink> Error for ReuniteError<T> {
     fn description(&self) -> &str {
         "tried to reunite a SplitStream and SplitSink that don't form a pair"

--- a/futures-util/src/task/local_waker_ref.rs
+++ b/futures-util/src/task/local_waker_ref.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::cast_ptr_alignment)] // clippy is too strict here
 
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::ptr::NonNull;
-use std::sync::Arc;
-use std::task::{LocalWaker, Waker, Wake, UnsafeWake};
+use core::marker::PhantomData;
+use core::ops::Deref;
+use core::ptr::NonNull;
+use alloc::sync::Arc;
+use alloc::task::{LocalWaker, Waker, Wake, UnsafeWake};
 
 /// A [`LocalWaker`](::std::task::LocalWaker) that is only valid for a given lifetime.
 ///

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -6,9 +6,9 @@ pub use self::noop_waker::{noop_local_waker, noop_local_waker_ref};
 mod spawn;
 pub use self::spawn::{SpawnExt, LocalSpawnExt};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod local_waker_ref;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::local_waker_ref::{local_waker_ref, local_waker_ref_from_nonlocal, LocalWakerRef};
 
 #[cfg_attr(

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -4,10 +4,12 @@ use futures_core::task::{LocalSpawn, Spawn};
 
 #[cfg(feature = "std")]
 use crate::future::{FutureExt, RemoteHandle};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use futures_core::future::{Future, FutureObj, LocalFutureObj};
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use futures_core::task::SpawnError;
+#[cfg(feature = "alloc")]
+use alloc::prelude::*;
 
 impl<Sp: ?Sized> SpawnExt for Sp where Sp: Spawn {}
 impl<Sp: ?Sized> LocalSpawnExt for Sp where Sp: LocalSpawn {}
@@ -39,7 +41,7 @@ pub trait SpawnExt: Spawn {
     /// let future = async { /* ... */ };
     /// executor.spawn(future).unwrap();
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn spawn<Fut>(&mut self, future: Fut) -> Result<(), SpawnError>
     where
         Fut: Future<Output = ()> + Send + 'static,
@@ -118,7 +120,7 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// let future = async { /* ... */ };
     /// spawner.spawn_local(future).unwrap();
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn spawn_local<Fut>(&mut self, future: Fut) -> Result<(), SpawnError>
     where
         Fut: Future<Output = ()> + 'static,

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -54,10 +54,10 @@ pub use self::or_else::OrElse;
 mod unwrap_or_else;
 pub use self::unwrap_or_else::UnwrapOrElse;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod try_join_all;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::try_join_all::{try_join_all, TryJoinAll};
 
 // Implementation details

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -1,13 +1,13 @@
 //! Definition of the `TryJoinAll` combinator, waiting for all of a list of
 //! futures to finish with either success or error.
 
-use std::fmt;
-use std::future::Future;
-use std::iter::FromIterator;
-use std::mem;
-use std::pin::Pin;
-use std::prelude::v1::*;
-use std::task::Poll;
+use core::fmt;
+use core::future::Future;
+use core::iter::FromIterator;
+use core::mem;
+use core::pin::Pin;
+use alloc::prelude::*;
+use alloc::task::Poll;
 
 use super::TryFuture;
 
@@ -139,7 +139,7 @@ where
 
     fn poll(
         mut self: Pin<&mut Self>,
-        lw: &::std::task::LocalWaker,
+        lw: &::alloc::task::LocalWaker,
     ) -> Poll<Self::Output> {
         let mut state = FinalState::AllDone;
 

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -41,21 +41,21 @@ pub use self::try_fold::TryFold;
 mod try_skip_while;
 pub use self::try_skip_while::TrySkipWhile;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod try_buffer_unordered;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::try_buffer_unordered::TryBufferUnordered;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod try_collect;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::try_collect::TryCollect;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod try_for_each_concurrent;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::try_for_each_concurrent::TryForEachConcurrent;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 use futures_core::future::Future;
 
 #[cfg(feature = "std")]
@@ -312,7 +312,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(Err(oneshot::Canceled), await!(fut));
     /// # })
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn try_for_each_concurrent<Fut, F>(
         self,
         limit: impl Into<Option<usize>>,
@@ -360,7 +360,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(output, Err(6));
     /// # })
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn try_collect<C: Default + Extend<Self::Ok>>(self) -> TryCollect<Self, C>
         where Self: Sized
     {
@@ -548,7 +548,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(await!(buffered.next()), Some(Err("error in the stream")));
     /// # })
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn try_buffer_unordered(self, n: usize) -> TryBufferUnordered<Self>
         where Self::Ok: TryFuture<Error = Self::Error>,
               Self: Sized

--- a/futures-util/src/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/try_stream/try_buffer_unordered.rs
@@ -5,7 +5,7 @@ use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::pin::Pin;
+use core::pin::Pin;
 
 /// A stream returned by the
 /// [`try_buffer_unordered`](super::TryStreamExt::try_buffer_unordered) method

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -2,9 +2,8 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{LocalWaker, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::mem;
-use std::pin::Pin;
-use std::prelude::v1::*;
+use core::mem;
+use core::pin::Pin;
 
 /// A future which attempts to collect all of the values of a stream.
 ///

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -36,8 +36,9 @@ futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.12" }
 tokio = "0.1.11"
 
 [features]
-nightly = ["futures-util-preview/nightly", "futures-core-preview/nightly"]
-std = ["futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std"]
+nightly = ["futures-util-preview/nightly", "futures-core-preview/nightly", "futures-sink-preview/nightly"]
+std = ["alloc", "futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std"]
 default = ["std"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
+alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-util-preview/alloc"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -31,6 +31,10 @@
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures")]
 
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+
+#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
+compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
 
 #[doc(hidden)] pub use futures_util::core_reexport;
 
@@ -189,14 +193,17 @@ pub mod future {
         Join5, Map, Then,
     };
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use futures_util::future::{
         abortable, Abortable, AbortHandle, AbortRegistration, Aborted,
+
+        join_all, JoinAll,
+    };
+    #[cfg(feature = "std")]
+    pub use futures_util::future::{
         Remote, RemoteHandle,
         // For FutureExt:
         CatchUnwind, Shared,
-
-        join_all, JoinAll,
 
         // ToDo: SelectAll, SelectOk, select_all, select_ok
     };
@@ -282,7 +289,7 @@ pub mod sink {
         // WithFlatMap,
     };
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use futures_util::sink::Buffer;
 }
 
@@ -319,16 +326,21 @@ pub mod stream {
         Take, TakeWhile, Then, Zip
     };
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use futures_util::stream::{
         futures_ordered, FuturesOrdered,
         futures_unordered, FuturesUnordered,
 
         // For StreamExt:
-        BufferUnordered, Buffered, CatchUnwind, Chunks, Collect, SplitStream,
-        SplitSink, ReuniteError,
+        BufferUnordered, Buffered, Chunks, Collect, SplitStream, SplitSink,
 
         select_all, SelectAll,
+    };
+
+    #[cfg(feature = "std")]
+    pub use futures_util::stream::{
+        // For StreamExt:
+        CatchUnwind, ReuniteError,
     };
 
     pub use futures_util::try_stream::{
@@ -339,7 +351,7 @@ pub mod stream {
         // ToDo: AndThen, ErrInto, InspectErr, MapErr, OrElse
     };
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use futures_util::try_stream::{
         // For TryStreamExt:
         TryCollect, TryBufferUnordered,
@@ -363,12 +375,12 @@ pub mod task {
         Waker, LocalWaker, UnsafeWake,
     };
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use futures_core::task::{
         Wake, local_waker, local_waker_from_nonlocal
     };
 
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     pub use futures_util::task::{
         LocalWakerRef, local_waker_ref, local_waker_ref_from_nonlocal,
         SpawnExt, LocalSpawnExt,


### PR DESCRIPTION
This adds the `alloc` features to `futures`, `futures-core`, `futures-sink`, and `futures-util`.

This allows to use `Box<Future>`, `alloc::task`, many `*Ext` traits's methods etc in the `no_std` + `alloc` environment.

This PR adds [alloc-shim](https://github.com/taiki-e/alloc-shim) crate as an optional dependency. ~~This is only valid if the `alloc` feature is enabled.~~
~~`alloc-shim` will re-export items of `core` and `alloc` in the same layout as `std`. This allows adding `no_std` + `alloc` support without changing existing imports.~~ 
Edit: The current `alloc-shim` has the same layout as the alloc crate.

Some other points:

* When using the `alloc` feature, the `nightly` feature must be used at the same time (see this [comment](https://github.com/rust-lang-nursery/futures-rs/issues/626#issuecomment-457906007) in #626).

* ~~`#[cfg(alloc)]` is the same as `#[cfg(any(feature = "alloc", feature = "std"))]`, but it is simpler and easier to write (`build.rs` was added for this).~~
  Edit:  The implementation was changed to use `#[cfg(feature = "alloc")]` (thanks! @Nemo157).

* `futures::stream::ReuniteError` implements `std::error::Error` only if "std" feature is valid.

* ~~Fixed an `unused_imports` warning in `no_std` build~~. Edit2: It was split into #1447

## Reason to add `alloc-shim` to dependencies

The layout in the prelude module is different for `std` and `alloc`, so `alloc::prelude::v1::*` can not be used (and `alloc::sync` does not include `atomic` module). ~~Also, until now, we've imported everything from `std`, but from now on we'll need to import them from `alloc` and `core`, respectively. Using `alloc-shim` can avoid these problems.~~

~~`alloc` crate is still unstable, so I think `alloc-shim` will be unnecessary in the future, but until then it will be possible to support `no_std` + `alloc` with less cost by using `alloc-shim` (also, `alloc-shim` is designed so that the build will not fail even if `atomic` module is added to `alloc::sync`).~~

~~Also, I've examined several other ways ([1](https://github.com/taiki-e/futures-rs/compare/master...alloc-no-deps), [2](https://github.com/taiki-e/futures-rs/compare/master...alloc-reexport), [3](https://github.com/taiki-e/futures-rs/compare/master...alloc-shim)), but I believe this is the simplest and cleanest.~~

Edit: 

Using `alloc-shim` can avoid the first problem. 

Also, this is an implementation that does not use `alloc-shim`: [alloc-no-deps](https://github.com/taiki-e/futures-rs/compare/master...alloc-no-deps)
