### PR TITLE
Remove deprecated ATOMIC_USIZE_INIT

### DIFF
--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -5,7 +5,7 @@ use futures::executor::block_on;
 use futures::future::poll_fn;
 use futures::stream::StreamExt;
 use futures::sink::SinkExt;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 #[test]
@@ -52,7 +52,7 @@ fn drop_rx() {
 
 #[test]
 fn drop_order() {
-    static DROPS: AtomicUsize = ATOMIC_USIZE_INIT;
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
     let (mut tx, rx) = mpsc::channel(1);
 
     struct A;


### PR DESCRIPTION
This fixes deprecation warnings.