### PR TITLE
Allow !Unpin Sinks in Forward combinator

### DIFF
--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -85,7 +85,7 @@ where
                 Poll::Ready(None) => {
                     try_ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL)
                                    .poll_close(waker));
-                    let _ = self.as_mut().sink().as_pin_mut().take().unwrap();
+                    self.as_mut().sink().set(None);
                     return Poll::Ready(Ok(()))
                 }
                 Poll::Pending => {

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -71,7 +71,7 @@ where
     Si: Sink + Unpin,
     St: Stream<Item = Result<Si::SinkItem, Si::SinkError>>,
 {
-    type Output = Result<Si, Si::SinkError>;
+    type Output = Result<(), Si::SinkError>;
 
     fn poll(
         mut self: Pin<&mut Self>,
@@ -91,7 +91,8 @@ where
                 Poll::Ready(None) => {
                     try_ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL)
                                    .poll_close(waker));
-                    return Poll::Ready(Ok(self.as_mut().sink().take().unwrap()))
+                    let _ = self.as_mut().sink().take().unwrap();
+                    return Poll::Ready(Ok(()))
                 }
                 Poll::Pending => {
                     try_ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL)

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -976,12 +976,6 @@ pub trait StreamExt: Stream {
     /// exhausted, sending each item to the sink. It will complete once both the
     /// stream is exhausted and the sink has received and flushed all items.
     /// Note that the sink is **not** closed.
-    ///
-    /// On completion, the sink is returned.
-    ///
-    /// Note that this combinator is only usable with `Unpin` sinks.
-    /// Sinks that are not `Unpin` will need to be pinned in order to be used
-    /// with `forward`.
     fn forward<S>(self, sink: S) -> Forward<Self, S>
     where
         S: Sink + Unpin,

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -970,15 +970,15 @@ pub trait StreamExt: Stream {
     }
 
     /// A future that completes after the given stream has been fully processed
-    /// into the sink, including flushing.
+    /// into the sink and the sink has been flushed and closed.
     ///
     /// This future will drive the stream to keep producing items until it is
-    /// exhausted, sending each item to the sink. It will complete once both the
-    /// stream is exhausted and the sink has received and flushed all items.
-    /// Note that the sink is **not** closed.
+    /// exhausted, sending each item to the sink. It will complete once the
+    /// stream is exhausted, the sink has received and flushed all items, and
+    /// the sink is closed.
     fn forward<S>(self, sink: S) -> Forward<Self, S>
     where
-        S: Sink + Unpin,
+        S: Sink,
         Self: Stream<Item = Result<S::SinkItem, S::SinkError>> + Sized,
     {
         Forward::new(self, sink)


### PR DESCRIPTION
### Changed

* Update `Forward` so it drops the sink without returning it. Users wishing to access the sink again can pass a `&mut sink` to `StreamExt::forward()`.
* Update docs for both `Forward` and `StreamExt::forward()`.

### Removed

* Remove requirement for `Unpin` sinks on `Forward`.

Fixes #1440. /CC @Nemo157.