### PR TITLE
Separate cfg-target-has-atomic feature

### DIFF
--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -18,6 +18,7 @@ name = "futures_core"
 default = ["std"]
 std = ["either/use_std"]
 nightly = []
+cfg-target-has-atomic = []
 
 [dependencies]
 either = { version = "1.4", default-features = false, optional = true }

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,7 +1,7 @@
 //! Core traits and types for asynchronous operations in Rust.
 
 #![feature(futures_api)]
-#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -9,6 +9,9 @@
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_core")]
+
+#[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
+compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 pub mod future;
 #[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};

--- a/futures-core/src/task/__internal/mod.rs
+++ b/futures-core/src/task/__internal/mod.rs
@@ -1,10 +1,10 @@
 #[cfg_attr(
-    feature = "nightly",
+    feature = "cfg-target-has-atomic",
     cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
 )]
 mod atomic_waker;
 #[cfg_attr(
-    feature = "nightly",
+    feature = "cfg-target-has-atomic",
     cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
 )]
 pub use self::atomic_waker::AtomicWaker;

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -21,6 +21,7 @@ compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
 nightly = []
+cfg-target-has-atomic = []
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.12", default-features = false }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -3,13 +3,16 @@
 
 #![feature(futures_api, box_into_pin)]
 #![cfg_attr(feature = "std", feature(async_await, await_macro))]
-#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
+#![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations)]
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_util")]
+
+#[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
+compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[macro_use]
 mod macros;

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -12,7 +12,7 @@ mod local_waker_ref;
 pub use self::local_waker_ref::{local_waker_ref, local_waker_ref_from_nonlocal, LocalWakerRef};
 
 #[cfg_attr(
-    feature = "nightly",
+    feature = "cfg-target-has-atomic",
     cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
 )]
 pub use futures_core::task::__internal::AtomicWaker;

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -41,3 +41,4 @@ std = ["futures-core-preview/std", "futures-executor-preview/std", "futures-io-p
 default = ["std"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
+cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -22,6 +22,7 @@
 //! completion, but *do not block* the thread running them.
 
 #![feature(futures_api)]
+#![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -29,6 +30,9 @@
 #![deny(bare_trait_objects)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures")]
+
+#[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
+compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[doc(hidden)] pub use futures_util::core_reexport;
 
@@ -377,7 +381,7 @@ pub mod task {
     };
 
     #[cfg_attr(
-        feature = "nightly",
+        feature = "target-has-atomic",
         cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
     )]
     pub use futures_util::task::AtomicWaker;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -30,8 +30,6 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures")]
 
-#![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
-
 #[doc(hidden)] pub use futures_util::core_reexport;
 
 #[doc(hidden)] pub use futures_core::future::Future;


### PR DESCRIPTION
The intention here is that `nightly` becomes a marker feature for opting in to features that use unstable features, but by itself it doesn't activate any extra unstable features; users then activate the specific `nightly` features they need (e.g. #1438 for another nightly feature) . This avoids unnecessary breakage on downstream crates, e.g. if `feature(cfg_target_has_atomic)` changes in some way we don't want to break crates that are only using `default-features = false, features = ["nightly", "alloc"]`.

(this is sort of future proofing for things that will not be stable before the core traits can be released on stable, it doesn't mean much yet, but something like this will be necessary in the future)