### PR TITLE
Fix unused_imports warning on --no-default-features build

### DIFF
--- a/futures-core/src/stream/stream_obj.rs
+++ b/futures-core/src/stream/stream_obj.rs
@@ -2,7 +2,6 @@ use super::Stream;
 use crate::task::{LocalWaker, Poll};
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem;
 use core::pin::Pin;
 
 /// A custom trait object for polling streams, roughly akin to
@@ -191,6 +190,7 @@ where
 #[cfg(feature = "std")]
 mod if_std {
     use std::boxed::Box;
+    use std::mem;
     use super::*;
 
     unsafe impl<'a, T, F> UnsafeStreamObj<'a, T> for Box<F>


### PR DESCRIPTION
This fixes an `unused_imports` warning on --no-default-features build.

https://travis-ci.com/rust-lang-nursery/futures-rs/jobs/173885922