### PR TITLE
Use #![warn(rust_2018_idioms)]

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_channel")]
 

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -7,8 +7,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_channel")]
 

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_core")]
 

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -5,8 +5,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_core")]
 

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_executor")]
 

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -4,8 +4,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_executor")]
 

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_io")]
 

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -6,8 +6,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_io")]
 

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -1,6 +1,7 @@
 //! The futures-rs `select! macro implementation.
 
 #![recursion_limit="128"]
+#![deny(rust_2018_idioms)]
 
 extern crate proc_macro;
 

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -1,7 +1,7 @@
 //! The futures-rs `select! macro implementation.
 
 #![recursion_limit="128"]
-#![deny(rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 extern crate proc_macro;
 

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -4,8 +4,7 @@
 //! asynchronously.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_sink")]
 
 #![feature(futures_api)]

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations)]
+#![deny(rust_2018_idioms)]
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_sink")]
 
 #![feature(futures_api)]

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -5,8 +5,7 @@
     await_macro,
     futures_api,
 )]
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(
     html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.5/futures_test"
 )]

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -6,7 +6,7 @@
     futures_api,
 )]
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 #![doc(
     html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.5/futures_test"
 )]

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -128,7 +128,7 @@ impl Current {
         Current(task01::current())
     }
 
-    fn as_waker(&self) -> LocalWakerLt {
+    fn as_waker(&self) -> LocalWakerLt<'_> {
         unsafe {
             LocalWakerLt {
                 inner: task03::LocalWaker::new(NonNull::new_unchecked(self as *const Current as *mut Current)),

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -6,8 +6,7 @@
 #![cfg_attr(feature = "nightly", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_util")]
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures_util")]
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -26,7 +26,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations)]
-#![deny(bare_trait_objects)]
+#![deny(rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures")]
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -25,8 +25,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations)]
-#![deny(rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.12/futures")]
 


### PR DESCRIPTION
Currently, only `#![bare_trait_objects)]` is used (bare_trait_objects is included in rust_2018_idioms), but since `#![deny(rust_2018_idioms)]` is used in rust-lang/rust (see rust-lang/rust#58099), I would like to use ~~`#![deny(rust_2018_idioms)]`~~`#![warn(rust_2018_idioms)]` even in futures-rs.