### PR TITLE
Use 'self: Pin<&mut Self>' on AsyncRead/AsyncWrite

### DIFF
--- a/futures-io/tests/cursor.rs
+++ b/futures-io/tests/cursor.rs
@@ -5,15 +5,16 @@ use futures::Poll;
 use futures::future::lazy;
 use futures::io::AsyncWrite;
 use std::io::Cursor;
+use std::pin::Pin;
 
 #[test]
 fn cursor_asyncwrite_asmut() {
     let mut cursor = Cursor::new([0; 5]);
     futures::executor::block_on(lazy(|ctx| {
-        assert_matches!(cursor.poll_write(ctx, &[1, 2]), Poll::Ready(Ok(2)));
-        assert_matches!(cursor.poll_write(ctx, &[3, 4]), Poll::Ready(Ok(2)));
-        assert_matches!(cursor.poll_write(ctx, &[5, 6]), Poll::Ready(Ok(1)));
-        assert_matches!(cursor.poll_write(ctx, &[6, 7]), Poll::Ready(Ok(0)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(ctx, &[1, 2]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(ctx, &[3, 4]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(ctx, &[5, 6]), Poll::Ready(Ok(1)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(ctx, &[6, 7]), Poll::Ready(Ok(0)));
     }));
     assert_eq!(cursor.into_inner(), [1, 2, 3, 4, 5]);
 }

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -354,7 +354,7 @@ mod io {
         ///
         /// let input = b"Hello World!";
         /// let reader: impl tokio_io::AsyncRead = std::io::Cursor::new(input);
-        /// let mut reader: impl futures::io::AsyncRead = reader.compat();
+        /// let mut reader: impl futures::io::AsyncRead + Unpin = reader.compat();
         ///
         /// let mut output = Vec::with_capacity(12);
         /// await!(reader.read_to_end(&mut output)).unwrap();

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -201,7 +201,7 @@ where
         mut self: Pin<&mut Self>,
         waker: &Waker,
     ) -> task03::Poll<Option<Self::Item>> {
-        match self.in_notify(waker, |f| f.poll()) {
+        match self.in_notify(waker, Stream01::poll) {
             Ok(Async01::Ready(Some(t))) => task03::Poll::Ready(Some(Ok(t))),
             Ok(Async01::Ready(None)) => task03::Poll::Ready(None),
             Ok(Async01::NotReady) => task03::Poll::Pending,
@@ -409,7 +409,7 @@ mod io {
             }
         }
 
-        fn poll_read(&mut self, waker: &task03::Waker, buf: &mut [u8])
+        fn poll_read(mut self: Pin<&mut Self>, waker: &task03::Waker, buf: &mut [u8])
             -> task03::Poll<Result<usize, Error>>
         {
             poll_01_to_03(self.in_notify(waker, |x| x.poll_read(buf)))
@@ -417,19 +417,19 @@ mod io {
     }
 
     impl<W: AsyncWrite01> AsyncWrite03 for Compat01As03<W> {
-        fn poll_write(&mut self, waker: &task03::Waker, buf: &[u8])
+        fn poll_write(mut self: Pin<&mut Self>, waker: &task03::Waker, buf: &[u8])
             -> task03::Poll<Result<usize, Error>>
         {
             poll_01_to_03(self.in_notify(waker, |x| x.poll_write(buf)))
         }
 
-        fn poll_flush(&mut self, waker: &task03::Waker)
+        fn poll_flush(mut self: Pin<&mut Self>, waker: &task03::Waker)
             -> task03::Poll<Result<(), Error>>
         {
             poll_01_to_03(self.in_notify(waker, AsyncWrite01::poll_flush))
         }
 
-        fn poll_close(&mut self, waker: &task03::Waker)
+        fn poll_close(mut self: Pin<&mut Self>, waker: &task03::Waker)
             -> task03::Poll<Result<(), Error>>
         {
             poll_01_to_03(self.in_notify(waker, AsyncWrite01::shutdown))

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -188,15 +188,15 @@ mod io {
         }
     }
 
-    impl<R: AsyncRead03> std::io::Read for Compat<R> {
+    impl<R: AsyncRead03 + Unpin> std::io::Read for Compat<R> {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
             let current = Current::new();
             let waker = current.as_waker();
-            poll_03_to_io(self.inner.poll_read(&waker, buf))
+            poll_03_to_io(Pin::new(&mut self.inner).poll_read(&waker, buf))
         }
     }
 
-    impl<R: AsyncRead03> AsyncRead01 for Compat<R> {
+    impl<R: AsyncRead03 + Unpin> AsyncRead01 for Compat<R> {
         unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
             let initializer = self.inner.initializer();
             let does_init = initializer.should_initialize();
@@ -207,25 +207,25 @@ mod io {
         }
     }
 
-    impl<W: AsyncWrite03> std::io::Write for Compat<W> {
+    impl<W: AsyncWrite03 + Unpin> std::io::Write for Compat<W> {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
             let current = Current::new();
             let waker = current.as_waker();
-            poll_03_to_io(self.inner.poll_write(&waker, buf))
+            poll_03_to_io(Pin::new(&mut self.inner).poll_write(&waker, buf))
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
             let current = Current::new();
             let waker = current.as_waker();
-            poll_03_to_io(self.inner.poll_flush(&waker))
+            poll_03_to_io(Pin::new(&mut self.inner).poll_flush(&waker))
         }
     }
 
-    impl<W: AsyncWrite03> AsyncWrite01 for Compat<W> {
+    impl<W: AsyncWrite03 + Unpin> AsyncWrite01 for Compat<W> {
         fn shutdown(&mut self) -> std::io::Result<Async01<()>> {
             let current = Current::new();
             let waker = current.as_waker();
-            poll_03_to_01(self.inner.poll_close(&waker))
+            poll_03_to_01(Pin::new(&mut self.inner).poll_close(&waker))
         }
     }
 }

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -10,23 +10,22 @@ use std::pin::Pin;
 ///
 /// [`close`]: fn.close.html
 #[derive(Debug)]
-pub struct Close<'a, W: ?Sized> {
+pub struct Close<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
 }
 
-// Pin is never projected to fields
-impl<W: ?Sized> Unpin for Close<'_, W> {}
+impl<W: ?Sized + Unpin> Unpin for Close<'_, W> {}
 
-impl<'a, W: AsyncWrite + ?Sized> Close<'a, W> {
+impl<'a, W: AsyncWrite + ?Sized + Unpin> Close<'a, W> {
     pub(super) fn new(writer: &'a mut W) -> Self {
         Close { writer }
     }
 }
 
-impl<W: AsyncWrite + ?Sized> Future for Close<'_, W> {
+impl<W: AsyncWrite + ?Sized + Unpin> Future for Close<'_, W> {
     type Output = io::Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
-        self.writer.poll_close(waker)
+        Pin::new(&mut *self.writer).poll_close(waker)
     }
 }

--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -12,7 +12,7 @@ use std::pin::Pin;
 ///
 /// [`copy_into`]: fn.copy_into.html
 #[derive(Debug)]
-pub struct CopyInto<'a, R: ?Sized, W: ?Sized> {
+pub struct CopyInto<'a, R: ?Sized + Unpin, W: ?Sized + Unpin> {
     reader: &'a mut R,
     read_done: bool,
     writer: &'a mut W,
@@ -22,10 +22,9 @@ pub struct CopyInto<'a, R: ?Sized, W: ?Sized> {
     buf: Box<[u8]>,
 }
 
-// No projections of Pin<&mut CopyInto> into Pin<&mut Field> are ever done.
-impl<R: ?Sized, W: ?Sized> Unpin for CopyInto<'_, R, W> {}
+impl<R: ?Sized + Unpin, W: ?Sized + Unpin> Unpin for CopyInto<'_, R, W> {}
 
-impl<'a, R: ?Sized, W: ?Sized> CopyInto<'a, R, W> {
+impl<'a, R: ?Sized + Unpin, W: ?Sized + Unpin> CopyInto<'a, R, W> {
     pub(super) fn new(reader: &'a mut R, writer: &'a mut W) -> Self {
         CopyInto {
             reader,
@@ -40,8 +39,8 @@ impl<'a, R: ?Sized, W: ?Sized> CopyInto<'a, R, W> {
 }
 
 impl<R, W> Future for CopyInto<'_, R, W>
-    where R: AsyncRead + ?Sized,
-          W: AsyncWrite + ?Sized,
+    where R: AsyncRead + ?Sized + Unpin,
+          W: AsyncWrite + ?Sized + Unpin,
 {
     type Output = io::Result<u64>;
 
@@ -51,7 +50,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
             // If our buffer is empty, then we need to read some data to
             // continue.
             if this.pos == this.cap && !this.read_done {
-                let n = try_ready!(this.reader.poll_read(waker, &mut this.buf));
+                let n = try_ready!(Pin::new(&mut this.reader).poll_read(waker, &mut this.buf));
                 if n == 0 {
                     this.read_done = true;
                 } else {
@@ -62,7 +61,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
 
             // If our buffer has some data, let's write it out!
             while this.pos < this.cap {
-                let i = try_ready!(this.writer.poll_write(waker, &this.buf[this.pos..this.cap]));
+                let i = try_ready!(Pin::new(&mut this.writer).poll_write(waker, &this.buf[this.pos..this.cap]));
                 if i == 0 {
                     return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
                 } else {
@@ -75,7 +74,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
             // data and finish the transfer.
             // done with the entire transfer.
             if this.pos == this.cap && this.read_done {
-                try_ready!(this.writer.poll_flush(waker));
+                try_ready!(Pin::new(&mut this.writer).poll_flush(waker));
                 return Poll::Ready(Ok(this.amt));
             }
         }

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -79,7 +79,7 @@ pub trait AsyncReadExt: AsyncRead {
         &'a mut self,
         writer: &'a mut W,
     ) -> CopyInto<'a, Self, W>
-        where W: AsyncWrite,
+        where Self: Unpin, W: AsyncWrite + Unpin,
     {
         CopyInto::new(self, writer)
     }
@@ -110,7 +110,9 @@ pub trait AsyncReadExt: AsyncRead {
     /// assert_eq!(output, [1, 2, 3, 4, 0]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
     /// ```
-    fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Read<'a, Self> {
+    fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Read<'a, Self>
+        where Self: Unpin,
+    {
         Read::new(self, buf)
     }
 
@@ -158,7 +160,9 @@ pub trait AsyncReadExt: AsyncRead {
     fn read_exact<'a>(
         &'a mut self,
         buf: &'a mut [u8],
-    ) -> ReadExact<'a, Self> {
+    ) -> ReadExact<'a, Self>
+        where Self: Unpin,
+    {
         ReadExact::new(self, buf)
     }
 
@@ -183,7 +187,9 @@ pub trait AsyncReadExt: AsyncRead {
     fn read_to_end<'a>(
         &'a mut self,
         buf: &'a mut Vec<u8>,
-    ) -> ReadToEnd<'a, Self> {
+    ) -> ReadToEnd<'a, Self>
+        where Self: Unpin,
+    {
         ReadToEnd::new(self, buf)
     }
 
@@ -232,7 +238,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// Requires the `io-compat` feature to enable.
     #[cfg(feature = "io-compat")]
     fn compat(self) -> Compat<Self>
-        where Self: Sized,
+        where Self: Sized + Unpin,
     {
         Compat::new(self)
     }
@@ -265,12 +271,16 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// assert_eq!(output, [1, 2, 3, 4, 0]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
     /// ```
-    fn flush(&mut self) -> Flush<'_, Self> {
+    fn flush(&mut self) -> Flush<'_, Self>
+        where Self: Unpin,
+    {
         Flush::new(self)
     }
 
     /// Creates a future which will entirely close this `AsyncWrite`.
-    fn close(&mut self) -> Close<'_, Self> {
+    fn close(&mut self) -> Close<'_, Self>
+        where Self: Unpin,
+    {
         Close::new(self)
     }
 
@@ -296,7 +306,9 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
     /// ```
-    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> WriteAll<'a, Self> {
+    fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> WriteAll<'a, Self>
+        where Self: Unpin,
+    {
         WriteAll::new(self, buf)
     }
 
@@ -305,7 +317,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// Requires the `io-compat` feature to enable.
     #[cfg(feature = "io-compat")]
     fn compat_write(self) -> Compat<Self>
-        where Self: Sized,
+        where Self: Sized + Unpin,
     {
         Compat::new(self)
     }

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -7,25 +7,24 @@ use std::pin::Pin;
 /// A future which can be used to easily read available number of bytes to fill
 /// a buffer.
 #[derive(Debug)]
-pub struct Read<'a, R: ?Sized> {
+pub struct Read<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut [u8],
 }
 
-// Pinning is never projected to fields
-impl<R: ?Sized> Unpin for Read<'_, R> {}
+impl<R: ?Sized + Unpin> Unpin for Read<'_, R> {}
 
-impl<'a, R: AsyncRead + ?Sized> Read<'a, R> {
+impl<'a, R: AsyncRead + ?Sized + Unpin> Read<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut [u8]) -> Self {
         Read { reader, buf }
     }
 }
 
-impl<R: AsyncRead + ?Sized> Future for Read<'_, R> {
+impl<R: AsyncRead + ?Sized + Unpin> Future for Read<'_, R> {
     type Output = io::Result<usize>;
 
     fn poll(mut self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
         let this = &mut *self;
-        this.reader.poll_read(waker, this.buf)
+        Pin::new(&mut this.reader).poll_read(waker, this.buf)
     }
 }

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -12,26 +12,26 @@ use std::pin::Pin;
 ///
 /// [`read_exact`]: fn.read_exact.html
 #[derive(Debug)]
-pub struct ReadExact<'a, R: ?Sized> {
+pub struct ReadExact<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut [u8],
 }
 
-impl<R: ?Sized> Unpin for ReadExact<'_, R> {}
+impl<R: ?Sized + Unpin> Unpin for ReadExact<'_, R> {}
 
-impl<'a, R: AsyncRead + ?Sized> ReadExact<'a, R> {
+impl<'a, R: AsyncRead + ?Sized + Unpin> ReadExact<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut [u8]) -> Self {
         ReadExact { reader, buf }
     }
 }
 
-impl<R: AsyncRead + ?Sized> Future for ReadExact<'_, R> {
+impl<R: AsyncRead + ?Sized + Unpin> Future for ReadExact<'_, R> {
     type Output = io::Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
         let this = &mut *self;
         while !this.buf.is_empty() {
-            let n = try_ready!(this.reader.poll_read(waker, this.buf));
+            let n = try_ready!(Pin::new(&mut this.reader).poll_read(waker, this.buf));
             {
                 let (_, rest) = mem::replace(&mut this.buf, &mut []).split_at_mut(n);
                 this.buf = rest;

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -21,12 +21,12 @@ fn lock_and_then<T, U, E, F>(
     waker: &Waker,
     f: F
 ) -> Poll<Result<U, E>>
-    where F: FnOnce(&mut T, &Waker) -> Poll<Result<U, E>>
+    where F: FnOnce(Pin<&mut T>, &Waker) -> Poll<Result<U, E>>
 {
     match lock.poll_lock(waker) {
         // Safety: the value behind the bilock used by `ReadHalf` and `WriteHalf` is never exposed
         // as a `Pin<&mut T>` anywhere other than here as a way to get to `&mut T`.
-        Poll::Ready(mut l) => f(unsafe { Pin::get_unchecked_mut(l.as_pin_mut()) }, waker),
+        Poll::Ready(mut l) => f(l.as_pin_mut(), waker),
         Poll::Pending => Poll::Pending,
     }
 }
@@ -37,13 +37,13 @@ pub fn split<T: AsyncRead + AsyncWrite>(t: T) -> (ReadHalf<T>, WriteHalf<T>) {
 }
 
 impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
-    fn poll_read(&mut self, waker: &Waker, buf: &mut [u8])
+    fn poll_read(self: Pin<&mut Self>, waker: &Waker, buf: &mut [u8])
         -> Poll<io::Result<usize>>
     {
         lock_and_then(&self.handle, waker, |l, waker| l.poll_read(waker, buf))
     }
 
-    fn poll_vectored_read(&mut self, waker: &Waker, vec: &mut [&mut IoVec])
+    fn poll_vectored_read(self: Pin<&mut Self>, waker: &Waker, vec: &mut [&mut IoVec])
         -> Poll<io::Result<usize>>
     {
         lock_and_then(&self.handle, waker, |l, waker| l.poll_vectored_read(waker, vec))
@@ -51,23 +51,23 @@ impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
 }
 
 impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
-    fn poll_write(&mut self, waker: &Waker, buf: &[u8])
+    fn poll_write(self: Pin<&mut Self>, waker: &Waker, buf: &[u8])
         -> Poll<io::Result<usize>>
     {
         lock_and_then(&self.handle, waker, |l, waker| l.poll_write(waker, buf))
     }
 
-    fn poll_vectored_write(&mut self, waker: &Waker, vec: &[&IoVec])
+    fn poll_vectored_write(self: Pin<&mut Self>, waker: &Waker, vec: &[&IoVec])
         -> Poll<io::Result<usize>>
     {
         lock_and_then(&self.handle, waker, |l, waker| l.poll_vectored_write(waker, vec))
     }
 
-    fn poll_flush(&mut self, waker: &Waker) -> Poll<io::Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, waker: &Waker) -> Poll<io::Result<()>> {
         lock_and_then(&self.handle, waker, |l, waker| l.poll_flush(waker))
     }
 
-    fn poll_close(&mut self, waker: &Waker) -> Poll<io::Result<()>> {
+    fn poll_close(self: Pin<&mut Self>, waker: &Waker) -> Poll<io::Result<()>> {
         lock_and_then(&self.handle, waker, |l, waker| l.poll_close(waker))
     }
 }

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -11,27 +11,26 @@ use std::pin::Pin;
 ///
 /// [`write_all`]: fn.write_all.html
 #[derive(Debug)]
-pub struct WriteAll<'a, W: ?Sized> {
+pub struct WriteAll<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
     buf: &'a [u8],
 }
 
-// Pinning is never projected to fields
-impl<W: ?Sized> Unpin for WriteAll<'_, W> {}
+impl<W: ?Sized + Unpin> Unpin for WriteAll<'_, W> {}
 
-impl<'a, W: AsyncWrite + ?Sized> WriteAll<'a, W> {
+impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteAll<'a, W> {
     pub(super) fn new(writer: &'a mut W, buf: &'a [u8]) -> Self {
         WriteAll { writer, buf }
     }
 }
 
-impl<W: AsyncWrite + ?Sized> Future for WriteAll<'_, W> {
+impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteAll<'_, W> {
     type Output = io::Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, waker: &Waker) -> Poll<io::Result<()>> {
         let this = &mut *self;
         while !this.buf.is_empty() {
-            let n = try_ready!(this.writer.poll_write(waker, this.buf));
+            let n = try_ready!(Pin::new(&mut this.writer).poll_write(waker, this.buf));
             {
                 let (_, rest) = mem::replace(&mut this.buf, &[]).split_at(n);
                 this.buf = rest;

--- a/futures-util/src/try_stream/into_async_read.rs
+++ b/futures-util/src/try_stream/into_async_read.rs
@@ -50,7 +50,7 @@ where
     St::Ok: AsRef<[u8]>,
 {
     fn poll_read(
-        &mut self,
+        mut self: Pin<&mut Self>,
         waker: &Waker,
         buf: &mut [u8],
     ) -> Poll<Result<usize>> {
@@ -108,7 +108,7 @@ mod tests {
     macro_rules! assert_read {
         ($reader:expr, $buf:expr, $item:expr) => {
             let waker = noop_waker_ref();
-            match $reader.poll_read(waker, $buf) {
+            match Pin::new(&mut $reader).poll_read(waker, $buf) {
                 Poll::Ready(Ok(x)) => {
                     assert_eq!(x, $item);
                 }


### PR DESCRIPTION
Closes #1454

concerns:

* Most methods of `AsyncReadExt`/`AsyncWriteExt` require `Self: Unpin`.

* ~~Add a new dependency ([pin-project](https://github.com/taiki-e/pin-project)).~~ - Removed