### PR TITLE
Use std IoVec on AsyncRead/AsyncWrite

### DIFF
--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -15,12 +15,11 @@ The `AsyncRead` and `AsyncWrite` traits for the futures-rs library.
 name = "futures_io"
 
 [features]
-std = ["futures-core-preview/std", "iovec"]
+std = ["futures-core-preview/std"]
 default = ["std"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.14", default-features = false }
-iovec = { version = "0.1", optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "=0.3.0-alpha.14" }

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -17,6 +17,8 @@ name = "futures_io"
 [features]
 std = ["futures-core-preview/std"]
 default = ["std"]
+nightly = []
+iovec = []
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.14", default-features = false }

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -140,7 +140,7 @@ mod if_std {
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
         #[cfg(feature = "iovec")]
-        fn poll_vectored_read(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
+        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
             -> Poll<Result<usize>>
         {
             if let Some(ref mut first_iovec) = vec.get_mut(0) {
@@ -202,7 +202,7 @@ mod if_std {
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
         #[cfg(feature = "iovec")]
-        fn poll_vectored_write(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
+        fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
             -> Poll<Result<usize>>
         {
             if let Some(ref first_iovec) = vec.get(0) {
@@ -262,10 +262,10 @@ mod if_std {
             }
 
             #[cfg(feature = "iovec")]
-            fn poll_vectored_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
+            fn poll_read_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
                 -> Poll<Result<usize>>
             {
-                Pin::new(&mut **self).poll_vectored_read(cx, vec)
+                Pin::new(&mut **self).poll_read_vectored(cx, vec)
             }
         }
     }
@@ -290,10 +290,10 @@ mod if_std {
         }
 
         #[cfg(feature = "iovec")]
-        fn poll_vectored_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
+        fn poll_read_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
             -> Poll<Result<usize>>
         {
-            T::poll_vectored_read((*self).as_mut(), cx, vec)
+            T::poll_read_vectored((*self).as_mut(), cx, vec)
         }
     }
 
@@ -312,7 +312,7 @@ mod if_std {
             }
 
             #[cfg(feature = "iovec")]
-            fn poll_vectored_read(mut self: Pin<&mut Self>, _: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
+            fn poll_read_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
                 -> Poll<Result<usize>>
             {
                 Poll::Ready(StdIo::Read::read_vectored(&mut *self, vec))
@@ -341,10 +341,10 @@ mod if_std {
             }
 
             #[cfg(feature = "iovec")]
-            fn poll_vectored_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
+            fn poll_write_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
                 -> Poll<Result<usize>>
             {
-                Pin::new(&mut **self).poll_vectored_write(cx, vec)
+                Pin::new(&mut **self).poll_write_vectored(cx, vec)
             }
 
             fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
@@ -373,10 +373,10 @@ mod if_std {
         }
 
         #[cfg(feature = "iovec")]
-        fn poll_vectored_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
+        fn poll_write_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
             -> Poll<Result<usize>>
         {
-            T::poll_vectored_write((*self).as_mut(), cx, vec)
+            T::poll_write_vectored((*self).as_mut(), cx, vec)
         }
 
         fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
@@ -397,7 +397,7 @@ mod if_std {
             }
 
             #[cfg(feature = "iovec")]
-            fn poll_vectored_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, vec: &[IoVec<'_>])
+            fn poll_write_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, vec: &[IoVec<'_>])
                 -> Poll<Result<usize>>
             {
                 Poll::Ready(StdIo::Write::write_vectored(&mut *self, vec))
@@ -432,7 +432,7 @@ mod if_std {
         }
 
         #[cfg(feature = "iovec")]
-        fn poll_vectored_write(self: Pin<&mut Self>, _: &mut Context<'_>, vec: &[IoVec<'_>])
+        fn poll_write_vectored(self: Pin<&mut Self>, _: &mut Context<'_>, vec: &[IoVec<'_>])
             -> Poll<Result<usize>>
         {
             Poll::Ready(StdIo::Write::write_vectored(&mut self.get_mut().get_mut().as_mut(), vec))

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -20,9 +20,10 @@ default = ["std", "futures-core-preview/either", "futures-sink-preview/either"]
 compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
-nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly"]
+nightly = ["futures-core-preview/nightly", "futures-io-preview/nightly", "futures-sink-preview/nightly"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc"]
+iovec = ["futures-io-preview/iovec"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.14", default-features = false }

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -7,7 +7,10 @@
 
 use std::vec::Vec;
 
-pub use futures_io::{AsyncRead, AsyncWrite, IoVec, IoVecMut};
+pub use futures_io::{AsyncRead, AsyncWrite};
+
+#[cfg(feature = "iovec")]
+pub use futures_io::{IoVec, IoVecMut};
 
 #[cfg(feature = "io-compat")] use crate::compat::Compat;
 

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -7,7 +7,7 @@
 
 use std::vec::Vec;
 
-pub use futures_io::{AsyncRead, AsyncWrite, IoVec};
+pub use futures_io::{AsyncRead, AsyncWrite, IoVec, IoVecMut};
 
 #[cfg(feature = "io-compat")] use crate::compat::Compat;
 

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -46,10 +46,10 @@ impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
     }
 
     #[cfg(feature = "iovec")]
-    fn poll_vectored_read(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
+    fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
         -> Poll<io::Result<usize>>
     {
-        lock_and_then(&self.handle, cx, |l, cx| l.poll_vectored_read(cx, vec))
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_read_vectored(cx, vec))
     }
 }
 
@@ -61,10 +61,10 @@ impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
     }
 
     #[cfg(feature = "iovec")]
-    fn poll_vectored_write(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
+    fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
         -> Poll<io::Result<usize>>
     {
-        lock_and_then(&self.handle, cx, |l, cx| l.poll_vectored_write(cx, vec))
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_write_vectored(cx, vec))
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -1,6 +1,6 @@
 use crate::lock::BiLock;
 use futures_core::task::{Context, Poll};
-use futures_io::{AsyncRead, AsyncWrite, IoVec};
+use futures_io::{AsyncRead, AsyncWrite, IoVec, IoVecMut};
 use std::io;
 use std::pin::Pin;
 
@@ -43,7 +43,7 @@ impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_read(cx, buf))
     }
 
-    fn poll_vectored_read(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [&mut IoVec])
+    fn poll_vectored_read(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
         -> Poll<io::Result<usize>>
     {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_vectored_read(cx, vec))
@@ -57,7 +57,7 @@ impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_write(cx, buf))
     }
 
-    fn poll_vectored_write(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[&IoVec])
+    fn poll_vectored_write(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
         -> Poll<io::Result<usize>>
     {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_vectored_write(cx, vec))

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -1,6 +1,8 @@
 use crate::lock::BiLock;
 use futures_core::task::{Context, Poll};
-use futures_io::{AsyncRead, AsyncWrite, IoVec, IoVecMut};
+use futures_io::{AsyncRead, AsyncWrite};
+#[cfg(feature = "iovec")]
+use futures_io::{IoVec, IoVecMut};
 use std::io;
 use std::pin::Pin;
 
@@ -43,6 +45,7 @@ impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_read(cx, buf))
     }
 
+    #[cfg(feature = "iovec")]
     fn poll_vectored_read(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoVecMut<'_>])
         -> Poll<io::Result<usize>>
     {
@@ -57,6 +60,7 @@ impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_write(cx, buf))
     }
 
+    #[cfg(feature = "iovec")]
     fn poll_vectored_write(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[IoVec<'_>])
         -> Poll<io::Result<usize>>
     {

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -3,8 +3,9 @@
 
 #![feature(futures_api)]
 #![cfg_attr(feature = "alloc", feature(box_into_pin))]
-#![cfg_attr(feature = "std", feature(async_await, await_macro, iovec))]
+#![cfg_attr(feature = "std", feature(async_await, await_macro))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
+#![cfg_attr(feature = "iovec", feature(iovec))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
@@ -13,6 +14,9 @@
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
+
+#[cfg(all(feature = "iovec", not(feature = "nightly")))]
+compile_error!("The `iovec` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![feature(futures_api)]
 #![cfg_attr(feature = "alloc", feature(box_into_pin))]
-#![cfg_attr(feature = "std", feature(async_await, await_macro))]
+#![cfg_attr(feature = "std", feature(async_await, await_macro, iovec))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -36,10 +36,11 @@ futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.14" }
 tokio = "0.1.11"
 
 [features]
-nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly", "futures-util-preview/nightly"]
+nightly = ["futures-core-preview/nightly", "futures-io-preview/nightly", "futures-sink-preview/nightly", "futures-util-preview/nightly"]
 std = ["alloc", "futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std"]
 default = ["std"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-util-preview/alloc"]
+iovec = ["futures-io-preview/iovec", "futures-util-preview/iovec"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -22,6 +22,7 @@
 //! completion, but *do not block* the thread running them.
 
 #![feature(futures_api)]
+#![cfg_attr(feature = "std", feature(iovec))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -255,7 +256,7 @@ pub mod io {
     //! sinks.
 
     pub use futures_io::{
-        Error, Initializer, IoVec, ErrorKind, AsyncRead, AsyncWrite, Result
+        Error, Initializer, IoVec, IoVecMut, ErrorKind, AsyncRead, AsyncWrite, Result
     };
     pub use futures_util::io::{
         AsyncReadExt, AsyncWriteExt, AllowStdIo, Close, CopyInto, Flush,

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -22,8 +22,8 @@
 //! completion, but *do not block* the thread running them.
 
 #![feature(futures_api)]
-#![cfg_attr(feature = "std", feature(iovec))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
+#![cfg_attr(feature = "iovec", feature(iovec))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -33,6 +33,9 @@
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
+
+#[cfg(all(feature = "iovec", not(feature = "nightly")))]
+compile_error!("The `iovec` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[doc(hidden)] pub use futures_util::core_reexport;
 
@@ -256,8 +259,12 @@ pub mod io {
     //! sinks.
 
     pub use futures_io::{
-        Error, Initializer, IoVec, IoVecMut, ErrorKind, AsyncRead, AsyncWrite, Result
+        Error, Initializer, ErrorKind, AsyncRead, AsyncWrite, Result,
     };
+
+    #[cfg(feature = "iovec")]
+    pub use futures_io::{IoVec, IoVecMut};
+
     pub use futures_util::io::{
         AsyncReadExt, AsyncWriteExt, AllowStdIo, Close, CopyInto, Flush,
         Read, ReadExact, ReadHalf, ReadToEnd, Window, WriteAll, WriteHalf,


### PR DESCRIPTION
By using this at an early stage, I think there is a high possibility of getting more tests and feedback early. I think that will have a positive impact on std `IoVec` API improvements and stabilization.

(Personally, at the time of stabilizing std `IoVec` API, it is preferable we are somewhat used to this API.)

Closes https://github.com/rust-lang-nursery/futures-rs/issues/1455