### PR TITLE
0.1: Allow deprecated items

### DIFF
--- a/futures-cpupool/tests/smoke.rs
+++ b/futures-cpupool/tests/smoke.rs
@@ -1,7 +1,9 @@
 extern crate futures;
 extern crate futures_cpupool;
 
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
+#[allow(deprecated)]
+use std::sync::atomic::ATOMIC_USIZE_INIT;
 use std::thread;
 use std::time::Duration;
 
@@ -36,6 +38,7 @@ fn select() {
 
 #[test]
 fn threads_go_away() {
+    #[allow(deprecated)]
     static CNT: AtomicUsize = ATOMIC_USIZE_INIT;
 
     struct A;
@@ -66,7 +69,9 @@ fn threads_go_away() {
 
 #[test]
 fn lifecycle_test() {
+    #[allow(deprecated)]
     static NUM_STARTS: AtomicUsize = ATOMIC_USIZE_INIT;
+    #[allow(deprecated)]
     static NUM_STOPS: AtomicUsize = ATOMIC_USIZE_INIT;
 
     fn after_start() {

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -306,6 +306,7 @@ impl<E> error::Error for SharedError<E>
         self.error.description()
     }
 
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&error::Error> {
         self.error.cause()
     }

--- a/src/task_impl/core.rs
+++ b/src/task_impl/core.rs
@@ -2,7 +2,9 @@
 
 use core::marker;
 use core::mem;
-use core::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use core::sync::atomic::AtomicUsize;
+#[allow(deprecated)]
+use core::sync::atomic::ATOMIC_USIZE_INIT;
 use core::sync::atomic::Ordering::{SeqCst, Relaxed};
 
 use super::{BorrowedTask, NotifyHandle};
@@ -84,7 +86,9 @@ impl Drop for TaskUnpark {
     }
 }
 
+#[allow(deprecated)]
 static GET: AtomicUsize = ATOMIC_USIZE_INIT;
+#[allow(deprecated)]
 static SET: AtomicUsize = ATOMIC_USIZE_INIT;
 
 /// Initialize the `futures` task system.

--- a/src/task_impl/mod.rs
+++ b/src/task_impl/mod.rs
@@ -24,13 +24,16 @@ pub struct BorrowedTask<'a> {
 }
 
 fn fresh_task_id() -> usize {
-    use core::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    #[allow(deprecated)]
+    use core::sync::atomic::ATOMIC_USIZE_INIT;
 
     // TODO: this assert is a real bummer, need to figure out how to reuse
     //       old IDs that are no longer in use.
     //
     // Note, though, that it is intended that these ids go away entirely
     // eventually, see the comment on `is_current` below.
+    #[allow(deprecated)]
     static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
     assert!(id < usize::max_value() / 2,

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -52,6 +52,7 @@ fn drop_rx() {
 
 #[test]
 fn drop_order() {
+    #[allow(deprecated)]
     static DROPS: AtomicUsize = ATOMIC_USIZE_INIT;
     let (tx, rx) = mpsc::channel(1);
 


### PR DESCRIPTION
- `ATOMIC_USIZE_INIT` - deprecated in Rust 1.34, but `AtomicUsize::new` stabilized in Rust 1.24 (the minimum supported version of futures 0.1 is Rust 1.15).
- `Error::cause` - deprecated in Rust 1.33, but `Error::source` stabilized in Rust 1.30.