### PR TITLE
Add no_std environment support to futures-channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
       script:
         - cargo build --manifest-path futures/Cargo.toml --no-default-features --features alloc,nightly
         - cargo build --manifest-path futures-core/Cargo.toml --no-default-features --features alloc,nightly
+        - cargo build --manifest-path futures-channel/Cargo.toml --no-default-features --features alloc,nightly
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features --features alloc,nightly
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features --features alloc,nightly
 

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -15,8 +15,11 @@ Channels for asynchronous communication using futures-rs.
 name = "futures_channel"
 
 [features]
-std = ["futures-core-preview/std"]
+std = ["alloc", "futures-core-preview/std"]
 default = ["std"]
+nightly = ["futures-core-preview/nightly"]
+cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic"]
+alloc = ["futures-core-preview/alloc"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.13", default-features = false }

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -4,6 +4,8 @@
 //! asynchronous tasks.
 
 #![feature(futures_api)]
+#![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -11,9 +13,32 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.13/futures_channel")]
 
+#[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
+compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
+
+#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
+compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
 #[cfg(feature = "std")]
-mod lock;
-#[cfg(feature = "std")]
-pub mod mpsc;
-#[cfg(feature = "std")]
-pub mod oneshot;
+extern crate std as alloc;
+
+macro_rules! cfg_target_has_atomic {
+    ($($item:item)*) => {$(
+        #[cfg_attr(
+            feature = "cfg-target-has-atomic",
+            cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
+        )]
+        $item
+    )*};
+}
+
+cfg_target_has_atomic! {
+    #[cfg(feature = "alloc")]
+    mod lock;
+    #[cfg(feature = "alloc")]
+    pub mod mpsc;
+    #[cfg(feature = "alloc")]
+    pub mod oneshot;
+}

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -2,12 +2,13 @@
 
 use futures_core::future::Future;
 use futures_core::task::{Waker, Poll};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering::SeqCst;
+use core::pin::Pin;
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::Ordering::SeqCst;
+use core::fmt;
+use alloc::sync::Arc;
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
 
 use crate::lock::Lock;
 
@@ -380,6 +381,7 @@ impl fmt::Display for Canceled {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for Canceled {
     fn description(&self) -> &str {
         "oneshot canceled"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -17,8 +17,9 @@ name = "futures_sink"
 [features]
 std = ["alloc", "either/use_std", "futures-core-preview/std", "futures-channel-preview/std"]
 default = ["std"]
-nightly = ["futures-core-preview/nightly"]
-alloc = ["futures-core-preview/alloc"]
+nightly = ["futures-core-preview/nightly", "futures-channel-preview/nightly"]
+cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-channel-preview/cfg-target-has-atomic"]
+alloc = ["futures-core-preview/alloc", "futures-channel-preview/alloc"]
 
 [dependencies]
 either = { version = "1.4", default-features = false, optional = true }

--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -1,7 +1,7 @@
 use crate::{Sink, Poll};
 use futures_core::task::Waker;
 use futures_channel::mpsc::{Sender, SendError, TrySendError, UnboundedSender};
-use std::pin::Pin;
+use core::pin::Pin;
 
 impl<T> Sink<T> for Sender<T> {
     type SinkError = SendError;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -8,7 +8,11 @@
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.13/futures_sink")]
 
 #![feature(futures_api)]
+#![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
+
+#[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
+compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
 compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
@@ -156,7 +160,11 @@ impl<'a, S: ?Sized + Sink<Item>, Item> Sink<Item> for Pin<&'a mut S> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg_attr(
+    feature = "cfg-target-has-atomic",
+    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
+)]
+#[cfg(feature = "alloc")]
 mod channel_impls;
 
 #[cfg(feature = "alloc")]

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -21,7 +21,7 @@ compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
 nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly"]
-cfg-target-has-atomic = []
+cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-sink-preview/cfg-target-has-atomic"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc"]
 
 [dependencies]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -41,5 +41,5 @@ std = ["alloc", "futures-core-preview/std", "futures-executor-preview/std", "fut
 default = ["std"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
-cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]
+cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-sink-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-util-preview/alloc"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -65,7 +65,11 @@ pub use futures_util::{
     join, try_join, pending, poll,
 };
 
-#[cfg(feature = "std")]
+#[cfg_attr(
+    feature = "cfg-target-has-atomic",
+    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
+)]
+#[cfg(feature = "alloc")]
 pub mod channel {
     //! Cross-task communication.
     //!


### PR DESCRIPTION
In the no_std environment, use own spinlock and spin_loop_hint because the OS provided mutex and the OS scheduler cannot be used (this change does not affect the behavior when the std function is enabled.).

(It seems that no other currently opened PRs will add other std items to futures-channel, so I opened this.)

cc @cramertj @Nemo157