### PR TITLE
Hide hidden item re-exports

### DIFF
--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -31,6 +31,7 @@ mod macros;
 #[doc(hidden)]
 pub mod async_await;
 #[cfg(feature = "std")]
+#[doc(hidden)]
 pub use self::async_await::*;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Please look at https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.13/futures_util/index.html#reexports.

Current `futures-util`'s document dosen't hide `pub use self::async_await::*;` (`async_await` is hidden module).