### PR TITLE
Propagate cfg-target-has-atomic feature

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -21,7 +21,7 @@ compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
 nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly"]
-cfg-target-has-atomic = []
+cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc"]
 
 [dependencies]


### PR DESCRIPTION
Currently `cfg-target-has-atomic` feature is not propagate from util to core, the E0599 error occurs when executing `cargo build --manifest-path futures-util/Cargo.toml  --target thumbv6m-none-eabi  --no-default-features --features nightly,cfg-target-has-atomic`.
```text
error[E0599]: no method named `compare_and_swap` found for type `core::sync::atomic::AtomicUsize` in the current scope
   --> futures-core/src/task/__internal/atomic_waker.rs:201:26
    |
201 |         match self.state.compare_and_swap(WAITING, REGISTERING, Acquire) {
```