### PR TITLE
Stabilize alloc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
     # When updating this, the reminder to update the minimum required version in README.md.
     - name: cargo test (minimum required version)
-      rust: nightly-2019-04-13
+      rust: nightly-2019-04-15
 
     - name: cargo clippy
       rust: nightly

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Now, you can use futures-rs:
 use futures::future::Future; // Note: It's not `futures_preview`
 ```
 
-The current version of futures-rs requires Rust nightly 2019-04-13 or later.
+The current version of futures-rs requires Rust nightly 2019-04-15 or later.
 
 ### Feature `std`
 

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![feature(futures_api)]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -13,13 +12,8 @@
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
-#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
-compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std as alloc;
 
 pub mod future;
 #[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -8,15 +8,9 @@
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.13/futures_sink")]
 
 #![feature(futures_api)]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
-#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
-compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std as alloc;
 
 use futures_core::task::{Context, Poll};
 use core::pin::Pin;

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -7,7 +7,8 @@ use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use alloc::prelude::v1::*;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 #[derive(Debug)]
 enum ElemState<F>

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -5,7 +5,6 @@
 #![cfg_attr(feature = "alloc", feature(box_into_pin))]
 #![cfg_attr(feature = "std", feature(async_await, await_macro))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
@@ -15,13 +14,8 @@
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
-#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
-compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
-
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std as alloc;
 
 #[macro_use]
 mod macros;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(feature = "alloc", feature(box_into_pin))]
 #![cfg_attr(feature = "std", feature(async_await, await_macro))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc, alloc_prelude))]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -5,7 +5,7 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use core::mem;
 use core::pin::Pin;
-use alloc::prelude::v1::*;
+use alloc::vec::Vec;
 
 /// Stream for the [`chunks`](super::StreamExt::chunks) method.
 #[derive(Debug)]

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -7,7 +7,8 @@ use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use alloc::prelude::v1::*;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use super::TryFuture;
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -23,7 +23,6 @@
 
 #![feature(futures_api)]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -33,9 +32,6 @@
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
-
-#[cfg(all(feature = "alloc", not(any(feature = "std", feature = "nightly"))))]
-compile_error!("The `alloc` feature without `std` requires the `nightly` feature active to explicitly opt-in to unstable features");
 
 #[doc(hidden)] pub use futures_util::core_reexport;
 


### PR DESCRIPTION
Currently, this feature requires the `nightly` feature active to explicitly opt-in to unstable features, but this is no longer needed because rust-lang/rust#59675 has been merged.