### PR TITLE
Add get_ref to Compat01As03 and Compat01As03Sink

### DIFF
--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -37,6 +37,11 @@ impl<T> Compat01As03<T> {
         let notify = &WakerToHandle(cx.waker());
         self.inner.poll_fn_notify(notify, 0, f)
     }
+
+    /// Get a reference to 0.1 Future, Stream, AsyncRead, or AsyncWrite object contained within.
+    pub fn get_ref(&self) -> &T {
+        self.inner.get_ref()
+    }
 }
 
 /// Extension trait for futures 0.1 [`Future`](futures::future::Future)
@@ -188,6 +193,11 @@ impl<S, SinkItem> Compat01As03Sink<S, SinkItem> {
     ) -> R {
         let notify = &WakerToHandle(cx.waker());
         self.inner.poll_fn_notify(notify, 0, f)
+    }
+
+    /// Get a reference to 0.1 Sink object contained within.
+    pub fn get_ref(&self) -> &S {
+        self.inner.get_ref()
     }
 }
 


### PR DESCRIPTION
Allows immutable access to the wrapped 0.1 Future/Stream/Sink.

ref [google/tarpc#216 (comment)](https://github.com/google/tarpc/pull/216#issuecomment-483299729)