### PR TITLE
Use #![warn(clippy::all)]

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_channel")]
 

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_core")]
 

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_executor")]
 

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_io")]
 

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![recursion_limit="128"]
 #![warn(rust_2018_idioms)]
+#![warn(clippy::all)]
 
 extern crate proc_macro;
 

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -5,6 +5,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_sink")]
 
 #[cfg(feature = "alloc")]

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -1,6 +1,8 @@
 //! Utilities to make testing [`Future`s](futures_core::Future) easier
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
+
 #![doc(
     html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.5/futures_test"
 )]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_util")]
 

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -121,7 +121,7 @@ mod tests {
         let (tx2, rx2) = mpsc::channel(2);
         let tx = tx1.fanout(tx2).sink_map_err(|_| ());
 
-        let src = stream::iter((0..10).map(|x| Ok(x)));
+        let src = stream::iter((0..10).map(Ok));
         let fwd = src.forward(tx);
 
         let collect_fut1 = rx1.collect::<Vec<_>>();

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -27,6 +27,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures")]
 


### PR DESCRIPTION
All lints included in `clippy::all` are enabled by default when doing `cargo clippy`.
But we can only check this by actually running `cargo clippy`.

In some editors, using `#![warn(clippy::all)]` makes it possible to receive warnings as well as lints provided by the language (at least with the vscode I use).

We will be happy because we do not have to check each time in local.