### PR TITLE
Add StreamExt::enumerate

### DIFF
--- a/futures-util/src/stream/enumerate.rs
+++ b/futures-util/src/stream/enumerate.rs
@@ -1,0 +1,61 @@
+use core::pin::Pin;
+use futures_core::stream::{FusedStream, Stream};
+use futures_core::task::{Context, Poll};
+use futures_sink::Sink;
+use pin_utils::{unsafe_pinned, unsafe_unpinned};
+
+/// Stream for the [`enumerate`](super::EnumerateExt::enumerate) method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Enumerate<St: Stream> {
+    stream: St,
+    count: usize,
+}
+
+impl<St: Stream + Unpin> Unpin for Enumerate<St> {}
+
+impl<St: Stream> Enumerate<St> {
+    unsafe_pinned!(stream: St);
+    unsafe_unpinned!(count: usize);
+
+    pub(super) fn new(stream: St) -> Enumerate<St> {
+        Enumerate {
+            stream,
+            count: 0,
+        }
+    }
+}
+
+impl<St: Stream + FusedStream> FusedStream for Enumerate<St> {
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
+    }
+}
+
+impl<St: Stream> Stream for Enumerate<St> {
+    type Item = (usize, St::Item);
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match ready!(self.as_mut().stream().poll_next(cx)) {
+            Some(item) => {
+                let count = self.count;
+                *self.as_mut().count() += 1;
+                Poll::Ready(Some((count, item)))
+            }
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+impl<S, Item> Sink<Item> for Enumerate<S>
+where
+    S: Stream + Sink<Item>,
+{
+    type SinkError = S::SinkError;
+
+    delegate_sink!(stream, Item);
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -345,9 +345,10 @@ pub mod stream {
         unfold, Unfold,
 
         StreamExt,
-        Chain, Collect, Concat, Filter, FilterMap, Flatten, Fold, Forward,
-        ForEach, Fuse, StreamFuture, Inspect, Map, Next, SelectNextSome,
-        Peekable, Select, Skip, SkipWhile, Take, TakeWhile, Then, Zip
+        Chain, Collect, Concat, Enumerate, Filter, FilterMap, Flatten, Fold,
+        Forward, ForEach, Fuse, StreamFuture, Inspect, Map, Next,
+        SelectNextSome, Peekable, Select, Skip, SkipWhile, Take, TakeWhile,
+        Then, Zip
     };
 
     #[cfg(feature = "alloc")]


### PR DESCRIPTION
In the future 0.1, [this method is provided by tokio](https://docs.rs/tokio/0.1.18/tokio/util/trait.StreamExt.html#method.enumerate).