### PR TITLE
Use std::io::IoSlice[Mut] on AsyncRead/AsyncWrite take2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
     # When updating this, the reminder to update the minimum required version in README.md.
     - name: cargo test (minimum required version)
-      rust: nightly-2019-04-25
+      rust: nightly-2019-04-30
 
     - name: cargo clippy
       rust: nightly

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Now, you can use futures-rs:
 use futures::future::Future; // Note: It's not `futures_preview`
 ```
 
-The current version of futures-rs requires Rust nightly 2019-04-25 or later.
+The current version of futures-rs requires Rust nightly 2019-04-30 or later.
 
 ### Feature `std`
 

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -15,12 +15,11 @@ The `AsyncRead` and `AsyncWrite` traits for the futures-rs library.
 name = "futures_io"
 
 [features]
-std = ["futures-core-preview/std", "iovec"]
+std = ["futures-core-preview/std"]
 default = ["std"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false }
-iovec = { version = "0.1", optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "=0.3.0-alpha.15" }

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -6,7 +6,7 @@
 //! to the `AsyncRead` and `AsyncWrite` types.
 
 pub use futures_io::{
-    AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, IoVec, SeekFrom,
+    AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, IoSlice, IoSliceMut, SeekFrom,
 };
 
 #[cfg(feature = "io-compat")] use crate::compat::Compat;

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -1,6 +1,6 @@
 use crate::lock::BiLock;
 use futures_core::task::{Context, Poll};
-use futures_io::{AsyncRead, AsyncWrite, IoVec};
+use futures_io::{AsyncRead, AsyncWrite, IoSlice, IoSliceMut};
 use std::io;
 use std::pin::Pin;
 
@@ -43,10 +43,10 @@ impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_read(cx, buf))
     }
 
-    fn poll_vectored_read(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [&mut IoVec])
+    fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoSliceMut<'_>])
         -> Poll<io::Result<usize>>
     {
-        lock_and_then(&self.handle, cx, |l, cx| l.poll_vectored_read(cx, vec))
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_read_vectored(cx, vec))
     }
 }
 
@@ -57,10 +57,10 @@ impl<W: AsyncWrite> AsyncWrite for WriteHalf<W> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_write(cx, buf))
     }
 
-    fn poll_vectored_write(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &[&IoVec])
+    fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
         -> Poll<io::Result<usize>>
     {
-        lock_and_then(&self.handle, cx, |l, cx| l.poll_vectored_write(cx, vec))
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_write_vectored(cx, bufs))
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -272,8 +272,9 @@ pub mod io {
 
     pub use futures_io::{
         AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, Error, ErrorKind,
-        Initializer, IoVec, Result, SeekFrom,
+        Initializer, IoSlice, IoSliceMut, Result, SeekFrom,
     };
+
     pub use futures_util::io::{
         AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt, AllowStdIo,
         Close, CopyInto, Flush, Read, ReadExact, ReadHalf, ReadToEnd, ReadUntil,


### PR DESCRIPTION
This replaces #1476.

~~`iovec` feature already in the FCP, so I think it's good to wait until it's stable.~~
Stabilized in https://github.com/rust-lang/rust/pull/60334.


Also, this renames `poll_vectored_*` to `poll_*_vectored` to make it in the same order as std.

Closes #1455