### PR TITLE
Remove #[allow(clippy::needless_lifetimes)]

### DIFF
--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -50,7 +50,6 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// future has been completed and [`take_output`](MaybeDone::take_output)
     /// has not yet been called.
     #[inline]
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn output_mut<'a>(self: Pin<&'a mut Self>) -> Option<&'a mut Fut::Output> {
         unsafe {
             let this = Pin::get_unchecked_mut(self);

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -33,7 +33,6 @@ impl<Si, F> SinkMapErr<Si, F> {
     }
 
     /// Get a pinned reference to the inner sink.
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
         unsafe { Pin::map_unchecked_mut(self, |x| &mut x.sink) }
     }

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -58,7 +58,6 @@ enum State<Fut, T> {
 }
 
 impl<Fut, T> State<Fut, T> {
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     #[allow(clippy::wrong_self_convention)]
     fn as_pin_mut<'a>(
         self: Pin<&'a mut Self>,

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -59,7 +59,6 @@ where
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
         unsafe { Pin::map_unchecked_mut(self, |x| &mut x.sink) }
     }

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -80,7 +80,6 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
         unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
     }

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -75,7 +75,6 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
         unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
     }

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -51,7 +51,6 @@ impl<St: Stream> Fuse<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
         unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
     }

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -195,7 +195,6 @@ impl<Fut> FuturesUnordered<Fut> {
     }
 
     /// Returns an iterator that allows modifying each future in the set.
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     pub fn iter_pin_mut<'a>(self: Pin<&'a mut Self>) -> IterPinMut<'a, Fut> {
         IterPinMut {
             task: self.head_all,

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -25,7 +25,6 @@ where
         FlattenSink(Waiting(future))
     }
 
-    #[allow(clippy::needless_lifetimes)] // https://github.com/rust-lang/rust/issues/52675
     fn project_pin<'a>(
         self: Pin<&'a mut Self>
     ) -> State<Pin<&'a mut Fut>, Pin<&'a mut Si>> {


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/52675 has not been fixed, but the current Clippy does not seem to warn we of this.