### PR TITLE
Add get_ref/get_mut/get_pin_mut/into_inner methods

### DIFF
--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -36,6 +36,24 @@ impl<Si: Sink<Item>, Item> Buffer<Si, Item> {
         &self.sink
     }
 
+    /// Get a mutable reference to the inner sink.
+    pub fn get_mut(&mut self) -> &mut Si {
+        &mut self.sink
+    }
+
+    /// Get a pinned mutable reference to the inner sink.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying sink.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> Si {
+        self.sink
+    }
+
     fn try_empty_buffer(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -34,6 +34,11 @@ impl<Si, E, Item> SinkErrInto<Si, Item, E>
         self.sink.get_mut()
     }
 
+    /// Get a pinned mutable reference to the inner sink.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying sink.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -21,6 +21,24 @@ impl<Si1, Si2> Fanout<Si1, Si2> {
         Fanout { sink1, sink2 }
     }
 
+    /// Get a shared reference to the inner sinks.
+    pub fn get_ref(&self) -> (&Si1, &Si2) {
+        (&self.sink1, &self.sink2)
+    }
+
+    /// Get a mutable reference to the inner sinks.
+    pub fn get_mut(&mut self) -> (&mut Si1, &mut Si2) {
+        (&mut self.sink1, &mut self.sink2)
+    }
+
+    /// Get a pinned mutable reference to the inner sinks.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut Si1>, Pin<&'a mut Si2>)
+        where Si1: Unpin, Si2: Unpin,
+    {
+        let Self { sink1, sink2 } = Pin::get_mut(self);
+        (Pin::new(sink1), Pin::new(sink2))
+    }
+
     /// Consumes this combinator, returning the underlying sinks.
     ///
     /// Note that this may discard intermediate state of this combinator,

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -32,9 +32,9 @@ impl<Si, F> SinkMapErr<Si, F> {
         &mut self.sink
     }
 
-    /// Get a pinned reference to the inner sink.
+    /// Get a pinned mutable reference to the inner sink.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
-        unsafe { Pin::map_unchecked_mut(self, |x| &mut x.sink) }
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
     }
 
     /// Consumes this combinator, returning the underlying sink.

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -107,6 +107,11 @@ impl<Si, Item, U, Fut, F, E> With<Si, Item, U, Fut, F>
         &mut self.sink
     }
 
+    /// Get a pinned mutable reference to the inner sink.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying sink.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -60,7 +60,7 @@ where
 
     /// Get a pinned mutable reference to the inner sink.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
-        unsafe { Pin::map_unchecked_mut(self, |x| &mut x.sink) }
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
     }
 
     /// Consumes this combinator, returning the underlying sink.

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -81,7 +81,7 @@ where
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
     }
 
     /// Consumes this combinator, returning the underlying stream.

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -70,13 +70,13 @@ where
         self.stream.get_mut()
     }
 
-    /// Acquires a mutable pinned reference to the underlying stream that this
+    /// Acquires a pinned mutable reference to the underlying stream that this
     /// combinator is pulling from.
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
     }
 
     /// Consumes this combinator, returning the underlying stream.

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -52,6 +52,15 @@ impl<St: Stream> Chunks<St> where St: Stream {
         self.stream.get_mut()
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/enumerate.rs
+++ b/futures-util/src/stream/enumerate.rs
@@ -24,6 +24,38 @@ impl<St: Stream> Enumerate<St> {
             count: 0,
         }
     }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut St {
+        &mut self.stream
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> St {
+        self.stream
+    }
 }
 
 impl<St: Stream + FusedStream> FusedStream for Enumerate<St> {

--- a/futures-util/src/stream/filter.rs
+++ b/futures-util/src/stream/filter.rs
@@ -53,6 +53,15 @@ where St: Stream,
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -52,6 +52,15 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -45,6 +45,15 @@ where St: Stream,
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -46,13 +46,13 @@ impl<St: Stream> Fuse<St> {
         &mut self.stream
     }
 
-    /// Acquires a mutable pinned reference to the underlying stream that this
+    /// Acquires a pinned mutable reference to the underlying stream that this
     /// combinator is pulling from.
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        unsafe { Pin::map_unchecked_mut(self, |x| x.get_mut()) }
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
     }
 
     /// Consumes this combinator, returning the underlying stream.

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -40,6 +40,15 @@ impl<St, F> Inspect<St, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/into_future.rs
+++ b/futures-util/src/stream/into_future.rs
@@ -16,6 +16,7 @@ impl<St: Stream + Unpin> StreamFuture<St> {
     pub(super) fn new(stream: St) -> StreamFuture<St> {
         StreamFuture { stream: Some(stream) }
     }
+
     /// Acquires a reference to the underlying stream that this combinator is
     /// pulling from.
     ///
@@ -39,6 +40,20 @@ impl<St: Stream + Unpin> StreamFuture<St> {
     /// an element.
     pub fn get_mut(&mut self) -> Option<&mut St> {
         self.stream.as_mut()
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    ///
+    /// This method returns an `Option` to account for the fact that `StreamFuture`'s
+    /// implementation of `Future::poll` consumes the underlying stream during polling
+    /// in order to return it to the caller of `Future::poll` if the stream yielded
+    /// an element.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Option<Pin<&'a mut St>> {
+        Pin::new(&mut Pin::get_mut(self).stream).as_pin_mut()
     }
 
     /// Consumes this combinator, returning the underlying stream.

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -40,6 +40,15 @@ impl<St, T, F> Map<St, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -30,6 +30,38 @@ impl<St: Stream> Peekable<St> {
         }
     }
 
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        self.stream.get_ref()
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut St {
+        self.stream.get_mut()
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> St {
+        self.stream.into_inner()
+    }
+
     /// Peek retrieves a reference to the next item in the stream.
     ///
     /// This method polls the underlying stream and return either a reference

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -25,6 +25,41 @@ impl<St1, St2> Select<St1, St2>
             flag: false,
         }
     }
+
+    /// Acquires a reference to the underlying streams that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> (&St1, &St2) {
+        (self.stream1.get_ref(), self.stream2.get_ref())
+    }
+
+    /// Acquires a mutable reference to the underlying streams that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> (&mut St1, &mut St2) {
+        (self.stream1.get_mut(), self.stream2.get_mut())
+    }
+
+    /// Acquires a pinned mutable reference to the underlying streams that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut St1>, Pin<&'a mut St2>)
+        where St1: Unpin, St2: Unpin,
+    {
+        let Self { stream1, stream2, .. } = Pin::get_mut(self);
+        (Pin::new(stream1.get_mut()), Pin::new(stream2.get_mut()))
+    }
+
+    /// Consumes this combinator, returning the underlying streams.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> (St1, St2) {
+        (self.stream1.into_inner(), self.stream2.into_inner())
+    }
 }
 
 impl<St1, St2> FusedStream for Select<St1, St2> {

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -40,6 +40,15 @@ impl<St: Stream> Skip<St> {
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -54,6 +54,15 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -40,6 +40,15 @@ impl<St: Stream> Take<St> {
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -54,6 +54,15 @@ impl<St, Fut, F> TakeWhile<St, Fut, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -31,6 +31,38 @@ impl<St, Fut, F> Then<St, Fut, F>
             f,
         }
     }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut St {
+        &mut self.stream
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> St {
+        self.stream
+    }
 }
 
 impl<St: FusedStream, Fut, F> FusedStream for Then<St, Fut, F> {

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -30,6 +30,41 @@ impl<St1: Stream, St2: Stream> Zip<St1, St2> {
             queued2: None,
         }
     }
+
+    /// Acquires a reference to the underlying streams that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> (&St1, &St2) {
+        (self.stream1.get_ref(), self.stream2.get_ref())
+    }
+
+    /// Acquires a mutable reference to the underlying streams that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> (&mut St1, &mut St2) {
+        (self.stream1.get_mut(), self.stream2.get_mut())
+    }
+
+    /// Acquires a pinned mutable reference to the underlying streams that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut St1>, Pin<&'a mut St2>)
+        where St1: Unpin, St2: Unpin,
+    {
+        let Self { stream1, stream2, .. } = Pin::get_mut(self);
+        (Pin::new(stream1.get_mut()), Pin::new(stream2.get_mut()))
+    }
+
+    /// Consumes this combinator, returning the underlying streams.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> (St1, St2) {
+        (self.stream1.into_inner(), self.stream2.into_inner())
+    }
 }
 
 impl<St1, St2> FusedStream for Zip<St1, St2>

--- a/futures-util/src/try_stream/and_then.rs
+++ b/futures-util/src/try_stream/and_then.rs
@@ -42,6 +42,15 @@ impl<St, Fut, F> AndThen<St, Fut, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/try_stream/err_into.rs
+++ b/futures-util/src/try_stream/err_into.rs
@@ -21,6 +21,38 @@ impl<St, E> ErrInto<St, E> {
     pub(super) fn new(stream: St) -> Self {
         ErrInto { stream, _marker: PhantomData }
     }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut St {
+        &mut self.stream
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> St {
+        self.stream
+    }
 }
 
 impl<St: FusedStream, E> FusedStream for ErrInto<St, E> {

--- a/futures-util/src/try_stream/into_stream.rs
+++ b/futures-util/src/try_stream/into_stream.rs
@@ -27,11 +27,26 @@ impl<St> IntoStream<St> {
 
     /// Acquires a mutable reference to the underlying stream that this
     /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
     pub fn get_mut(&mut self) -> &mut St {
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
     pub fn into_inner(self) -> St {
         self.stream
     }

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -20,6 +20,38 @@ impl<St, F> MapErr<St, F> {
     pub(super) fn new(stream: St, f: F) -> Self {
         MapErr { stream, f }
     }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut St {
+        &mut self.stream
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> St {
+        self.stream
+    }
 }
 
 impl<St: Unpin, F> Unpin for MapErr<St, F> {}

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -20,6 +20,38 @@ impl<St, F> MapOk<St, F> {
     pub(super) fn new(stream: St, f: F) -> Self {
         MapOk { stream, f }
     }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &St {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut St {
+        &mut self.stream
+    }
+
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> St {
+        self.stream
+    }
 }
 
 impl<St: Unpin, F> Unpin for MapOk<St, F> {}

--- a/futures-util/src/try_stream/or_else.rs
+++ b/futures-util/src/try_stream/or_else.rs
@@ -42,6 +42,15 @@ impl<St, Fut, F> OrElse<St, Fut, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/try_stream/try_buffer_unordered.rs
@@ -54,6 +54,15 @@ impl<St> TryBufferUnordered<St>
         self.stream.get_mut().get_mut()
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/try_stream/try_filter_map.rs
+++ b/futures-util/src/try_stream/try_filter_map.rs
@@ -43,6 +43,15 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so

--- a/futures-util/src/try_stream/try_skip_while.rs
+++ b/futures-util/src/try_stream/try_skip_while.rs
@@ -55,6 +55,15 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
         &mut self.stream
     }
 
+    /// Acquires a pinned mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+        unsafe { Pin::map_unchecked_mut(self, Self::get_mut) }
+    }
+
     /// Consumes this combinator, returning the underlying stream.
     ///
     /// Note that this may discard intermediate state of this combinator, so


### PR DESCRIPTION
This adds get_ref/get_mut/get_pin_mut/into_inner methods to stream/sink combinators.

Currently, some combinators have these methods (e.g., [`stream::Buffered`](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.14/futures/stream/struct.Buffered.html#methods)), but I think that more combinators can be implemented.

Related https://github.com/rust-lang-nursery/futures-rs/commit/dd6b045693f3d1ae611f4b9f9afd739a3be30939, https://github.com/rust-lang-nursery/futures-rs/issues/633

Closes https://github.com/rust-lang-nursery/futures-rs/issues/573
Closes https://github.com/rust-lang-nursery/futures-rs/issues/400

(These issues are feature requirements for 0.1, but we will not actively develop 0.1, so closes by this PR)
