### PR TITLE
Move non-stable Rust features behind Cargo features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ matrix:
     - name: cargo build (default features)
       rust: nightly
       script:
+        - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         - cargo build --all
 
     - name: cargo build (compat feature)

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,12 @@ matrix:
         - cargo bench --all
         - cargo bench --manifest-path futures-util/Cargo.toml --features=bench
 
-    - name: cargo build --no-default-features
+    - name: cargo +stable build --no-default-features
       rust: nightly
+      env:
+        - RUSTFLAGS="-Z allow-features="
       script:
+        - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         - cargo build --manifest-path futures/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-core/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-channel/Cargo.toml --no-default-features
@@ -54,23 +57,31 @@ matrix:
         - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features
         - cargo build --manifest-path futures-util/Cargo.toml --no-default-features
 
-    - name: cargo build (alloc)
+    - name: cargo +stable build (alloc)
       rust: nightly
+      env:
+        - RUSTFLAGS="-Z allow-features="
       script:
-        - cargo build --manifest-path futures/Cargo.toml --no-default-features --features alloc,nightly
-        - cargo build --manifest-path futures-core/Cargo.toml --no-default-features --features alloc,nightly
-        - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features --features alloc,nightly
-        - cargo build --manifest-path futures-util/Cargo.toml --no-default-features --features alloc,nightly
+        - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
+        - cargo build --manifest-path futures/Cargo.toml --no-default-features --features alloc
+        - cargo build --manifest-path futures-core/Cargo.toml --no-default-features --features alloc
+        - cargo build --manifest-path futures-sink/Cargo.toml --no-default-features --features alloc
+        - cargo build --manifest-path futures-util/Cargo.toml --no-default-features --features alloc
 
-    - name: cargo build (default features)
+    - name: cargo +stable build (default features)
       rust: nightly
+      env:
+        - RUSTFLAGS="-Z allow-features="
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         - cargo build --all
 
-    - name: cargo build (compat feature)
+    - name: cargo +stable build (compat feature)
       rust: nightly
+      env:
+        - RUSTFLAGS="-Z allow-features="
       script:
+        - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
 
     - name: cargo build --target=thumbv6m-none-eabi

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -1,6 +1,5 @@
 //! Utilities to make testing [`Future`s](futures_core::Future) easier
 
-#![feature(async_await, await_macro)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(
     html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.5/futures_test"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -15,8 +15,9 @@ Common utilities and extension traits for the futures-rs library.
 name = "futures_util"
 
 [features]
-std = ["alloc", "futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-select-macro-preview/std", "rand", "rand_core", "slab", "memchr"]
+std = ["alloc", "futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "slab", "memchr"]
 default = ["std"]
+async-await = ["std", "futures-select-macro-preview", "proc-macro-hack", "proc-macro-nested", "rand", "rand_core"]
 compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
@@ -30,9 +31,9 @@ futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.14", 
 futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.14", default-features = false }
 futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.14", default-features = false }
 futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.14", default-features = false}
-futures-select-macro-preview = { path = "../futures-select-macro", version = "=0.3.0-alpha.14", default-features = false }
-proc-macro-hack = "0.5"
-proc-macro-nested = "0.1.2"
+futures-select-macro-preview = { path = "../futures-select-macro", version = "=0.3.0-alpha.14", default-features = false, optional = true }
+proc-macro-hack = { version = "0.5", optional = true }
+proc-macro-nested = { version = "0.1.2", optional = true }
 rand = { version = "0.6.4", optional = true }
 rand_core = { version = ">=0.2.2, <0.4", optional = true } # See https://github.com/rust-random/rand/issues/645
 slab = { version = "0.4", optional = true }
@@ -42,7 +43,7 @@ tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
-futures-preview = { path = "../futures", version = "=0.3.0-alpha.14" }
+futures-preview = { path = "../futures", version = "=0.3.0-alpha.14", features = ["async-await", "nightly"] }
 futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.14" }
 futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.14" }
 tokio = "0.1.11"

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -116,7 +116,7 @@ where
     I::Item: Future,
 {
     let elems: Box<[_]> = i.into_iter().map(ElemState::Pending).collect();
-    JoinAll { elems: Box::into_pin(elems) }
+    JoinAll { elems: elems.into() }
 }
 
 impl<F> Future for JoinAll<F>

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -2,7 +2,7 @@
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
 #![cfg_attr(feature = "alloc", feature(box_into_pin))]
-#![cfg_attr(feature = "std", feature(async_await, await_macro))]
+#![cfg_attr(feature = "async-await", feature(async_await, await_macro))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "never-type", feature(never_type))]
 
@@ -17,21 +17,24 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` featu
 #[cfg(all(feature = "never-type", not(feature = "nightly")))]
 compile_error!("The `never-type` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
+#[cfg(all(feature = "async-await", not(feature = "nightly")))]
+compile_error!("The `async-await` feature requires the `nightly` feature as an explicit opt-in to unstable features");
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[macro_use]
 mod macros;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 #[macro_use]
 #[doc(hidden)]
 pub mod async_await;
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub use self::async_await::*;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub mod rand_reexport { // used by select!
     pub use rand::*;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -1,7 +1,6 @@
 //! Combinators and utilities for working with `Future`s, `Stream`s, `Sink`s,
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
-#![cfg_attr(feature = "alloc", feature(box_into_pin))]
 #![cfg_attr(feature = "async-await", feature(async_await, await_macro))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "never-type", feature(never_type))]

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -125,7 +125,7 @@ where
 {
     let elems: Box<[_]> = i.into_iter().map(ElemState::Pending).collect();
     TryJoinAll {
-        elems: Box::into_pin(elems),
+        elems: elems.into(),
     }
 }
 

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -38,6 +38,7 @@ tokio = "0.1.11"
 [features]
 nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly", "futures-util-preview/nightly"]
 std = ["alloc", "futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std"]
+async-await = ["futures-util-preview/async-await"]
 default = ["std"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -30,6 +30,9 @@
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.14/futures")]
 
+#[cfg(all(feature = "async-await", not(feature = "nightly")))]
+compile_error!("The `async-await` feature requires the `nightly` feature as an explicit opt-in to unstable features");
+
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
@@ -58,7 +61,7 @@ pub use futures_util::{
     // Error/readiness propagation
     try_ready, ready,
 };
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 pub use futures_util::{
     // Async-await
     join, try_join, pending, poll,
@@ -455,17 +458,17 @@ pub mod task {
 
 // `select!` re-export --------------------------------------
 
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub use futures_util::rand_reexport;
 
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub mod inner_select {
     pub use futures_util::select;
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "async-await")]
 futures_util::document_select_macro! {
     #[macro_export]
     macro_rules! select { // replace `::futures_util` with `::futures` as the crate path


### PR DESCRIPTION
This gets the crates to a point where they should compile on stable 1.36 when it is released. The travis jobs have been updated to make the compiler act like a stable compiler where possible to catch any regressions.