### PR TITLE
Non-Send boxed()

### DIFF
--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -16,7 +16,7 @@ pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send 
 
 #[cfg(feature = "alloc")]
 /// `BoxFuture`, but without the `Send` requirement.
-pub type BoxFutureLocal<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
+pub type LocalBoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
 
 /// A `Future` or `TryFuture` which tracks whether or not the underlying future
 /// should no longer be polled.

--- a/futures-core/src/future/mod.rs
+++ b/futures-core/src/future/mod.rs
@@ -14,6 +14,10 @@ pub use self::future_obj::{FutureObj, LocalFutureObj, UnsafeFutureObj};
 /// statically type your result or need to add some indirection.
 pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send + 'a>>;
 
+#[cfg(feature = "alloc")]
+/// `BoxFuture`, but without the `Send` requirement.
+pub type BoxFutureLocal<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
+
 /// A `Future` or `TryFuture` which tracks whether or not the underlying future
 /// should no longer be polled.
 ///

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -10,7 +10,7 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
-use futures_core::future::{BoxFuture, BoxFutureLocal};
+use futures_core::future::{BoxFuture, LocalBoxFuture};
 
 // re-export for `select!`
 #[doc(hidden)]
@@ -503,7 +503,7 @@ pub trait FutureExt: Future {
     ///
     /// Similar to `boxed`, but without the `Send` requirement.
     #[cfg(feature = "alloc")]
-    fn boxed_local<'a>(self) -> BoxFutureLocal<'a, Self::Output>
+    fn boxed_local<'a>(self) -> LocalBoxFuture<'a, Self::Output>
         where Self: Sized + 'a
     {
         Box::pin(self)

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -10,7 +10,7 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
-use futures_core::future::BoxFuture;
+use futures_core::future::{BoxFuture, BoxFutureLocal};
 
 // re-export for `select!`
 #[doc(hidden)]
@@ -495,6 +495,16 @@ pub trait FutureExt: Future {
     #[cfg(feature = "alloc")]
     fn boxed<'a>(self) -> BoxFuture<'a, Self::Output>
         where Self: Sized + Send + 'a
+    {
+        Box::pin(self)
+    }
+
+    /// Wrap the future in a Box, pinning it.
+    ///
+    /// Similar to `boxed`, but without the `Send` requirement.
+    #[cfg(feature = "alloc")]
+    fn boxed_local<'a>(self) -> BoxFutureLocal<'a, Self::Output>
+        where Self: Sized + 'a
     {
         Box::pin(self)
     }


### PR DESCRIPTION
This PR adds non-`Send` versions of `BoxFuture` and `boxed()`, prompted by the `Send` requirement in #1494 (and thus the latest release) breaking some of our code. This allows avoiding unnecessary `Send` bounds in generic-heavy code.