### PR TITLE
Remove uses of try_ready! macro

### DIFF
--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -45,7 +45,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
             // If our buffer is empty, then we need to read some data to
             // continue.
             if this.pos == this.cap && !this.read_done {
-                let n = try_ready!(Pin::new(&mut this.reader).poll_read(cx, &mut this.buf));
+                let n = ready!(Pin::new(&mut this.reader).poll_read(cx, &mut this.buf))?;
                 if n == 0 {
                     this.read_done = true;
                 } else {
@@ -56,7 +56,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
 
             // If our buffer has some data, let's write it out!
             while this.pos < this.cap {
-                let i = try_ready!(Pin::new(&mut this.writer).poll_write(cx, &this.buf[this.pos..this.cap]));
+                let i = ready!(Pin::new(&mut this.writer).poll_write(cx, &this.buf[this.pos..this.cap]))?;
                 if i == 0 {
                     return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
                 } else {
@@ -69,7 +69,7 @@ impl<R, W> Future for CopyInto<'_, R, W>
             // data and finish the transfer.
             // done with the entire transfer.
             if this.pos == this.cap && this.read_done {
-                try_ready!(Pin::new(&mut this.writer).poll_flush(cx));
+                ready!(Pin::new(&mut this.writer).poll_flush(cx))?;
                 return Poll::Ready(Ok(this.amt));
             }
         }

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -26,7 +26,7 @@ impl<R: AsyncRead + ?Sized + Unpin> Future for ReadExact<'_, R> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = &mut *self;
         while !this.buf.is_empty() {
-            let n = try_ready!(Pin::new(&mut this.reader).poll_read(cx, this.buf));
+            let n = ready!(Pin::new(&mut this.reader).poll_read(cx, this.buf))?;
             {
                 let (_, rest) = mem::replace(&mut this.buf, &mut []).split_at_mut(n);
                 this.buf = rest;

--- a/futures-util/src/io/read_until.rs
+++ b/futures-util/src/io/read_until.rs
@@ -31,7 +31,7 @@ fn read_until_internal<R: AsyncBufRead + ?Sized + Unpin>(
 ) -> Poll<io::Result<usize>> {
     loop {
         let (done, used) = {
-            let available = try_ready!(reader.as_mut().poll_fill_buf(cx));
+            let available = ready!(reader.as_mut().poll_fill_buf(cx))?;
             if let Some(i) = memchr::memchr(byte, available) {
                 buf.extend_from_slice(&available[..=i]);
                 (true, i + 1)

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -26,7 +26,7 @@ impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteAll<'_, W> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = &mut *self;
         while !this.buf.is_empty() {
-            let n = try_ready!(Pin::new(&mut this.writer).poll_write(cx, this.buf));
+            let n = ready!(Pin::new(&mut this.writer).poll_write(cx, this.buf))?;
             {
                 let (_, rest) = mem::replace(&mut this.buf, &[]).split_at(n);
                 this.buf = rest;

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -58,13 +58,13 @@ impl<Si: Sink<Item>, Item> Buffer<Si, Item> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Si::SinkError>> {
-        try_ready!(self.as_mut().sink().poll_ready(cx));
+        ready!(self.as_mut().sink().poll_ready(cx))?;
         while let Some(item) = self.as_mut().buf().pop_front() {
             if let Err(e) = self.as_mut().sink().start_send(item) {
                 return Poll::Ready(Err(e));
             }
             if !self.buf.is_empty() {
-                try_ready!(self.as_mut().sink().poll_ready(cx));
+                ready!(self.as_mut().sink().poll_ready(cx))?;
             }
         }
         Poll::Ready(Ok(()))
@@ -118,7 +118,7 @@ impl<Si: Sink<Item>, Item> Sink<Item> for Buffer<Si, Item> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::SinkError>> {
-        try_ready!(self.as_mut().try_empty_buffer(cx));
+        ready!(self.as_mut().try_empty_buffer(cx))?;
         debug_assert!(self.as_mut().buf().is_empty());
         self.as_mut().sink().poll_flush(cx)
     }
@@ -127,7 +127,7 @@ impl<Si: Sink<Item>, Item> Sink<Item> for Buffer<Si, Item> {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::SinkError>> {
-        try_ready!(self.as_mut().try_empty_buffer(cx));
+        ready!(self.as_mut().try_empty_buffer(cx))?;
         debug_assert!(self.as_mut().buf().is_empty());
         self.as_mut().sink().poll_close(cx)
     }

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -49,7 +49,7 @@ impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Send<'_, Si, Item> {
 
         // we're done sending the item, but want to block on flushing the
         // sink
-        try_ready!(Pin::new(&mut this.sink).poll_flush(cx));
+        ready!(Pin::new(&mut this.sink).poll_flush(cx))?;
 
         Poll::Ready(Ok(()))
     }

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -75,20 +75,20 @@ where
         // If we've got an item buffered already, we need to write it to the
         // sink before we can do anything else
         if let Some(item) = this.buffered.take() {
-            try_ready!(this.try_start_send(cx, item))
+            ready!(this.try_start_send(cx, item))?
         }
 
         loop {
             match this.stream.poll_next_unpin(cx) {
                 Poll::Ready(Some(item)) => {
-                    try_ready!(this.try_start_send(cx, item))
+                    ready!(this.try_start_send(cx, item))?
                 }
                 Poll::Ready(None) => {
-                    try_ready!(Pin::new(&mut this.sink).poll_flush(cx));
+                    ready!(Pin::new(&mut this.sink).poll_flush(cx))?;
                     return Poll::Ready(Ok(()))
                 }
                 Poll::Pending => {
-                    try_ready!(Pin::new(&mut this.sink).poll_flush(cx));
+                    ready!(Pin::new(&mut this.sink).poll_flush(cx))?;
                     return Poll::Pending
                 }
             }

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -126,7 +126,7 @@ impl<Si, Item, U, Fut, F, E> With<Si, Item, U, Fut, F>
     ) -> Poll<Result<(), E>> {
         let buffered = match self.as_mut().state().as_pin_mut() {
             State::Empty => return Poll::Ready(Ok(())),
-            State::Process(fut) => Some(try_ready!(fut.poll(cx))),
+            State::Process(fut) => Some(ready!(fut.poll(cx))?),
             State::Buffered(_) => None,
         };
         if let Some(buffered) = buffered {
@@ -168,8 +168,8 @@ impl<Si, Item, U, Fut, F, E> Sink<U> for With<Si, Item, U, Fut, F>
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::SinkError>> {
-        try_ready!(self.as_mut().poll(cx));
-        try_ready!(self.as_mut().sink().poll_flush(cx));
+        ready!(self.as_mut().poll(cx))?;
+        ready!(self.as_mut().sink().poll_flush(cx))?;
         Poll::Ready(Ok(()))
     }
 
@@ -177,8 +177,8 @@ impl<Si, Item, U, Fut, F, E> Sink<U> for With<Si, Item, U, Fut, F>
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::SinkError>> {
-        try_ready!(self.as_mut().poll(cx));
-        try_ready!(self.as_mut().sink().poll_close(cx));
+        ready!(self.as_mut().poll(cx))?;
+        ready!(self.as_mut().sink().poll_close(cx))?;
         Poll::Ready(Ok(()))
     }
 }

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -81,13 +81,13 @@ where
         let mut stream = unsafe { Pin::new_unchecked(stream) };
 
         if buffer.is_some() {
-            try_ready!(sink.as_mut().poll_ready(cx));
+            ready!(sink.as_mut().poll_ready(cx))?;
             let item = buffer.take().unwrap();
-            try_ready!(Poll::Ready(sink.as_mut().start_send(item)));
+            ready!(Poll::Ready(sink.as_mut().start_send(item)))?;
         }
         if let Some(mut some_stream) = stream.as_mut().as_pin_mut() {
             while let Some(x) = ready!(some_stream.as_mut().poll_next(cx)) {
-                let item = try_ready!(Poll::Ready(x));
+                let item = ready!(Poll::Ready(x))?;
                 match sink.as_mut().poll_ready(cx)? {
                     Poll::Ready(()) => sink.as_mut().start_send(item)?,
                     Poll::Pending => {

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -73,23 +73,21 @@ where
         // If we've got an item buffered already, we need to write it to the
         // sink before we can do anything else
         if let Some(item) = self.as_mut().buffered_item().take() {
-            try_ready!(self.as_mut().try_start_send(cx, item));
+            ready!(self.as_mut().try_start_send(cx, item))?;
         }
 
         loop {
             match self.as_mut().stream().poll_next(cx) {
                 Poll::Ready(Some(Ok(item))) =>
-                   try_ready!(self.as_mut().try_start_send(cx, item)),
+                   ready!(self.as_mut().try_start_send(cx, item))?,
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Err(e)),
                 Poll::Ready(None) => {
-                    try_ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL)
-                                   .poll_close(cx));
+                    ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL).poll_close(cx))?;
                     self.as_mut().sink().set(None);
                     return Poll::Ready(Ok(()))
                 }
                 Poll::Pending => {
-                    try_ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL)
-                                   .poll_flush(cx));
+                    ready!(self.as_mut().sink().as_pin_mut().expect(INVALID_POLL).poll_flush(cx))?;
                     return Poll::Pending
                 }
             }

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -75,7 +75,7 @@ impl<S: Sink<Item>, Item> Sink<Item> for SplitSink<S, Item> {
             if self.slot.is_none() {
                 return Poll::Ready(Ok(()));
             }
-            try_ready!(self.as_mut().poll_flush(cx));
+            ready!(self.as_mut().poll_flush(cx))?;
         }
     }
 
@@ -89,7 +89,7 @@ impl<S: Sink<Item>, Item> Sink<Item> for SplitSink<S, Item> {
         match this.lock.poll_lock(cx) {
             Poll::Ready(mut inner) => {
                 if this.slot.is_some() {
-                    try_ready!(inner.as_pin_mut().poll_ready(cx));
+                    ready!(inner.as_pin_mut().poll_ready(cx))?;
                     if let Err(e) = inner.as_pin_mut().start_send(this.slot.take().unwrap()) {
                         return Poll::Ready(Err(e));
                     }
@@ -105,7 +105,7 @@ impl<S: Sink<Item>, Item> Sink<Item> for SplitSink<S, Item> {
         match this.lock.poll_lock(cx) {
             Poll::Ready(mut inner) => {
                 if this.slot.is_some() {
-                    try_ready!(inner.as_pin_mut().poll_ready(cx));
+                    ready!(inner.as_pin_mut().poll_ready(cx))?;
                     if let Err(e) = inner.as_pin_mut().start_send(this.slot.take().unwrap()) {
                         return Poll::Ready(Err(e));
                     }

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -51,7 +51,7 @@ where
     ) -> Poll<Result<(), Self::SinkError>> {
         let resolved_stream = match self.as_mut().project_pin() {
             Ready(s) => return s.poll_ready(cx),
-            Waiting(f) => try_ready!(f.try_poll(cx)),
+            Waiting(f) => ready!(f.try_poll(cx))?,
             Closed => panic!("poll_ready called after eof"),
         };
         self.set(FlattenSink(Ready(resolved_stream)));

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -43,7 +43,7 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             if let Some(future) = self.as_mut().future().as_pin_mut() {
-                try_ready!(future.try_poll(cx));
+                ready!(future.try_poll(cx))?;
             }
             self.as_mut().future().set(None);
 

--- a/futures/tests_disabled/sink.rs
+++ b/futures/tests_disabled/sink.rs
@@ -125,7 +125,7 @@ impl<S: Sink> Future for StartSendFut<S> {
     fn poll(&mut self, cx: &mut Context<'_>) -> Poll<S, S::SinkError> {
         {
             let inner = self.0.as_mut().unwrap();
-            try_ready!(inner.poll_ready(cx));
+            ready!(inner.poll_ready(cx))?;
             inner.start_send(self.1.take().unwrap())?;
         }
         Ok(Poll::Ready(self.0.take().unwrap()))

--- a/futures/tests_disabled/stream.rs
+++ b/futures/tests_disabled/stream.rs
@@ -290,7 +290,7 @@ fn peek() {
 
         fn poll(&mut self, cx: &mut Context<'_>) -> Poll<(), u32> {
             {
-                let res = try_ready!(self.inner.peek(cx));
+                let res = ready!(self.inner.peek(cx))?;
                 assert_eq!(res, Some(&1));
             }
             assert_eq!(self.inner.peek(cx).unwrap(), Some(&1).into());


### PR DESCRIPTION
`try_ready!(..)` is equivalent to `ready!(..)?` and `ready!(..?)`, but the alternatives are shorter.

(Also, `ready!(..)?` is actually more powerful because it can handle `Poll<Option<Result>>`.)