### PR TITLE
Re-export io traits to prelude and top-level

### DIFF
--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -99,7 +99,7 @@ pub mod compat;
 #[cfg(feature = "std")]
 pub mod io;
 #[cfg(feature = "std")]
-#[doc(hidden)] pub use crate::io::{AsyncReadExt, AsyncWriteExt, AsyncBufReadExt};
+#[doc(hidden)] pub use crate::io::{AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt};
 
 cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -54,6 +54,11 @@ compile_error!("The `never-type` feature requires the `nightly` feature as an ex
 #[doc(hidden)] pub use futures_sink::Sink;
 #[doc(hidden)] pub use futures_util::sink::SinkExt;
 
+#[cfg(feature = "std")]
+#[doc(hidden)] pub use futures_io::{AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead};
+#[cfg(feature = "std")]
+#[doc(hidden)] pub use futures_util::{AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt};
+
 #[doc(hidden)] pub use futures_core::task::Poll;
 
 // Macro reexports
@@ -305,7 +310,10 @@ pub mod prelude {
     pub use crate::sink::{self, Sink, SinkExt};
 
     #[cfg(feature = "std")]
-    pub use crate::io::{ AsyncRead, AsyncWrite, AsyncReadExt, AsyncWriteExt };
+    pub use crate::io::{
+        AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead,
+        AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt,
+    };
 }
 
 pub mod sink {


### PR DESCRIPTION
Current intra-doc generates errors based on the path of where it is actually defined and generates an actual link based on the path of where it is exposed to the public.

For example, clicking on `flush` in [doc of futures](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures/io/struct.Flush.html) does not jump to the method. In [doc of futures_util](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_util/io/struct.Flush.html), on the other hand, the link works.

This PR avoids these problems and also do some re-exports that I forgot.