### PR TITLE
Minimize re-exports from rand

### DIFF
--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -262,7 +262,7 @@ pub fn select(input: TokenStream) -> TokenStream {
             #( #poll_functions )*
 
             let mut __select_arr = [#( #variant_names ),*];
-            <[_] as #rand_crate::prelude::SliceRandom>::shuffle(
+            <[_] as #rand_crate::SliceRandom>::shuffle(
                 &mut __select_arr,
                 &mut #rand_crate::thread_rng(),
             );

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -36,7 +36,12 @@ pub use self::async_await::*;
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub mod rand_reexport { // used by select!
-    pub use rand::*;
+    pub use rand::{prelude::SliceRandom, thread_rng};
+
+    // HACK: Define dummy `ThreadRng` to avoid `intra_doc_link_resolution_failure` warning.
+    #[allow(missing_debug_implementations)]
+    #[doc(hidden)]
+    pub struct ThreadRng {}
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
This should avoid all doc errors from rand.