### PR TITLE
Replace await! macro with await syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
 
     # When updating this, the reminder to update the minimum required version in README.md.
     - name: cargo test (minimum required version)
-      rust: nightly-2019-04-30
+      rust: nightly-2019-05-09
 
     - name: cargo clippy
       rust: nightly

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Now, you can use futures-rs:
 use futures::future::Future; // Note: It's not `futures_preview`
 ```
 
-The current version of futures-rs requires Rust nightly 2019-04-30 or later.
+The current version of futures-rs requires Rust nightly 2019-05-09 or later.
 
 ### Feature `std`
 

--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::channel::mpsc;
 use futures::executor::block_on;
@@ -28,7 +28,7 @@ fn sequence() {
 
 async fn send_sequence(n: u32, mut sender: mpsc::Sender<u32>) {
     for x in 0..n {
-        await!(sender.send(n - x)).unwrap();
+        sender.send(n - x).await.unwrap();
     }
 }
 

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};
@@ -357,7 +357,7 @@ fn stress_drop_sender() {
 
 async fn send_one_two_three(mut tx: mpsc::Sender<i32>) {
     for i in 1..=3 {
-        await!(tx.send(i)).unwrap();
+        tx.send(i).await.unwrap();
     }
 }
 
@@ -403,7 +403,7 @@ fn stress_close_receiver() {
 
 async fn stress_poll_ready_sender(mut sender: mpsc::Sender<u32>, count: u32) {
     for i in (1..=count).rev() {
-        await!(sender.send(i)).unwrap();
+        sender.send(i).await.unwrap();
     }
 }
 

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -247,7 +247,7 @@ pub fn select(input: TokenStream) -> TokenStream {
         }
     } else {
         quote! {
-            match r#await!(#futures_crate::future::poll_fn(__poll_fn)) {
+            match #futures_crate::future::poll_fn(__poll_fn).await {
                 #branches
             }
         }

--- a/futures-util/src/async_await/join.rs
+++ b/futures-util/src/async_await/join.rs
@@ -3,7 +3,7 @@
 /// Polls multiple futures simultaneously, returning a tuple
 /// of all results once complete.
 ///
-/// While `join!(a, b)` is similar to `(await!(a), await!(b))`,
+/// While `join!(a, b)` is similar to `(a.await, b.await)`,
 /// `join!` polls both futures concurrently and therefore is more efficent.
 ///
 /// This macro is only usable inside of async functions, closures, and blocks.
@@ -13,7 +13,7 @@
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::{join, future};
 ///
@@ -31,7 +31,7 @@ macro_rules! join {
             // is no longer accessible by the end user.
             let mut $fut = $crate::future::maybe_done($fut);
         )*
-        await!($crate::future::poll_fn(move |cx| {
+        $crate::future::poll_fn(move |cx| {
             let mut all_done = true;
             $(
                 all_done &= $crate::core_reexport::future::Future::poll(
@@ -44,7 +44,7 @@ macro_rules! join {
             } else {
                 $crate::core_reexport::task::Poll::Pending
             }
-        }))
+        }).await
     } }
 }
 
@@ -64,7 +64,7 @@ macro_rules! join {
 /// `Ok` of a tuple of the values:
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::{try_join, future};
 ///
@@ -79,7 +79,7 @@ macro_rules! join {
 /// that error:
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::{try_join, future};
 ///
@@ -98,7 +98,7 @@ macro_rules! try_join {
             let mut $fut = $crate::future::maybe_done($fut);
         )*
 
-        let res: $crate::core_reexport::result::Result<_, _> = await!($crate::future::poll_fn(move |cx| {
+        let res: $crate::core_reexport::result::Result<_, _> = $crate::future::poll_fn(move |cx| {
             let mut all_done = true;
             $(
                 if $crate::core_reexport::future::Future::poll(
@@ -126,7 +126,7 @@ macro_rules! try_join {
             } else {
                 $crate::core_reexport::task::Poll::Pending
             }
-        }));
+        }).await;
 
         res
     } }

--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -15,7 +15,7 @@ use futures_core::task::{Context, Poll};
 #[macro_export]
 macro_rules! pending {
     () => {
-        await!($crate::async_await::pending_once())
+        $crate::async_await::pending_once().await
     }
 }
 

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -11,7 +11,7 @@ use futures_core::task::{Context, Poll};
 #[macro_export]
 macro_rules! poll {
     ($x:expr) => {
-        await!($crate::async_await::poll($x))
+        $crate::async_await::poll($x).await
     }
 }
 

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -26,7 +26,7 @@ macro_rules! document_select_macro {
         /// # Examples
         ///
         /// ```
-        /// #![feature(async_await, await_macro)]
+        /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
         /// use futures::future::{self, FutureExt};
         /// use futures::select;
@@ -42,7 +42,7 @@ macro_rules! document_select_macro {
         /// ```
         ///
         /// ```
-        /// #![feature(async_await, await_macro)]
+        /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
         /// use futures::future::{self, FutureExt};
         /// use futures::stream::{self, StreamExt};
@@ -64,7 +64,7 @@ macro_rules! document_select_macro {
         /// the case where all futures have completed.
         ///
         /// ```
-        /// #![feature(async_await, await_macro)]
+        /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
         /// use futures::future::{self, FutureExt};
         /// use futures::select;

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -52,14 +52,14 @@ pub trait Future01CompatExt: Future01 {
     /// [`Future<Output = Result<T, E>>`](futures_core::future::Future).
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// # // TODO: These should be all using `futures::compat`, but that runs up against Cargo
     /// # // feature issues
     /// use futures_util::compat::Future01CompatExt;
     ///
     /// let future = futures_01::future::ok::<u32, ()>(1);
-    /// assert_eq!(await!(future.compat()), Ok(1));
+    /// assert_eq!(future.compat().await, Ok(1));
     /// # });
     /// ```
     fn compat(self) -> Compat01As03<Self>
@@ -79,15 +79,15 @@ pub trait Stream01CompatExt: Stream01 {
     /// [`Stream<Item = Result<T, E>>`](futures_core::stream::Stream).
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::stream::StreamExt;
     /// use futures_util::compat::Stream01CompatExt;
     ///
     /// let stream = futures_01::stream::once::<u32, ()>(Ok(1));
     /// let mut stream = stream.compat();
-    /// assert_eq!(await!(stream.next()), Some(Ok(1)));
-    /// assert_eq!(await!(stream.next()), None);
+    /// assert_eq!(stream.next().await, Some(Ok(1)));
+    /// assert_eq!(stream.next().await, None);
     /// # });
     /// ```
     fn compat(self) -> Compat01As03<Self>
@@ -107,7 +107,7 @@ pub trait Sink01CompatExt: Sink01 {
     /// [`Sink<SinkItem = T, SinkError = E>`](futures_sink::sink::Sink).
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::{sink::SinkExt, stream::StreamExt};
     /// use futures_util::compat::{Stream01CompatExt, Sink01CompatExt};
@@ -115,10 +115,10 @@ pub trait Sink01CompatExt: Sink01 {
     /// let (tx, rx) = futures_01::unsync::mpsc::channel(1);
     /// let (mut tx, mut rx) = (tx.sink_compat(), rx.compat());
     ///
-    /// await!(tx.send(1)).unwrap();
+    /// tx.send(1).await.unwrap();
     /// drop(tx);
-    /// assert_eq!(await!(rx.next()), Some(Ok(1)));
-    /// assert_eq!(await!(rx.next()), None);
+    /// assert_eq!(rx.next().await, Some(Ok(1)));
+    /// assert_eq!(rx.next().await, None);
     /// # });
     /// ```
     fn sink_compat(self) -> Compat01As03Sink<Self, Self::SinkItem>
@@ -356,7 +356,7 @@ mod io {
         /// [`AsyncRead`](futures_io::AsyncRead).
         ///
         /// ```
-        /// #![feature(async_await, await_macro, impl_trait_in_bindings)]
+        /// #![feature(async_await, impl_trait_in_bindings)]
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncReadExt;
         /// use futures_util::compat::AsyncRead01CompatExt;
@@ -366,7 +366,7 @@ mod io {
         /// let mut reader: impl futures::io::AsyncRead + Unpin = reader.compat();
         ///
         /// let mut output = Vec::with_capacity(12);
-        /// await!(reader.read_to_end(&mut output)).unwrap();
+        /// reader.read_to_end(&mut output).await.unwrap();
         /// assert_eq!(output, input);
         /// # });
         /// ```
@@ -385,7 +385,7 @@ mod io {
         /// [`AsyncWrite`](futures_io::AsyncWrite).
         ///
         /// ```
-        /// #![feature(async_await, await_macro, impl_trait_in_bindings)]
+        /// #![feature(async_await, impl_trait_in_bindings)]
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncWriteExt;
         /// use futures_util::compat::AsyncWrite01CompatExt;
@@ -394,7 +394,7 @@ mod io {
         /// let mut cursor = std::io::Cursor::new(Vec::with_capacity(12));
         ///
         /// let mut writer = (&mut cursor).compat();
-        /// await!(writer.write_all(input)).unwrap();
+        /// writer.write_all(input).await.unwrap();
         ///
         /// assert_eq!(cursor.into_inner(), input);
         /// # });

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -22,7 +22,7 @@ pub trait Executor01CompatExt: Executor01<Executor01Future> +
     /// futures 0.3 [`Spawn`](futures_core::task::Spawn).
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::Future;
     /// use futures::task::SpawnExt;
     /// use futures::future::{FutureExt, TryFutureExt};

--- a/futures-util/src/future/empty.rs
+++ b/futures-util/src/future/empty.rs
@@ -22,12 +22,12 @@ impl<T> FusedFuture for Empty<T> {
 /// # Examples
 ///
 /// ```ignore
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
 /// let future = future::empty();
-/// let () = await!(future);
+/// let () = future.await;
 /// unreachable!();
 /// # });
 /// ```

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -27,7 +27,7 @@ impl<Fut: Future> Fuse<Fut> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro, futures_api)]
+    /// #![feature(async_await, futures_api)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;
     /// use futures::future::{Fuse, FusedFuture, FutureExt};

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -90,7 +90,7 @@ generate! {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -98,7 +98,7 @@ generate! {
 /// let b = future::ready(2);
 /// let pair = future::join(a, b);
 ///
-/// assert_eq!(await!(pair), (1, 2));
+/// assert_eq!(pair.await, (1, 2));
 /// # });
 /// ```
 pub fn join<Fut1, Fut2>(future1: Fut1, future2: Fut2) -> Join<Fut1, Fut2>
@@ -115,7 +115,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -124,7 +124,7 @@ where
 /// let c = future::ready(3);
 /// let tuple = future::join3(a, b, c);
 ///
-/// assert_eq!(await!(tuple), (1, 2, 3));
+/// assert_eq!(tuple.await, (1, 2, 3));
 /// # });
 /// ```
 pub fn join3<Fut1, Fut2, Fut3>(
@@ -145,7 +145,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -155,7 +155,7 @@ where
 /// let d = future::ready(4);
 /// let tuple = future::join4(a, b, c, d);
 ///
-/// assert_eq!(await!(tuple), (1, 2, 3, 4));
+/// assert_eq!(tuple.await, (1, 2, 3, 4));
 /// # });
 /// ```
 pub fn join4<Fut1, Fut2, Fut3, Fut4>(
@@ -179,7 +179,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -190,7 +190,7 @@ where
 /// let e = future::ready(5);
 /// let tuple = future::join5(a, b, c, d, e);
 ///
-/// assert_eq!(await!(tuple), (1, 2, 3, 4, 5));
+/// assert_eq!(tuple.await, (1, 2, 3, 4, 5));
 /// # });
 /// ```
 pub fn join5<Fut1, Fut2, Fut3, Fut4, Fut5>(

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -99,7 +99,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future::{join_all};
 ///
@@ -107,7 +107,7 @@ where
 ///
 /// let futures = vec![foo(1), foo(2), foo(3)];
 ///
-/// assert_eq!(await!(join_all(futures)), [1, 2, 3]);
+/// assert_eq!(join_all(futures).await, [1, 2, 3]);
 /// # });
 /// ```
 pub fn join_all<I>(i: I) -> JoinAll<I::Item>

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -19,12 +19,12 @@ impl<F> Unpin for Lazy<F> {}
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
 /// let a = future::lazy(|_| 1);
-/// assert_eq!(await!(a), 1);
+/// assert_eq!(a.await, 1);
 ///
 /// let b = future::lazy(|_| -> i32 {
 ///     panic!("oh no!")

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -27,7 +27,7 @@ impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 /// use pin_utils::pin_mut;
@@ -35,7 +35,7 @@ impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
 /// let future = future::maybe_done(future::ready(5));
 /// pin_mut!(future);
 /// assert_eq!(future.as_mut().take_output(), None);
-/// let () = await!(future.as_mut());
+/// let () = future.as_mut().await;
 /// assert_eq!(future.as_mut().take_output(), Some(5));
 /// assert_eq!(future.as_mut().take_output(), None);
 /// # });

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -129,13 +129,13 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
     /// let future = future::ready(1);
     /// let new_future = future.map(|x| x + 3);
-    /// assert_eq!(await!(new_future), 4);
+    /// assert_eq!(new_future.await, 4);
     /// # });
     /// ```
     fn map<U, F>(self, f: F) -> Map<Self, F>
@@ -161,13 +161,13 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
     /// let future_of_1 = future::ready(1);
     /// let future_of_4 = future_of_1.then(|x| future::ready(x + 3));
-    /// assert_eq!(await!(future_of_4), 4);
+    /// assert_eq!(future_of_4.await, 4);
     /// # });
     /// ```
     fn then<Fut, F>(self, f: F) -> Then<Self, Fut, F>
@@ -187,7 +187,7 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
@@ -198,7 +198,7 @@ pub trait FutureExt: Future {
     ///     future::ready(false).right_future()
     /// };
     ///
-    /// assert_eq!(await!(future), true);
+    /// assert_eq!(future.await, true);
     /// # });
     /// ```
     fn left_future<B>(self) -> Either<Self, B>
@@ -217,7 +217,7 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
@@ -228,7 +228,7 @@ pub trait FutureExt: Future {
     ///     future::ready(false).right_future()
     /// };
     ///
-    /// assert_eq!(await!(future), false);
+    /// assert_eq!(future.await, false);
     /// # });
     /// ```
     fn right_future<A>(self) -> Either<A, Self>
@@ -246,14 +246,14 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     /// use futures::stream::StreamExt;
     ///
     /// let future = future::ready(17);
     /// let stream = future.into_stream();
-    /// let collected: Vec<_> = await!(stream.collect());
+    /// let collected: Vec<_> = stream.collect().await;
     /// assert_eq!(collected, vec![17]);
     /// # });
     /// ```
@@ -280,13 +280,13 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
     /// let nested_future = future::ready(future::ready(1));
     /// let future = nested_future.flatten();
-    /// assert_eq!(await!(future), 1);
+    /// assert_eq!(future.await, 1);
     /// # });
     /// ```
     fn flatten(self) -> Flatten<Self>
@@ -310,7 +310,7 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     /// use futures::stream::{self, StreamExt};
@@ -319,7 +319,7 @@ pub trait FutureExt: Future {
     /// let future_of_a_stream = future::ready(stream::iter(stream_items));
     ///
     /// let stream = future_of_a_stream.flatten_stream();
-    /// let list: Vec<_> = await!(stream.collect());
+    /// let list: Vec<_> = stream.collect().await;
     /// assert_eq!(list, vec![17, 18, 19]);
     /// # });
     /// ```
@@ -363,13 +363,13 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
     /// let future = future::ready(1);
     /// let new_future = future.inspect(|&x| println!("about to resolve: {}", x));
-    /// assert_eq!(await!(new_future), 1);
+    /// assert_eq!(new_future.await, 1);
     /// # });
     /// ```
     fn inspect<F>(self, f: F) -> Inspect<Self, F>
@@ -400,17 +400,17 @@ pub trait FutureExt: Future {
     // TODO: minimize and open rust-lang/rust ticket, currently errors:
     //       'assertion failed: !value.has_escaping_regions()'
     /// ```ignore
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt, Ready};
     ///
     /// let future = future::ready(2);
-    /// assert!(await!(future.catch_unwind()).is_ok());
+    /// assert!(future.catch_unwind().await.is_ok());
     ///
     /// let future = future::lazy(|_| -> Ready<i32> {
     ///     unimplemented!()
     /// });
-    /// assert!(await!(future.catch_unwind()).is_err());
+    /// assert!(future.catch_unwind().await.is_err());
     /// # });
     /// ```
     #[cfg(feature = "std")]
@@ -433,7 +433,7 @@ pub trait FutureExt: Future {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt};
     ///
@@ -441,8 +441,8 @@ pub trait FutureExt: Future {
     /// let shared1 = future.shared();
     /// let shared2 = shared1.clone();
     ///
-    /// assert_eq!(6, await!(shared1));
-    /// assert_eq!(6, await!(shared2));
+    /// assert_eq!(6, shared1.await);
+    /// assert_eq!(6, shared2.await);
     /// # });
     /// ```
     ///

--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -12,15 +12,15 @@ use pin_utils::unsafe_pinned;
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future::{self, OptionFuture};
 ///
 /// let mut a: OptionFuture<_> = Some(future::ready(123)).into();
-/// assert_eq!(await!(a), Some(123));
+/// assert_eq!(a.await, Some(123));
 ///
 /// a = None.into();
-/// assert_eq!(await!(a), None);
+/// assert_eq!(a.await, None);
 /// # });
 /// ```
 #[derive(Debug, Clone)]

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -20,7 +20,7 @@ impl<F> Unpin for PollFn<F> {}
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future::poll_fn;
 /// use futures::task::{Context, Poll};
@@ -30,7 +30,7 @@ impl<F> Unpin for PollFn<F> {}
 /// }
 ///
 /// let read_future = poll_fn(read_line);
-/// assert_eq!(await!(read_future), "Hello, World!".to_owned());
+/// assert_eq!(read_future.await, "Hello, World!".to_owned());
 /// # });
 /// ```
 pub fn poll_fn<T, F>(f: F) -> PollFn<F>

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -29,12 +29,12 @@ impl<T> Future for Ready<T> {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
 /// let a = future::ready(1);
-/// assert_eq!(await!(a), 1);
+/// assert_eq!(a.await, 1);
 /// # });
 /// ```
 pub fn ready<T>(t: T) -> Ready<T> {
@@ -46,12 +46,12 @@ pub fn ready<T>(t: T) -> Ready<T> {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
 /// let a = future::ok::<i32, i32>(1);
-/// assert_eq!(await!(a), Ok(1));
+/// assert_eq!(a.await, Ok(1));
 /// # });
 /// ```
 pub fn ok<T, E>(t: T) -> Ready<Result<T, E>> {
@@ -63,12 +63,12 @@ pub fn ok<T, E>(t: T) -> Ready<Result<T, E>> {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
 /// let a = future::err::<i32, i32>(1);
-/// assert_eq!(await!(a), Err(1));
+/// assert_eq!(a.await, Err(1));
 /// # });
 /// ```
 pub fn err<T, E>(err: E) -> Ready<Result<T, E>> {

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -77,7 +77,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncReadExt;
     /// use std::io::Cursor;
@@ -85,7 +85,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut writer = Cursor::new([0u8; 5]);
     ///
-    /// let bytes = await!(reader.copy_into(&mut writer))?;
+    /// let bytes = reader.copy_into(&mut writer).await?;
     ///
     /// assert_eq!(bytes, 4);
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
@@ -109,7 +109,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncReadExt;
     /// use std::io::Cursor;
@@ -117,7 +117,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 5];
     ///
-    /// let bytes = await!(reader.read(&mut output[..]))?;
+    /// let bytes = reader.read(&mut output[..]).await?;
     ///
     /// // This is only guaranteed to be 4 because `&[u8]` is a synchronous
     /// // reader. In a real system you could get anywhere from 1 to
@@ -143,7 +143,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncReadExt;
     /// use std::io::Cursor;
@@ -151,7 +151,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 4];
     ///
-    /// await!(reader.read_exact(&mut output))?;
+    /// reader.read_exact(&mut output).await?;
     ///
     /// assert_eq!(output, [1, 2, 3, 4]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
@@ -160,7 +160,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// ## EOF is hit before `buf` is filled
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncReadExt;
     /// use std::io::{self, Cursor};
@@ -168,7 +168,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 5];
     ///
-    /// let result = await!(reader.read_exact(&mut output));
+    /// let result = reader.read_exact(&mut output).await;
     ///
     /// assert_eq!(result.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
     /// # });
@@ -187,7 +187,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncReadExt;
     /// use std::io::Cursor;
@@ -195,7 +195,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = Vec::with_capacity(4);
     ///
-    /// await!(reader.read_to_end(&mut output))?;
+    /// reader.read_to_end(&mut output).await?;
     ///
     /// assert_eq!(output, vec![1, 2, 3, 4]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
@@ -217,7 +217,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncReadExt;
     /// use std::io::Cursor;
@@ -232,8 +232,8 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// {
     ///     let (mut buffer_reader, mut buffer_writer) = (&mut buffer).split();
-    ///     await!(reader.copy_into(&mut buffer_writer))?;
-    ///     await!(buffer_reader.copy_into(&mut writer))?;
+    ///     reader.copy_into(&mut buffer_writer).await?;
+    ///     buffer_reader.copy_into(&mut writer).await?;
     /// }
     ///
     /// assert_eq!(buffer.into_inner(), [1, 2, 3, 4, 5, 6, 7, 8]);
@@ -269,7 +269,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::{AllowStdIo, AsyncWriteExt};
     /// use std::io::{BufWriter, Cursor};
@@ -279,9 +279,9 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// {
     ///     let mut writer = Cursor::new(&mut output[..]);
     ///     let mut buffered = AllowStdIo::new(BufWriter::new(writer));
-    ///     await!(buffered.write_all(&[1, 2]))?;
-    ///     await!(buffered.write_all(&[3, 4]))?;
-    ///     await!(buffered.flush())?;
+    ///     buffered.write_all(&[1, 2]).await?;
+    ///     buffered.write_all(&[3, 4]).await?;
+    ///     buffered.flush().await?;
     /// }
     ///
     /// assert_eq!(output, [1, 2, 3, 4, 0]);
@@ -310,14 +310,14 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncWriteExt;
     /// use std::io::Cursor;
     ///
     /// let mut writer = Cursor::new([0u8; 5]);
     ///
-    /// await!(writer.write_all(&[1, 2, 3, 4]))?;
+    /// writer.write_all(&[1, 2, 3, 4]).await?;
     ///
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
@@ -376,7 +376,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncBufReadExt;
     /// use std::io::Cursor;
@@ -385,19 +385,19 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// let mut buf = vec![];
     ///
     /// // cursor is at 'l'
-    /// let num_bytes = await!(cursor.read_until(b'-', &mut buf))?;
+    /// let num_bytes = cursor.read_until(b'-', &mut buf).await?;
     /// assert_eq!(num_bytes, 6);
     /// assert_eq!(buf, b"lorem-");
     /// buf.clear();
     ///
     /// // cursor is at 'i'
-    /// let num_bytes = await!(cursor.read_until(b'-', &mut buf))?;
+    /// let num_bytes = cursor.read_until(b'-', &mut buf).await?;
     /// assert_eq!(num_bytes, 5);
     /// assert_eq!(buf, b"ipsum");
     /// buf.clear();
     ///
     /// // cursor is at EOF
-    /// let num_bytes = await!(cursor.read_until(b'-', &mut buf))?;
+    /// let num_bytes = cursor.read_until(b'-', &mut buf).await?;
     /// assert_eq!(num_bytes, 0);
     /// assert_eq!(buf, b"");
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
@@ -439,7 +439,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncBufReadExt;
     /// use std::io::Cursor;
@@ -448,19 +448,19 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// let mut buf = String::new();
     ///
     /// // cursor is at 'f'
-    /// let num_bytes = await!(cursor.read_line(&mut buf))?;
+    /// let num_bytes = cursor.read_line(&mut buf).await?;
     /// assert_eq!(num_bytes, 4);
     /// assert_eq!(buf, "foo\n");
     /// buf.clear();
     ///
     /// // cursor is at 'b'
-    /// let num_bytes = await!(cursor.read_line(&mut buf))?;
+    /// let num_bytes = cursor.read_line(&mut buf).await?;
     /// assert_eq!(num_bytes, 3);
     /// assert_eq!(buf, "bar");
     /// buf.clear();
     ///
     /// // cursor is at EOF
-    /// let num_bytes = await!(cursor.read_line(&mut buf))?;
+    /// let num_bytes = cursor.read_line(&mut buf).await?;
     /// assert_eq!(num_bytes, 0);
     /// assert_eq!(buf, "");
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
@@ -490,7 +490,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncBufReadExt;
     /// use futures::stream::StreamExt;
@@ -499,10 +499,10 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// let cursor = Cursor::new(b"lorem\nipsum\r\ndolor");
     ///
     /// let mut lines_stream = cursor.lines().map(|l| l.unwrap());
-    /// assert_eq!(await!(lines_stream.next()), Some(String::from("lorem")));
-    /// assert_eq!(await!(lines_stream.next()), Some(String::from("ipsum")));
-    /// assert_eq!(await!(lines_stream.next()), Some(String::from("dolor")));
-    /// assert_eq!(await!(lines_stream.next()), None);
+    /// assert_eq!(lines_stream.next().await, Some(String::from("lorem")));
+    /// assert_eq!(lines_stream.next().await, Some(String::from("ipsum")));
+    /// assert_eq!(lines_stream.next().await, Some(String::from("dolor")));
+    /// assert_eq!(lines_stream.next().await, None);
     /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
     /// ```
     fn lines(self) -> Lines<Self>

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -1,7 +1,7 @@
 //! Combinators and utilities for working with `Future`s, `Stream`s, `Sink`s,
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
-#![cfg_attr(feature = "async-await", feature(async_await, await_macro))]
+#![cfg_attr(feature = "async-await", feature(async_await))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "never-type", feature(never_type))]
 

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -23,12 +23,12 @@ pub enum DrainError {
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::sink::{self, SinkExt};
 ///
 /// let mut drain = sink::drain();
-/// await!(drain.send(5))?;
+/// drain.send(5).await?;
 /// # Ok::<(), futures::sink::DrainError>(()) }).unwrap();
 /// ```
 pub fn drain<T>() -> Drain<T> {

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -271,7 +271,7 @@ pub trait StreamExt: Stream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::stream::{self, StreamExt};
     ///
@@ -279,10 +279,10 @@ pub trait StreamExt: Stream {
     ///
     /// let mut stream = stream.enumerate();
     ///
-    /// assert_eq!(await!(stream.next()), Some((0, 'a')));
-    /// assert_eq!(await!(stream.next()), Some((1, 'b')));
-    /// assert_eq!(await!(stream.next()), Some((2, 'c')));
-    /// assert_eq!(await!(stream.next()), None);
+    /// assert_eq!(stream.next().await, Some((0, 'a')));
+    /// assert_eq!(stream.next().await, Some((1, 'b')));
+    /// assert_eq!(stream.next().await, Some((2, 'c')));
+    /// assert_eq!(stream.next().await, None);
     /// # });
     /// ```
     fn enumerate(self) -> Enumerate<Self>
@@ -644,7 +644,7 @@ pub trait StreamExt: Stream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::oneshot;
     /// use futures::stream::{self, StreamExt};
@@ -656,13 +656,13 @@ pub trait StreamExt: Stream {
     /// let fut = stream::iter(vec![rx1, rx2, rx3]).for_each_concurrent(
     ///     /* limit */ 2,
     ///     async move |rx| {
-    ///         await!(rx).unwrap();
+    ///         rx.await.unwrap();
     ///     }
     /// );
     /// tx1.send(()).unwrap();
     /// tx2.send(()).unwrap();
     /// tx3.send(()).unwrap();
-    /// await!(fut);
+    /// fut.await;
     /// # })
     /// ```
     #[cfg_attr(
@@ -892,7 +892,7 @@ pub trait StreamExt: Stream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::oneshot;
     /// use futures::stream::{self, StreamExt};
@@ -904,12 +904,12 @@ pub trait StreamExt: Stream {
     /// let mut buffered = stream_of_futures.buffer_unordered(10);
     ///
     /// send_two.send(2i32);
-    /// assert_eq!(await!(buffered.next()), Some(Ok(2i32)));
+    /// assert_eq!(buffered.next().await, Some(Ok(2i32)));
     ///
     /// send_one.send(1i32);
-    /// assert_eq!(await!(buffered.next()), Some(Ok(1i32)));
+    /// assert_eq!(buffered.next().await, Some(Ok(1i32)));
     ///
-    /// assert_eq!(await!(buffered.next()), None);
+    /// assert_eq!(buffered.next().await, None);
     /// # })
     /// ```
     #[cfg_attr(
@@ -1116,7 +1116,7 @@ pub trait StreamExt: Stream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::{future, select};
     /// use futures::stream::{StreamExt, FuturesUnordered};

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -32,7 +32,7 @@ pub trait SpawnExt: Spawn {
     /// today. Feel free to use this method in the meantime.
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::executor::ThreadPool;
     /// use futures::task::SpawnExt;
     ///
@@ -57,7 +57,7 @@ pub trait SpawnExt: Spawn {
     /// resolves to the output of the spawned future.
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::executor::ThreadPool;
     /// use futures::future;
     /// use futures::task::SpawnExt;
@@ -110,7 +110,7 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// today. Feel free to use this method in the meantime.
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::executor::LocalPool;
     /// use futures::task::LocalSpawnExt;
     ///
@@ -136,7 +136,7 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// resolves to the output of the spawned future.
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::executor::LocalPool;
     /// use futures::future;
     /// use futures::task::LocalSpawnExt;

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -117,13 +117,13 @@ pub trait TryFutureExt: TryFuture {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Ok::<i32, i32>(1));
     /// let future = future.map_ok(|x| x + 3);
-    /// assert_eq!(await!(future), Ok(4));
+    /// assert_eq!(future.await, Ok(4));
     /// # });
     /// ```
     ///
@@ -131,13 +131,13 @@ pub trait TryFutureExt: TryFuture {
     /// effect:
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Err::<i32, i32>(1));
     /// let future = future.map_ok(|x| x + 3);
-    /// assert_eq!(await!(future), Err(1));
+    /// assert_eq!(future.await, Err(1));
     /// # });
     /// ```
     fn map_ok<T, F>(self, f: F) -> MapOk<Self, F>
@@ -165,13 +165,13 @@ pub trait TryFutureExt: TryFuture {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Err::<i32, i32>(1));
     /// let future = future.map_err(|x| x + 3);
-    /// assert_eq!(await!(future), Err(4));
+    /// assert_eq!(future.await, Err(4));
     /// # });
     /// ```
     ///
@@ -179,13 +179,13 @@ pub trait TryFutureExt: TryFuture {
     /// no effect:
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Ok::<i32, i32>(1));
     /// let future = future.map_err(|x| x + 3);
-    /// assert_eq!(await!(future), Ok(1));
+    /// assert_eq!(future.await, Ok(1));
     /// # });
     /// ```
     fn map_err<E, F>(self, f: F) -> MapErr<Self, F>
@@ -210,7 +210,7 @@ pub trait TryFutureExt: TryFuture {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
@@ -240,13 +240,13 @@ pub trait TryFutureExt: TryFuture {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Ok::<i32, i32>(1));
     /// let future = future.and_then(|x| future::ready(Ok::<i32, i32>(x + 3)));
-    /// assert_eq!(await!(future), Ok(4));
+    /// assert_eq!(future.await, Ok(4));
     /// # });
     /// ```
     ///
@@ -254,13 +254,13 @@ pub trait TryFutureExt: TryFuture {
     /// effect:
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Err::<i32, i32>(1));
     /// let future = future.and_then(|x| future::ready(Err::<i32, i32>(x + 3)));
-    /// assert_eq!(await!(future), Err(1));
+    /// assert_eq!(future.await, Err(1));
     /// # });
     /// ```
     fn and_then<Fut, F>(self, f: F) -> AndThen<Self, Fut, F>
@@ -286,13 +286,13 @@ pub trait TryFutureExt: TryFuture {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Err::<i32, i32>(1));
     /// let future = future.or_else(|x| future::ready(Err::<i32, i32>(x + 3)));
-    /// assert_eq!(await!(future), Err(4));
+    /// assert_eq!(future.await, Err(4));
     /// # });
     /// ```
     ///
@@ -300,13 +300,13 @@ pub trait TryFutureExt: TryFuture {
     /// no effect:
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Ok::<i32, i32>(1));
     /// let future = future.or_else(|x| future::ready(Ok::<i32, i32>(x + 3)));
-    /// assert_eq!(await!(future), Ok(1));
+    /// assert_eq!(future.await, Ok(1));
     /// # });
     /// ```
     fn or_else<Fut, F>(self, f: F) -> OrElse<Self, Fut, F>
@@ -375,13 +375,13 @@ pub trait TryFutureExt: TryFuture {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{self, TryFutureExt};
     ///
     /// # futures::executor::block_on(async {
     /// let future = future::ready(Err::<(), &str>("Boom!"));
     /// let future = future.unwrap_or_else(|_| ());
-    /// assert_eq!(await!(future), ());
+    /// assert_eq!(future.await, ());
     /// # });
     /// ```
     fn unwrap_or_else<F>(self, f: F) -> UnwrapOrElse<Self, F>

--- a/futures-util/src/try_future/try_join.rs
+++ b/futures-util/src/try_future/try_join.rs
@@ -133,7 +133,7 @@ generate! {
 /// [`Ok`] of a tuple of the values:
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -141,7 +141,7 @@ generate! {
 /// let b = future::ready(Ok::<i32, i32>(2));
 /// let pair = future::try_join(a, b);
 ///
-/// assert_eq!(await!(pair), Ok((1, 2)));
+/// assert_eq!(pair.await, Ok((1, 2)));
 /// # });
 /// ```
 ///
@@ -149,7 +149,7 @@ generate! {
 /// that error:
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -157,7 +157,7 @@ generate! {
 /// let b = future::ready(Err::<i32, i32>(2));
 /// let pair = future::try_join(a, b);
 ///
-/// assert_eq!(await!(pair), Err(2));
+/// assert_eq!(pair.await, Err(2));
 /// # });
 /// ```
 pub fn try_join<Fut1, Fut2>(future1: Fut1, future2: Fut2) -> TryJoin<Fut1, Fut2>
@@ -173,7 +173,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -182,7 +182,7 @@ where
 /// let c = future::ready(Ok::<i32, i32>(3));
 /// let tuple = future::try_join3(a, b, c);
 ///
-/// assert_eq!(await!(tuple), Ok((1, 2, 3)));
+/// assert_eq!(tuple.await, Ok((1, 2, 3)));
 /// # });
 /// ```
 pub fn try_join3<Fut1, Fut2, Fut3>(
@@ -203,7 +203,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -213,7 +213,7 @@ where
 /// let d = future::ready(Ok::<i32, i32>(4));
 /// let tuple = future::try_join4(a, b, c, d);
 ///
-/// assert_eq!(await!(tuple), Ok((1, 2, 3, 4)));
+/// assert_eq!(tuple.await, Ok((1, 2, 3, 4)));
 /// # });
 /// ```
 pub fn try_join4<Fut1, Fut2, Fut3, Fut4>(
@@ -236,7 +236,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
@@ -247,7 +247,7 @@ where
 /// let e = future::ready(Ok::<i32, i32>(5));
 /// let tuple = future::try_join5(a, b, c, d, e);
 ///
-/// assert_eq!(await!(tuple), Ok((1, 2, 3, 4, 5)));
+/// assert_eq!(tuple.await, Ok((1, 2, 3, 4, 5)));
 /// # });
 /// ```
 pub fn try_join5<Fut1, Fut2, Fut3, Fut4, Fut5>(

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -97,7 +97,7 @@ where
 /// # Examples
 ///
 /// ```
-/// #![feature(async_await, await_macro)]
+/// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future::{self, try_join_all};
 ///
@@ -107,7 +107,7 @@ where
 ///     future::ok::<u32, u32>(3),
 /// ];
 ///
-/// assert_eq!(await!(try_join_all(futures)), Ok(vec![1, 2, 3]));
+/// assert_eq!(try_join_all(futures).await, Ok(vec![1, 2, 3]));
 ///
 /// let futures = vec![
 ///     future::ok::<u32, u32>(1),
@@ -115,7 +115,7 @@ where
 ///     future::ok::<u32, u32>(3),
 /// ];
 ///
-/// assert_eq!(await!(try_join_all(futures)), Err(2));
+/// assert_eq!(try_join_all(futures).await, Err(2));
 /// # });
 /// ```
 pub fn try_join_all<I>(i: I) -> TryJoinAll<I::Item>

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -86,7 +86,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::stream::{self, TryStreamExt};
     ///
@@ -94,8 +94,8 @@ pub trait TryStreamExt: TryStream {
     ///     stream::iter(vec![Ok(()), Err(5i32)])
     ///         .err_into::<i64>();
     ///
-    /// assert_eq!(await!(stream.try_next()), Ok(Some(())));
-    /// assert_eq!(await!(stream.try_next()), Err(5i64));
+    /// assert_eq!(stream.try_next().await, Ok(Some(())));
+    /// assert_eq!(stream.try_next().await, Err(5i64));
     /// # })
     /// ```
     fn err_into<E>(self) -> ErrInto<Self, E>
@@ -112,7 +112,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::stream::{self, TryStreamExt};
     ///
@@ -120,8 +120,8 @@ pub trait TryStreamExt: TryStream {
     ///     stream::iter(vec![Ok(5), Err(0)])
     ///         .map_ok(|x| x + 2);
     ///
-    /// assert_eq!(await!(stream.try_next()), Ok(Some(7)));
-    /// assert_eq!(await!(stream.try_next()), Err(0));
+    /// assert_eq!(stream.try_next().await, Ok(Some(7)));
+    /// assert_eq!(stream.try_next().await, Err(0));
     /// # })
     /// ```
     fn map_ok<T, F>(self, f: F) -> MapOk<Self, F>
@@ -138,7 +138,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::stream::{self, TryStreamExt};
     ///
@@ -146,8 +146,8 @@ pub trait TryStreamExt: TryStream {
     ///     stream::iter(vec![Ok(5), Err(0)])
     ///         .map_err(|x| x + 2);
     ///
-    /// assert_eq!(await!(stream.try_next()), Ok(Some(5)));
-    /// assert_eq!(await!(stream.try_next()), Err(2));
+    /// assert_eq!(stream.try_next().await, Ok(Some(5)));
+    /// assert_eq!(stream.try_next().await, Err(2));
     /// # })
     /// ```
     fn map_err<E, F>(self, f: F) -> MapErr<Self, F>
@@ -292,14 +292,14 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::stream::{self, TryStreamExt};
     ///
     /// let mut stream = stream::iter(vec![Ok(()), Err(())]);
     ///
-    /// assert_eq!(await!(stream.try_next()), Ok(Some(())));
-    /// assert_eq!(await!(stream.try_next()), Err(()));
+    /// assert_eq!(stream.try_next().await, Ok(Some(())));
+    /// assert_eq!(stream.try_next().await, Err(()));
     /// # })
     /// ```
     fn try_next(&mut self) -> TryNext<'_, Self>
@@ -324,7 +324,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future;
     /// use futures::stream::{self, TryStreamExt};
@@ -336,7 +336,7 @@ pub trait TryStreamExt: TryStream {
     ///         x += item;
     ///         future::ready(if x == 3 { Err(()) } else { Ok(()) })
     ///     });
-    ///     assert_eq!(await!(fut), Err(()));
+    ///     assert_eq!(fut.await, Err(()));
     /// }
     ///
     /// assert_eq!(x, 3);
@@ -359,7 +359,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future;
     /// use futures::stream::{self, TryStreamExt};
@@ -367,7 +367,7 @@ pub trait TryStreamExt: TryStream {
     /// let stream = stream::iter(vec![Ok::<i32, i32>(1), Ok(3), Ok(2)]);
     /// let mut stream = stream.try_skip_while(|x| future::ready(Ok(*x < 3)));
     ///
-    /// let output: Result<Vec<i32>, i32> = await!(stream.try_collect());
+    /// let output: Result<Vec<i32>, i32> = stream.try_collect().await;
     /// assert_eq!(output, Ok(vec![3, 2]));
     /// # })
     /// ```
@@ -394,7 +394,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::oneshot;
     /// use futures::stream::{self, StreamExt, TryStreamExt};
@@ -407,7 +407,7 @@ pub trait TryStreamExt: TryStream {
     /// let fut = stream.map(Ok).try_for_each_concurrent(
     ///     /* limit */ 2,
     ///     async move |rx| {
-    ///         let res: Result<(), oneshot::Canceled> = await!(rx);
+    ///         let res: Result<(), oneshot::Canceled> = rx.await;
     ///         res
     ///     }
     /// );
@@ -418,7 +418,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// // The final result is an error because the second future
     /// // resulted in an error.
-    /// assert_eq!(Err(oneshot::Canceled), await!(fut));
+    /// assert_eq!(Err(oneshot::Canceled), fut.await);
     /// # })
     /// ```
     #[cfg_attr(
@@ -450,7 +450,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;
     /// use futures::executor::block_on;
@@ -466,7 +466,7 @@ pub trait TryStreamExt: TryStream {
     ///     tx.unbounded_send(Err(6)).unwrap();
     /// });
     ///
-    /// let output: Result<Vec<i32>, i32> = await!(rx.try_collect());
+    /// let output: Result<Vec<i32>, i32> = rx.try_collect().await;
     /// assert_eq!(output, Err(6));
     /// # })
     /// ```
@@ -493,7 +493,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// # Examples
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::executor::block_on;
     /// use futures::future;
@@ -504,8 +504,8 @@ pub trait TryStreamExt: TryStream {
     ///     future::ready(x % 2 == 0)
     /// });
     ///
-    /// assert_eq!(await!(evens.next()), Some(Ok(2)));
-    /// assert_eq!(await!(evens.next()), Some(Err("error")));
+    /// assert_eq!(evens.next().await, Some(Ok(2)));
+    /// assert_eq!(evens.next().await, Some(Err("error")));
     /// # })
     /// ```
     fn try_filter<Fut, F>(self, f: F) -> TryFilter<Self, Fut, F>
@@ -533,7 +533,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// # Examples
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::executor::block_on;
     /// use futures::future;
@@ -545,8 +545,8 @@ pub trait TryStreamExt: TryStream {
     ///     future::ready(Ok(ret))
     /// });
     ///
-    /// assert_eq!(await!(halves.next()), Some(Ok(3)));
-    /// assert_eq!(await!(halves.next()), Some(Err("error")));
+    /// assert_eq!(halves.next().await, Some(Ok(3)));
+    /// assert_eq!(halves.next().await, Some(Err("error")));
     /// # })
     /// ```
     fn try_filter_map<Fut, F, T>(self, f: F) -> TryFilterMap<Self, Fut, F>
@@ -574,18 +574,18 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future;
     /// use futures::stream::{self, TryStreamExt};
     ///
     /// let number_stream = stream::iter(vec![Ok::<i32, i32>(1), Ok(2)]);
     /// let sum = number_stream.try_fold(0, |acc, x| future::ready(Ok(acc + x)));
-    /// assert_eq!(await!(sum), Ok(3));
+    /// assert_eq!(sum.await, Ok(3));
     ///
     /// let number_stream_with_err = stream::iter(vec![Ok::<i32, i32>(1), Err(2), Ok(1)]);
     /// let sum = number_stream_with_err.try_fold(0, |acc, x| future::ready(Ok(acc + x)));
-    /// assert_eq!(await!(sum), Err(2));
+    /// assert_eq!(sum.await, Err(2));
     /// # })
     /// ```
     fn try_fold<T, Fut, F>(self, init: T, f: F) -> TryFold<Self, Fut, T, F>
@@ -657,7 +657,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// Results are returned in the order of completion:
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::oneshot;
     /// use futures::stream::{self, StreamExt, TryStreamExt};
@@ -670,18 +670,18 @@ pub trait TryStreamExt: TryStream {
     /// let mut buffered = stream_of_futures.try_buffer_unordered(10);
     ///
     /// send_two.send(2i32);
-    /// assert_eq!(await!(buffered.next()), Some(Ok(2i32)));
+    /// assert_eq!(buffered.next().await, Some(Ok(2i32)));
     ///
     /// send_one.send(1i32);
-    /// assert_eq!(await!(buffered.next()), Some(Ok(1i32)));
+    /// assert_eq!(buffered.next().await, Some(Ok(1i32)));
     ///
-    /// assert_eq!(await!(buffered.next()), None);
+    /// assert_eq!(buffered.next().await, None);
     /// # })
     /// ```
     ///
     /// Errors from the underlying stream itself are propagated:
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;
     /// use futures::future;
@@ -691,10 +691,10 @@ pub trait TryStreamExt: TryStream {
     /// let mut buffered = stream_of_futures.try_buffer_unordered(10);
     ///
     /// sink.unbounded_send(Ok(future::ready(Ok(7i32))));
-    /// assert_eq!(await!(buffered.next()), Some(Ok(7i32)));
+    /// assert_eq!(buffered.next().await, Some(Ok(7i32)));
     ///
     /// sink.unbounded_send(Err("error in the stream"));
-    /// assert_eq!(await!(buffered.next()), Some(Err("error in the stream")));
+    /// assert_eq!(buffered.next().await, Some(Err("error in the stream")));
     /// # })
     /// ```
     #[cfg_attr(
@@ -725,7 +725,7 @@ pub trait TryStreamExt: TryStream {
     /// Wraps a [`TryStream`] into a stream compatible with libraries using
     /// futures 0.1 `Stream`. Requires the `compat` feature to be enabled.
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// use futures::future::{FutureExt, TryFutureExt};
     /// # let (tx, rx) = futures::channel::oneshot::channel();
     ///
@@ -761,7 +761,7 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     ///
     /// ```
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::executor::block_on;
     /// use futures::future::lazy;
@@ -773,7 +773,7 @@ pub trait TryStreamExt: TryStream {
     /// let mut reader = stream.into_async_read();
     /// let mut buf = Vec::new();
     ///
-    /// assert!(await!(reader.read_to_end(&mut buf)).is_ok());
+    /// assert!(reader.read_to_end(&mut buf).await.is_ok());
     /// assert_eq!(buf, &[1, 2, 3, 4, 5]);
     /// # })
     /// ```

--- a/futures-util/tests/futures_unordered.rs
+++ b/futures-util/tests/futures_unordered.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::future;
 use futures::task::Poll;

--- a/futures-util/tests/mutex.rs
+++ b/futures-util/tests/mutex.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::channel::mpsc;
 use futures::future::{ready, FutureExt};
@@ -51,8 +51,8 @@ fn mutex_contested() {
         let tx = tx.clone();
         let mutex = mutex.clone();
         pool.spawn(async move {
-            let mut lock = await!(mutex.lock());
-            await!(ready(()).pending_once());
+            let mut lock = mutex.lock().await;
+            ready(()).pending_once().await;
             *lock += 1;
             tx.unbounded_send(()).unwrap();
             drop(lock);
@@ -61,9 +61,9 @@ fn mutex_contested() {
 
     pool.run(async {
         for _ in 0..num_tasks {
-            let () = await!(rx.next()).unwrap();
+            let () = rx.next().await.unwrap();
         }
-        let lock = await!(mutex.lock());
+        let lock = mutex.lock().await;
         assert_eq!(num_tasks, *lock);
     })
 }

--- a/futures-util/tests/select_all.rs
+++ b/futures-util/tests/select_all.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::future;
 use futures::FutureExt;

--- a/futures-util/tests/select_next_some.rs
+++ b/futures-util/tests/select_next_some.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::{future, select};
 use futures::future::{FusedFuture, FutureExt};

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -1,5 +1,5 @@
 #![recursion_limit="128"]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::{Poll, pending, poll, join, try_join, select};
 use futures::channel::{mpsc, oneshot};
@@ -72,8 +72,8 @@ fn select_streams() {
             _ = rx1.next() => panic!(),
             _ = rx2.next() => panic!(),
             default => {
-                await!(tx1.send(2)).unwrap();
-                await!(tx2.send(3)).unwrap();
+                tx1.send(2).await.unwrap();
+                tx2.send(3).await.unwrap();
                 tx1_opt = Some(tx1);
                 tx2_opt = Some(tx2);
             }
@@ -113,12 +113,12 @@ fn select_can_move_uncompleted_futures() {
         select! {
             res = rx1 => {
                 assert_eq!(Ok(1), res);
-                assert_eq!(Ok(2), await!(rx2));
+                assert_eq!(Ok(2), rx2.await);
                 ran = true;
             },
             res = rx2 => {
                 assert_eq!(Ok(2), res);
-                assert_eq!(Ok(1), await!(rx1));
+                assert_eq!(Ok(1), rx1.await);
                 ran = true;
             },
         }

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,4 +1,4 @@
-#![feature(await_macro, async_await)]
+#![feature(async_await)]
 #![cfg(feature = "compat")]
 
 use tokio::timer::Delay;
@@ -10,7 +10,7 @@ use futures::compat::Future01CompatExt;
 #[test]
 fn can_use_01_futures_in_a_03_future_running_on_a_01_executor() {
     let f = async {
-        await!(Delay::new(Instant::now()).compat())
+        Delay::new(Instant::now()).compat().await
     };
 
     let mut runtime = Runtime::new().unwrap();

--- a/futures/tests_disabled/async_await/pinned.rs
+++ b/futures/tests_disabled/async_await/pinned.rs
@@ -13,7 +13,7 @@ fn bar(x: &i32) -> Result<i32, i32> {
 
 #[async]
 fn baz(x: i32) -> Result<i32, i32> {
-    await!(bar(&x))
+    bar(&x).await
 }
 
 #[async(boxed)]
@@ -43,7 +43,7 @@ fn spawnable() -> Result<(), Never> {
 
 fn baz_block(x: i32) -> impl StableFuture<Item = i32, Error = i32> {
     async_block! {
-        await!(bar(&x))
+        bar(&x).await
     }
 }
 

--- a/futures/tests_disabled/async_await/smoke.rs
+++ b/futures/tests_disabled/async_await/smoke.rs
@@ -66,13 +66,13 @@ fn _foo9() -> Result<(), Never> {
 
 #[async]
 fn _bar() -> Result<i32, i32> {
-    await!(foo())
+    foo().await
 }
 
 #[async]
 fn _bar2() -> Result<i32, i32> {
-    let a = await!(foo())?;
-    let b = await!(foo())?;
+    let a = foo().await?;
+    let b = foo().await?;
     Ok(a + b)
 }
 


### PR DESCRIPTION
`await` syntax was implemented in https://github.com/rust-lang/rust/pull/60586, and nightly-2019-05-09 has been released with the changes. Also, `await!` macro will be removed in the future.

Refs: [migration tool](https://github.com/taiki-e/replace-await)