### PR TITLE
Add is_in_task

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -33,7 +33,7 @@
 #[allow(deprecated)]
 pub use task_impl::{Spawn, spawn, Unpark, Executor, Run, park};
 
-pub use task_impl::{Task, AtomicTask, current, init};
+pub use task_impl::{Task, AtomicTask, current, init, is_in_task};
 
 #[allow(deprecated)]
 #[cfg(feature = "use_std")]

--- a/src/task_impl/core.rs
+++ b/src/task_impl/core.rs
@@ -140,6 +140,15 @@ pub unsafe fn init(get: fn() -> *mut u8, set: fn(*mut u8)) -> bool {
     }
 }
 
+/// Return whether the caller is running in a task (and so can use task_local!).
+pub fn is_in_task() -> bool {
+    if let Some(ptr) = get_ptr() {
+        !ptr.is_null()
+    } else {
+        false
+    }
+}
+
 #[inline]
 pub fn get_ptr() -> Option<*mut u8> {
     match GET.load(Relaxed) {

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -27,6 +27,11 @@ pub use task_impl::core::init;
 
 thread_local!(static CURRENT_TASK: Cell<*mut u8> = Cell::new(ptr::null_mut()));
 
+/// Return whether the caller is running in a task (and so can use task_local!).
+pub fn is_in_task() -> bool {
+    CURRENT_TASK.with(|task| !task.get().is_null())
+}
+
 static INIT: Once = ONCE_INIT;
 
 pub fn get_ptr() -> Option<*mut u8> {


### PR DESCRIPTION
This returns whether the caller is in a Task.

If a `task_local!` is accessed from outside a Task, it panics. Right now,
there is no way for a caller to know whether it's safe to look in a
task_local!.

For my use-case, I have a logger implementation which uses some task-local information when logging, if logging from a task; the logger is also used from non-tasks, and I don't have a way to guard accessing the task-local information on whether the caller is a task.

If there's a better way to do this, or a change to `task_local!` which would be better, I'd be happy to run with that instead.