### PR TITLE
Prepare 0.3.0-alpha.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
+# 0.3.0-alpha.16 - 2019-5-10
+* Updated to new nightly `async_await`.
+* Changed `AsyncRead::poll_vectored_read` and `AsyncWrite::poll_vectored_write` to use
+  stabilized `std::io::{IoSlice, IoSliceMut}` instead of `iovec::IoVec`, and renamed to
+  `AsyncRead::poll_read_vectored` and `AsyncWrite::poll_write_vectored`.
+* Added `LocalBoxFuture` and `FutureExt::boxed_local`.
+* Added `TryStreamExt::{try_filter, inspect_ok, inspect_err}`.
+* Added `try_future::select_ok`.
+* Added `AsyncBufReadExt::{read_line, lines}`.
+* Added `io::BufReader`.
+
 # 0.3.0-alpha.15 - 2019-4-26
 * Updated to stabilized `futures_api`.
 * Removed `StreamObj`, cautioned against usage of `FutureObj`.
 * Changed `StreamExt::select` to a function.
 * Added `AsyncBufRead` and `AsyncSeek` traits.
-* Expanded trait impls to include more pinned pointers and ?Sized types. 
+* Expanded trait impls to include more pinned pointers and ?Sized types.
 * Added `future::Fuse::terminated` constructor.
 * Added `never_error` combinator.
 * Added `StreamExt::enumerate`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures/">
+  <a href="https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures/">
     Documentation
   </a> | <a href="https://rust-lang-nursery.github.io/futures-rs/">
     Website
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-futures-preview = "0.3.0-alpha.15"
+futures-preview = "0.3.0-alpha.16"
 ```
 
 Now, you can use futures-rs:
@@ -49,7 +49,7 @@ a `#[no_std]` environment, use:
 
 ```toml
 [dependencies]
-futures-preview = { version = "=0.3.0-alpha.15", default-features = false }
+futures-preview = { version = "=0.3.0-alpha.16", default-features = false }
 ```
 
 # License

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-channel-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_channel"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_channel"
 description = """
 Channels for asynchronous communication using futures-rs.
 """
@@ -19,9 +19,9 @@ std = ["futures-core-preview/std"]
 default = ["std"]
 
 [dependencies]
-futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
 
 [dev-dependencies]
-futures-preview = { path = "../futures", version = "=0.3.0-alpha.15", default-features = true }
-futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.15", default-features = true }
+futures-preview = { path = "../futures", version = "=0.3.0-alpha.16", default-features = true }
+futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.16", default-features = true }
 pin-utils = "0.1.0-alpha.4"

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -8,7 +8,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_channel")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_channel")]
 
 #[cfg(feature = "std")]
 mod lock;

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-core-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_core"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_core"
 description = """
 The core traits and types in for the `futures` library.
 """
@@ -24,4 +24,4 @@ alloc = []
 [dependencies]
 
 [dev-dependencies]
-futures-preview = { path = "../futures", version = "=0.3.0-alpha.15" }
+futures-preview = { path = "../futures", version = "=0.3.0-alpha.16" }

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_core")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_core")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-executor-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_executor"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_executor"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """
@@ -19,12 +19,12 @@ std = ["num_cpus", "futures-core-preview/std", "futures-util-preview/std", "futu
 default = ["std"]
 
 [dependencies]
-futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false}
-futures-util-preview = { path = "../futures-util", version = "=0.3.0-alpha.15", default-features = false}
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.15", default-features = false}
+futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false}
+futures-util-preview = { path = "../futures-util", version = "=0.3.0-alpha.16", default-features = false}
+futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false}
 num_cpus = { version = "1.8.0", optional = true }
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
-futures-preview = { path = "../futures", version = "=0.3.0-alpha.15" }
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.15" }
+futures-preview = { path = "../futures", version = "=0.3.0-alpha.16" }
+futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16" }

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_executor")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_executor")]
 
 #[cfg(feature = "std")]
 mod local_pool;

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-io-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_io"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_io"
 description = """
 The `AsyncRead` and `AsyncWrite` traits for the futures-rs library.
 """
@@ -19,8 +19,8 @@ std = ["futures-core-preview/std"]
 default = ["std"]
 
 [dependencies]
-futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
 
 [dev-dependencies]
-futures-preview = { path = "../futures", version = "=0.3.0-alpha.15" }
+futures-preview = { path = "../futures", version = "=0.3.0-alpha.16" }
 assert_matches = "1.3.0"

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_io")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_io")]
 
 #[cfg(feature = "std")]
 mod if_std {

--- a/futures-select-macro/Cargo.toml
+++ b/futures-select-macro/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-select-macro-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Taylor Cramer <cramertj@google.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_select_macro"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_select_macro"
 description = """
 The `select!` macro for waiting on multiple different `Future`s at once and handling the first one to complete.
 """

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-sink-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_sink"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_sink"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """
@@ -21,5 +21,5 @@ nightly = ["futures-core-preview/nightly"]
 alloc = ["futures-core-preview/alloc"]
 
 [dependencies]
-futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false }
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.15", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_sink")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_sink")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-test-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -15,14 +15,14 @@ Common utilities for testing components built off futures-rs.
 name = "futures_test"
 
 [dependencies]
-futures-core-preview = { version = "=0.3.0-alpha.15", path = "../futures-core", default-features = false }
-futures-io-preview = { version = "=0.3.0-alpha.15", path = "../futures-io", default-features = false }
-futures-util-preview = { version = "=0.3.0-alpha.15", path = "../futures-util", default-features = false }
-futures-executor-preview = { version = "=0.3.0-alpha.15", path = "../futures-executor", default-features = false }
+futures-core-preview = { version = "=0.3.0-alpha.16", path = "../futures-core", default-features = false }
+futures-io-preview = { version = "=0.3.0-alpha.16", path = "../futures-io", default-features = false }
+futures-util-preview = { version = "=0.3.0-alpha.16", path = "../futures-util", default-features = false }
+futures-executor-preview = { version = "=0.3.0-alpha.16", path = "../futures-executor", default-features = false }
 pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 
 [dev-dependencies]
-futures-preview = { version = "=0.3.0-alpha.15", path = "../futures", default-features = false, features = ["std"] }
+futures-preview = { version = "=0.3.0-alpha.16", path = "../futures", default-features = false, features = ["std"] }
 
 [features]
 default = ["std"]

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -3,9 +3,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(
-    html_root_url = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.5/futures_test"
-)]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_test")]
 
 #[cfg(not(feature = "std"))]
 compile_error!("`futures-test` must have the `std` feature activated, this is a default-active feature");

--- a/futures-test/src/task/mod.rs
+++ b/futures-test/src/task/mod.rs
@@ -3,8 +3,8 @@
 //
 // Also, there is cross crate links in here. They are not going to work anytime soon. Do we put https links
 // in here? to here: https://rust-lang-nursery.github.io/futures-api-docs? The problem is these have a
-// version hardcoded in the url: 0.3.0-alpha.15 We could link to docs.rs, but currently that says:
-// docs.rs failed to build futures-preview-0.3.0-alpha.15 -> ok the reason seems to be that they are on
+// version hardcoded in the url: 0.3.0-alpha.16 We could link to docs.rs, but currently that says:
+// docs.rs failed to build futures-preview-0.3.0-alpha.16 -> ok the reason seems to be that they are on
 // 2019-04-17 which does still have futures-api unstable feature, so that should get solved.
 //
 //! Task related testing utilities.

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-util-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_util"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_util"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """
@@ -27,11 +27,11 @@ never-type = []
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc"]
 
 [dependencies]
-futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false }
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.15", default-features = false }
-futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.15", default-features = false }
-futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.15", default-features = false}
-futures-select-macro-preview = { path = "../futures-select-macro", version = "=0.3.0-alpha.15", default-features = false, optional = true }
+futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false }
+futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.16", default-features = false }
+futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.16", default-features = false}
+futures-select-macro-preview = { path = "../futures-select-macro", version = "=0.3.0-alpha.16", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 rand = { version = "0.6.4", optional = true }
@@ -43,7 +43,7 @@ tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
-futures-preview = { path = "../futures", version = "=0.3.0-alpha.15", features = ["async-await", "nightly"] }
-futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.15" }
-futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.15" }
+futures-preview = { path = "../futures", version = "=0.3.0-alpha.16", features = ["async-await", "nightly"] }
+futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.16" }
+futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.16" }
 tokio = "0.1.11"

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -9,7 +9,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures_util")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_util")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures-preview"
 edition = "2018"
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures"
+documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -23,16 +23,16 @@ travis-ci = { repository = "rust-lang-nursery/futures-rs" }
 appveyor = { repository = "rust-lang-nursery/futures-rs" }
 
 [dependencies]
-futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.15", default-features = false }
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.15", default-features = false }
-futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.15", default-features = false }
-futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.15", default-features = false }
-futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.15", default-features = false }
-futures-util-preview = { path = "../futures-util", version = "=0.3.0-alpha.15", default-features = false }
+futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false }
+futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.16", default-features = false }
+futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.16", default-features = false }
+futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.16", default-features = false }
+futures-util-preview = { path = "../futures-util", version = "=0.3.0-alpha.16", default-features = false }
 
 [dev-dependencies]
 pin-utils = "0.1.0-alpha.4"
-futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.15" }
+futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.16" }
 tokio = "0.1.11"
 
 [features]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -29,7 +29,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![warn(clippy::all)]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.15/futures")]
+#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures")]
 
 #[cfg(all(feature = "async-await", not(feature = "nightly")))]
 compile_error!("The `async-await` feature requires the `nightly` feature as an explicit opt-in to unstable features");


### PR DESCRIPTION
In relation to https://github.com/rust-lang/rust/issues/60660, it seems that `select!` macro of 0.3.0-alpha.15 cannot compile ([it uses `r#await!`](https://github.com/rust-lang-nursery/futures-rs/blob/0.3.0-alpha.15/futures-select-macro/src/lib.rs#L249)).

cc @cramertj @Nemo157 @seanmonstar 