### PR TITLE
Add #[must_use] to more types

### DIFF
--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -14,7 +14,7 @@ use crate::lock::Lock;
 /// A future for a value that will be provided by another asynchronous task.
 ///
 /// This is created by the [`channel`] function.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct Receiver<T> {
     inner: Arc<Inner<T>>,

--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -10,7 +10,7 @@ use std::thread::panicking;
 /// [`FutureTestExt::assert_unmoved`](super::FutureTestExt::assert_unmoved)
 /// method.
 #[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct AssertUnmoved<Fut> {
     future: Fut,
     this_ptr: *const AssertUnmoved<Fut>,

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -10,7 +10,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// [`FutureTestExt::pending_once`](super::FutureTestExt::pending_once)
 /// method.
 #[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct PendingOnce<Fut: Future> {
     future: Fut,
     polled_before: bool,

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -17,7 +17,7 @@ pub use io::{AsyncRead01CompatExt, AsyncWrite01CompatExt};
 /// Converts a futures 0.1 Future, Stream, AsyncRead, or AsyncWrite
 /// object to a futures 0.3-compatible version,
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Compat01As03<T> {
     pub(crate) inner: Spawn01<T>,
 }

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -29,7 +29,7 @@ use std::{
 /// [`Stream`](futures::stream::Stream) or
 /// [`Sink`](futures::sink::Sink).
 #[derive(Debug, Clone, Copy)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Compat<T> {
     pub(crate) inner: T,
 }

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -8,7 +8,7 @@ use alloc::sync::Arc;
 
 /// A future which can be remotely short-circuited using an `AbortHandle`.
 #[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Abortable<Fut> {
     future: Fut,
     inner: Arc<AbortInner>,

--- a/futures-util/src/future/catch_unwind.rs
+++ b/futures-util/src/future/catch_unwind.rs
@@ -8,7 +8,7 @@ use std::prelude::v1::*;
 
 /// Future for the [`catch_unwind`](super::FutureExt::catch_unwind) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct CatchUnwind<Fut> where Fut: Future {
     future: Fut,
 }

--- a/futures-util/src/future/chain.rs
+++ b/futures-util/src/future/chain.rs
@@ -2,7 +2,7 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
 
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub(crate) enum Chain<Fut1, Fut2, Data> {
     First(Fut1, Option<Data>),

--- a/futures-util/src/future/empty.rs
+++ b/futures-util/src/future/empty.rs
@@ -5,7 +5,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`empty`] function.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Empty<T> {
     _data: marker::PhantomData<T>,
 }

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -6,7 +6,7 @@ use futures_core::task::{Context, Poll};
 use pin_utils::unsafe_pinned;
 
 /// Future for the [`flatten`](super::FutureExt::flatten) method.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Flatten<Fut>
     where Fut: Future,
           Fut::Output: Future,

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -5,7 +5,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`fuse`](super::FutureExt::fuse) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Fuse<Fut: Future> {
     future: Option<Fut>,
 }

--- a/futures-util/src/future/inspect.rs
+++ b/futures-util/src/future/inspect.rs
@@ -5,7 +5,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`inspect`](super::FutureExt::inspect) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Inspect<Fut, F> where Fut: Future {
     future: Fut,
     f: Option<F>,

--- a/futures-util/src/future/into_stream.rs
+++ b/futures-util/src/future/into_stream.rs
@@ -5,7 +5,7 @@ use futures_core::task::{Context, Poll};
 use pin_utils::unsafe_pinned;
 
 /// Stream for the [`into_stream`](super::FutureExt::into_stream) method.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "streams do nothing unless polled"]
 #[derive(Debug)]
 pub struct IntoStream<Fut: Future> {
     future: Option<Fut>

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -14,7 +14,7 @@ macro_rules! generate {
         ($Join:ident, <$($Fut:ident),*>),
     )*) => ($(
         $(#[$doc])*
-        #[must_use = "futures do nothing unless polled"]
+        #[must_use = "futures do nothing unless you `.await` or poll them"]
         pub struct $Join<$($Fut: Future),*> {
             $($Fut: MaybeDone<$Fut>,)*
         }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -57,7 +57,7 @@ fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
 }
 
 /// Future for the [`join_all`] function.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct JoinAll<F>
 where
     F: Future,

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -4,7 +4,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`lazy`] function.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Lazy<F> {
     f: Option<F>
 }

--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -5,7 +5,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`map`](super::FutureExt::map) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Map<Fut, F> {
     future: Fut,
     f: Option<F>,

--- a/futures-util/src/future/never_error.rs
+++ b/futures-util/src/future/never_error.rs
@@ -5,7 +5,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`never_error`](super::FutureExt::never_error) combinator.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct NeverError<Fut> {
     future: Fut,
 }

--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -24,7 +24,7 @@ use pin_utils::unsafe_pinned;
 /// # });
 /// ```
 #[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct OptionFuture<F> {
     option: Option<F>,
 }

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -6,7 +6,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`poll_fn`] function.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct PollFn<F> {
     f: F,
 }

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -4,7 +4,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`ready`](ready()) function.
 #[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Ready<T>(Option<T>);
 
 impl<T> Unpin for Ready<T> {}

--- a/futures-util/src/future/remote_handle.rs
+++ b/futures-util/src/future/remote_handle.rs
@@ -21,7 +21,7 @@ use {
 
 /// The handle to a remote future returned by
 /// [`remote_handle`](crate::future::FutureExt::remote_handle).
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct RemoteHandle<T> {
     rx: Receiver<thread::Result<T>>,
@@ -55,7 +55,7 @@ type SendMsg<Fut> = Result<<Fut as Future>::Output, Box<(dyn Any + Send + 'stati
 
 /// A future which sends its output to the corresponding `RemoteHandle`.
 /// Created by [`remote_handle`](crate::future::FutureExt::remote_handle).
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Remote<Fut: Future> {
     tx: Option<Sender<SendMsg<Fut>>>,
     keep_running: Arc<AtomicBool>,

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -4,7 +4,7 @@ use futures_core::task::{Context, Poll};
 use crate::future::Either;
 
 /// Future for the [`select()`] function.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct Select<A: Unpin, B: Unpin> {
     inner: Option<(A, B)>,

--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`select_all`] function.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SelectAll<Fut> {
     inner: Vec<Fut>,
 }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
 
 /// Future for the [`shared`](super::FutureExt::shared) method.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Shared<Fut: Future> {
     inner: Option<Arc<Inner<Fut>>>,
     waker_key: usize,

--- a/futures-util/src/future/then.rs
+++ b/futures-util/src/future/then.rs
@@ -6,7 +6,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`then`](super::FutureExt::then) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Then<Fut1, Fut2, F> {
     chain: Chain<Fut1, Fut2, F>,
 }

--- a/futures-util/src/future/unit_error.rs
+++ b/futures-util/src/future/unit_error.rs
@@ -5,7 +5,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`unit_error`](super::FutureExt::unit_error) combinator.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UnitError<Fut> {
     future: Fut,
 }

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`close`](super::AsyncWriteExt::close) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Close<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
 }

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`close`](super::AsyncWriteExt::close) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct Close<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
 }

--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`copy_into`](super::AsyncReadExt::copy_into) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct CopyInto<'a, R: ?Sized + Unpin, W: ?Sized + Unpin> {
     reader: &'a mut R,
     read_done: bool,

--- a/futures-util/src/io/copy_into.rs
+++ b/futures-util/src/io/copy_into.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`copy_into`](super::AsyncReadExt::copy_into) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct CopyInto<'a, R: ?Sized + Unpin, W: ?Sized + Unpin> {
     reader: &'a mut R,
     read_done: bool,

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`flush`](super::AsyncWriteExt::flush) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Flush<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
 }

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`flush`](super::AsyncWriteExt::flush) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct Flush<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
 }

--- a/futures-util/src/io/lines.rs
+++ b/futures-util/src/io/lines.rs
@@ -8,6 +8,7 @@ use super::read_line::read_line_internal;
 
 /// Stream for the [`lines`](super::AsyncBufReadExt::lines) method.
 #[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
 pub struct Lines<R> {
     reader: R,
     buf: String,

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`read`](super::AsyncReadExt::read) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct Read<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut [u8],

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`read`](super::AsyncReadExt::read) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Read<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut [u8],

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`read_exact`](super::AsyncReadExt::read_exact) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct ReadExact<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut [u8],

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`read_exact`](super::AsyncReadExt::read_exact) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ReadExact<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut [u8],

--- a/futures-util/src/io/read_line.rs
+++ b/futures-util/src/io/read_line.rs
@@ -9,6 +9,7 @@ use super::read_until::read_until_internal;
 
 /// Future for the [`read_line`](super::AsyncBufReadExt::read_line) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct ReadLine<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut String,

--- a/futures-util/src/io/read_line.rs
+++ b/futures-util/src/io/read_line.rs
@@ -9,7 +9,7 @@ use super::read_until::read_until_internal;
 
 /// Future for the [`read_line`](super::AsyncBufReadExt::read_line) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ReadLine<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut String,

--- a/futures-util/src/io/read_to_end.rs
+++ b/futures-util/src/io/read_to_end.rs
@@ -7,6 +7,7 @@ use std::vec::Vec;
 
 /// Future for the [`read_to_end`](super::AsyncReadExt::read_to_end) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct ReadToEnd<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut Vec<u8>,

--- a/futures-util/src/io/read_to_end.rs
+++ b/futures-util/src/io/read_to_end.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 
 /// Future for the [`read_to_end`](super::AsyncReadExt::read_to_end) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ReadToEnd<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     buf: &'a mut Vec<u8>,

--- a/futures-util/src/io/read_until.rs
+++ b/futures-util/src/io/read_until.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`read_until`](super::AsyncBufReadExt::read_until) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct ReadUntil<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     byte: u8,

--- a/futures-util/src/io/read_until.rs
+++ b/futures-util/src/io/read_until.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`read_until`](super::AsyncBufReadExt::read_until) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ReadUntil<'a, R: ?Sized + Unpin> {
     reader: &'a mut R,
     byte: u8,

--- a/futures-util/src/io/seek.rs
+++ b/futures-util/src/io/seek.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`seek`](crate::io::AsyncSeekExt::seek) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct Seek<'a, S: ?Sized + Unpin> {
     seek: &'a mut S,
     pos: SeekFrom,

--- a/futures-util/src/io/seek.rs
+++ b/futures-util/src/io/seek.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 
 /// Future for the [`seek`](crate::io::AsyncSeekExt::seek) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Seek<'a, S: ?Sized + Unpin> {
     seek: &'a mut S,
     pos: SeekFrom,

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`write_all`](super::AsyncWriteExt::write_all) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct WriteAll<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
     buf: &'a [u8],

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 
 /// Future for the [`write_all`](super::AsyncWriteExt::write_all) method.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless polled"]
 pub struct WriteAll<'a, W: ?Sized + Unpin> {
     writer: &'a mut W,
     buf: &'a [u8],

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -259,7 +259,7 @@ impl<T> Drop for BiLockGuard<'_, T> {
 
 /// Future returned by `BiLock::lock` which will resolve when the lock is
 /// acquired.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct BiLockAcquire<'a, T> {
     bilock: &'a BiLock<T>,

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -6,7 +6,7 @@ use futures_sink::Sink;
 
 /// Future for the [`close`](super::SinkExt::close) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Close<'a, Si: Sink<Item> + Unpin + ?Sized, Item> {
     sink: &'a mut Si,
     _phantom: PhantomData<fn(Item)>,

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -6,7 +6,7 @@ use futures_sink::Sink;
 
 /// Sink for the [`drain`] function.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "sinks do nothing unless polled"]
 pub struct Drain<T> {
     marker: PhantomData<T>,
 }

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -7,7 +7,7 @@ use pin_utils::unsafe_pinned;
 
 /// Sink for the [`sink_err_into`](super::SinkExt::sink_err_into) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "sinks do nothing unless polled"]
 pub struct SinkErrInto<Si: Sink<Item>, Item, E> {
     sink: SinkMapErr<Si, fn(Si::SinkError) -> E>,
 }

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -8,6 +8,7 @@ use pin_utils::unsafe_pinned;
 ///
 /// Backpressure from any downstream sink propagates up, which means that this sink
 /// can only process items as fast as its _slowest_ downstream sink.
+#[must_use = "sinks do nothing unless polled"]
 pub struct Fanout<Si1, Si2> {
     sink1: Si1,
     sink2: Si2

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -6,7 +6,7 @@ use futures_sink::Sink;
 
 /// Future for the [`flush`](super::SinkExt::flush) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Flush<'a, Si: Sink<Item> + Unpin + ?Sized, Item> {
     sink: &'a mut Si,
     _phantom: PhantomData<fn(Item)>,

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -5,7 +5,7 @@ use futures_sink::Sink;
 
 /// Future for the [`send`](super::SinkExt::send) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Send<'a, Si: Sink<Item> + Unpin + ?Sized, Item> {
     sink: &'a mut Si,
     item: Option<Item>,

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -7,7 +7,7 @@ use futures_sink::Sink;
 
 /// Future for the [`send_all`](super::SinkExt::send_all) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SendAll<'a, Si, St>
 where
     Si: Sink<St::Item> + Unpin + ?Sized,

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -7,7 +7,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`collect`](super::StreamExt::collect) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Collect<St, C> {
     stream: St,
     collection: C,

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -7,7 +7,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`collect`](super::StreamExt::collect) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct Collect<St, C> {
     stream: St,
     collection: C,

--- a/futures-util/src/stream/concat.rs
+++ b/futures-util/src/stream/concat.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`concat`](super::StreamExt::concat) method.
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct Concat<St: Stream> {
     stream: St,
     accum: Option<St::Item>,

--- a/futures-util/src/stream/concat.rs
+++ b/futures-util/src/stream/concat.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`concat`](super::StreamExt::concat) method.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Concat<St: Stream> {
     stream: St,
     accum: Option<St::Item>,

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`fold`](super::StreamExt::fold) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct Fold<St, Fut, T, F> {
     stream: St,
     f: F,

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`fold`](super::StreamExt::fold) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Fold<St, Fut, T, F> {
     stream: St,
     f: F,

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`for_each`](super::StreamExt::for_each) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct ForEach<St, Fut, F> {
     stream: St,
     f: F,

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`for_each`](super::StreamExt::for_each) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ForEach<St, Fut, F> {
     stream: St,
     f: F,

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -9,7 +9,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// Future for the [`for_each_concurrent`](super::StreamExt::for_each_concurrent)
 /// method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ForEachConcurrent<St, Fut, F> {
     stream: Option<St>,
     f: F,

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -9,7 +9,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// Future for the [`for_each_concurrent`](super::StreamExt::for_each_concurrent)
 /// method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct ForEachConcurrent<St, Fut, F> {
     stream: Option<St>,
     f: F,

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -10,7 +10,7 @@ const INVALID_POLL: &str = "polled `Forward` after completion";
 
 /// Future for the [`forward`](super::StreamExt::forward) method.
 #[derive(Debug)]
-#[must_use = "steams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct Forward<St: TryStream, Si: Sink<St::Ok>> {
     sink: Option<Si>,
     stream: Fuse<St>,

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -10,7 +10,7 @@ const INVALID_POLL: &str = "polled `Forward` after completion";
 
 /// Future for the [`forward`](super::StreamExt::forward) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Forward<St: TryStream, Si: Sink<St::Ok>> {
     sink: Option<Si>,
     stream: Fuse<St>,

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -9,7 +9,7 @@ use core::iter::FromIterator;
 use core::pin::Pin;
 use alloc::collections::binary_heap::{BinaryHeap, PeekMut};
 
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 struct OrderWrapper<T> {
     data: T, // A future or a future's output

--- a/futures-util/src/stream/into_future.rs
+++ b/futures-util/src/stream/into_future.rs
@@ -5,7 +5,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`into_future`](super::StreamExt::into_future) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct StreamFuture<St> {
     stream: Option<St>,
 }

--- a/futures-util/src/stream/next.rs
+++ b/futures-util/src/stream/next.rs
@@ -5,7 +5,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`next`](super::StreamExt::next) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Next<'a, St> {
     stream: &'a mut St,
 }

--- a/futures-util/src/stream/select_next_some.rs
+++ b/futures-util/src/stream/select_next_some.rs
@@ -7,7 +7,7 @@ use crate::stream::StreamExt;
 /// Future for the [`select_next_some`](super::StreamExt::select_next_some)
 /// method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SelectNextSome<'a, St> {
     stream: &'a mut St,
 }

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -11,8 +11,8 @@ use std::error::Error;
 use crate::lock::BiLock;
 
 /// A `Stream` part of the split pair
-#[must_use = "streams do nothing unless polled"]
 #[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
 pub struct SplitStream<S>(BiLock<S>);
 
 impl<S> Unpin for SplitStream<S> {}
@@ -49,6 +49,7 @@ fn SplitSink<S: Sink<Item>, Item>(lock: BiLock<S>) -> SplitSink<S, Item> {
 
 /// A `Sink` part of the split pair
 #[derive(Debug)]
+#[must_use = "sinks do nothing unless polled"]
 pub struct SplitSink<S: Sink<Item>, Item> {
     lock: BiLock<S>,
     slot: Option<Item>,

--- a/futures-util/src/try_future/and_then.rs
+++ b/futures-util/src/try_future/and_then.rs
@@ -6,7 +6,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`and_then`](super::TryFutureExt::and_then) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct AndThen<Fut1, Fut2, F> {
     try_chain: TryChain<Fut1, Fut2, F>,
 }

--- a/futures-util/src/try_future/err_into.rs
+++ b/futures-util/src/try_future/err_into.rs
@@ -6,7 +6,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`err_into`](super::TryFutureExt::err_into) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ErrInto<Fut, E> {
     future: Fut,
     _marker: PhantomData<E>,

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -11,8 +11,9 @@ enum State<Fut, Si> {
 }
 use self::State::*;
 
-/// Future for the [`flatten_sink`](super::TryFutureExt::flatten_sink) method.
+/// Sink for the [`flatten_sink`](super::TryFutureExt::flatten_sink) method.
 #[derive(Debug)]
+#[must_use = "sinks do nothing unless polled"]
 pub struct FlattenSink<Fut, Si>(State<Fut, Si>);
 
 impl<Fut: Unpin, Si: Unpin> Unpin for FlattenSink<Fut, Si> {}

--- a/futures-util/src/try_future/into_future.rs
+++ b/futures-util/src/try_future/into_future.rs
@@ -5,7 +5,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`into_future`](super::TryFutureExt::into_future) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct IntoFuture<Fut> {
     future: Fut,
 }

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -5,7 +5,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`map_err`](super::TryFutureExt::map_err) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct MapErr<Fut, F> {
     future: Fut,
     f: Option<F>,

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -5,7 +5,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`map_ok`](super::TryFutureExt::map_ok) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct MapOk<Fut, F> {
     future: Fut,
     f: Option<F>,

--- a/futures-util/src/try_future/or_else.rs
+++ b/futures-util/src/try_future/or_else.rs
@@ -6,7 +6,7 @@ use pin_utils::unsafe_pinned;
 
 /// Future for the [`or_else`](super::TryFutureExt::or_else) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct OrElse<Fut1, Fut2, F> {
     try_chain: TryChain<Fut1, Fut2, F>,
 }

--- a/futures-util/src/try_future/select_ok.rs
+++ b/futures-util/src/try_future/select_ok.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 
 /// Future for the [`select_ok`] function.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct SelectOk<Fut> {
     inner: Vec<Fut>,
 }

--- a/futures-util/src/try_future/try_chain.rs
+++ b/futures-util/src/try_future/try_chain.rs
@@ -2,7 +2,7 @@ use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::task::{Context, Poll};
 
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub(crate) enum TryChain<Fut1, Fut2, Data> {
     First(Fut1, Option<Data>),

--- a/futures-util/src/try_future/try_join.rs
+++ b/futures-util/src/try_future/try_join.rs
@@ -14,7 +14,7 @@ macro_rules! generate {
         ($Join:ident, <Fut1, $($Fut:ident),*>),
     )*) => ($(
         $(#[$doc])*
-        #[must_use = "futures do nothing unless polled"]
+        #[must_use = "futures do nothing unless you `.await` or poll them"]
         pub struct $Join<Fut1: TryFuture, $($Fut: TryFuture),*> {
             Fut1: MaybeDone<IntoFuture<Fut1>>,
             $($Fut: MaybeDone<IntoFuture<$Fut>>,)*

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -61,7 +61,7 @@ enum FinalState<E = ()> {
 }
 
 /// Future for the [`try_join_all`] function.
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryJoinAll<F>
 where
     F: TryFuture,

--- a/futures-util/src/try_future/unwrap_or_else.rs
+++ b/futures-util/src/try_future/unwrap_or_else.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// Future for the [`unwrap_or_else`](super::TryFutureExt::unwrap_or_else)
 /// method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct UnwrapOrElse<Fut, F> {
     future: Fut,
     f: Option<F>,

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -7,7 +7,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_collect`](super::TryStreamExt::try_collect) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryCollect<St, C> {
     stream: St,
     items: C,

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -7,7 +7,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_collect`](super::TryStreamExt::try_collect) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct TryCollect<St, C> {
     stream: St,
     items: C,

--- a/futures-util/src/try_stream/try_concat.rs
+++ b/futures-util/src/try_stream/try_concat.rs
@@ -7,7 +7,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_concat`](super::TryStreamExt::try_concat) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryConcat<St: TryStream> {
     stream: St,
     accum: Option<St::Ok>,

--- a/futures-util/src/try_stream/try_concat.rs
+++ b/futures-util/src/try_stream/try_concat.rs
@@ -7,7 +7,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_concat`](super::TryStreamExt::try_concat) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct TryConcat<St: TryStream> {
     stream: St,
     accum: Option<St::Ok>,

--- a/futures-util/src/try_stream/try_fold.rs
+++ b/futures-util/src/try_stream/try_fold.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_fold`](super::TryStreamExt::try_fold) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryFold<St, Fut, T, F> {
     stream: St,
     f: F,

--- a/futures-util/src/try_stream/try_fold.rs
+++ b/futures-util/src/try_stream/try_fold.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_fold`](super::TryStreamExt::try_fold) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct TryFold<St, Fut, T, F> {
     stream: St,
     f: F,

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_for_each`](super::TryStreamExt::try_for_each) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct TryForEach<St, Fut, F> {
     stream: St,
     f: F,

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -6,7 +6,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_for_each`](super::TryStreamExt::try_for_each) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryForEach<St, Fut, F> {
     stream: St,
     f: F,

--- a/futures-util/src/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/try_stream/try_for_each_concurrent.rs
@@ -11,7 +11,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// [`try_for_each_concurrent`](super::TryStreamExt::try_for_each_concurrent)
 /// method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryForEachConcurrent<St, Fut, F> {
     stream: Option<St>,
     f: F,

--- a/futures-util/src/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/try_stream/try_for_each_concurrent.rs
@@ -11,7 +11,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// [`try_for_each_concurrent`](super::TryStreamExt::try_for_each_concurrent)
 /// method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct TryForEachConcurrent<St, Fut, F> {
     stream: Option<St>,
     f: F,

--- a/futures-util/src/try_stream/try_next.rs
+++ b/futures-util/src/try_stream/try_next.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 
 /// Future for the [`try_next`](super::TryStreamExt::try_next) method.
 #[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
+#[must_use = "futures do nothing unless polled"]
 pub struct TryNext<'a, St: Unpin> {
     stream: &'a mut St,
 }

--- a/futures-util/src/try_stream/try_next.rs
+++ b/futures-util/src/try_stream/try_next.rs
@@ -5,7 +5,7 @@ use core::pin::Pin;
 
 /// Future for the [`try_next`](super::TryStreamExt::try_next) method.
 #[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryNext<'a, St: Unpin> {
     stream: &'a mut St,
 }


### PR DESCRIPTION
Also fixes some `#[must_use]` messages.

EDIT: also updates `#[must_use]` message of impl `Future` types.