### PR TITLE
Remove try_ready! macro

### DIFF
--- a/futures-util/src/macros/poll.rs
+++ b/futures-util/src/macros/poll.rs
@@ -1,19 +1,3 @@
-/// Extracts the successful type of a `Poll<Result<T, E>>`.
-///
-/// This macro bakes in propagation of `Pending` and `Err` signals by returning early.
-#[macro_export]
-macro_rules! try_ready {
-    ($x:expr) => {
-        match $x {
-            $crate::core_reexport::task::Poll::Ready(Ok(x)) => x,
-            $crate::core_reexport::task::Poll::Ready(Err(e)) =>
-                return $crate::core_reexport::task::Poll::Ready(Err(e.into())),
-            $crate::core_reexport::task::Poll::Pending =>
-                return $crate::core_reexport::task::Poll::Pending,
-        }
-    }
-}
-
 /// Extracts the successful type of a `Poll<T>`.
 ///
 /// This macro bakes in propagation of `Pending` signals by returning early.

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -63,10 +63,7 @@ compile_error!("The `never-type` feature requires the `nightly` feature as an ex
 #[doc(hidden)] pub use futures_core::task::Poll;
 
 // Macro reexports
-pub use futures_util::{
-    // Error/readiness propagation
-    try_ready, ready,
-};
+pub use futures_util::ready; // Readiness propagation
 #[cfg(feature = "async-await")]
 pub use futures_util::{
     // Async-await


### PR DESCRIPTION
`Poll` implements the `Try` trait, so we can use the `?` operator and `ready!` macro to do the equivalent of `try_ready!` macro.

Actually, `ready!` + `?` operator is more powerful than `try_ready!` because it also can be used in functions that return `Poll<Option<Result>>`. (Also, `Result` + `?` can be used in functions that return `Poll<Result>` and `Poll<Option<Result>>` as well.)

I think it is not a problem to remove `try_ready!`, and it may also rather increase code consistency.

Related: https://github.com/rust-lang-nursery/futures-rs/pull/1599, https://github.com/rust-lang-nursery/futures-rs/pull/1572