### PR TITLE
Implement std::error::Error for SpawnError

### DIFF
--- a/futures-core/src/task/spawn.rs
+++ b/futures-core/src/task/spawn.rs
@@ -72,6 +72,7 @@ impl fmt::Display for SpawnError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SpawnError {}
 
 impl SpawnError {

--- a/futures-core/src/task/spawn.rs
+++ b/futures-core/src/task/spawn.rs
@@ -66,6 +66,14 @@ impl fmt::Debug for SpawnError {
     }
 }
 
+impl fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Executor is shutdown")
+    }
+}
+
+impl std::error::Error for SpawnError {}
+
 impl SpawnError {
     /// Spawning failed because the executor has been shut down.
     pub fn shutdown() -> Self {


### PR DESCRIPTION
Pretty straightforward - just a `Display` and `Error` implementation for `SpawnError`.