### PR TITLE
Replace `vec` with `bufs` in AsyncRead::poll_read_vectored

### DIFF
--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -138,13 +138,13 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoSliceMut<'_>])
+        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
             -> Poll<Result<usize>>
         {
-            if let Some(ref mut first_iovec) = vec.get_mut(0) {
+            if let Some(ref mut first_iovec) = bufs.get_mut(0) {
                 self.poll_read(cx, first_iovec)
             } else {
-                // `vec` is empty.
+                // `bufs` is empty.
                 Poll::Ready(Ok(0))
             }
         }
@@ -339,10 +339,10 @@ mod if_std {
                 Pin::new(&mut **self).poll_read(cx, buf)
             }
 
-            fn poll_read_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoSliceMut<'_>])
+            fn poll_read_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
                 -> Poll<Result<usize>>
             {
-                Pin::new(&mut **self).poll_read_vectored(cx, vec)
+                Pin::new(&mut **self).poll_read_vectored(cx, bufs)
             }
         }
     }
@@ -370,10 +370,10 @@ mod if_std {
             Pin::get_mut(self).as_mut().poll_read(cx, buf)
         }
 
-        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoSliceMut<'_>])
+        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
             -> Poll<Result<usize>>
         {
-            Pin::get_mut(self).as_mut().poll_read_vectored(cx, vec)
+            Pin::get_mut(self).as_mut().poll_read_vectored(cx, bufs)
         }
     }
 
@@ -391,10 +391,10 @@ mod if_std {
                 Poll::Ready(StdIo::Read::read(&mut *self, buf))
             }
 
-            fn poll_read_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, vec: &mut [IoSliceMut<'_>])
+            fn poll_read_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
                 -> Poll<Result<usize>>
             {
-                Poll::Ready(StdIo::Read::read_vectored(&mut *self, vec))
+                Poll::Ready(StdIo::Read::read_vectored(&mut *self, bufs))
             }
         }
     }

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -43,10 +43,10 @@ impl<R: AsyncRead> AsyncRead for ReadHalf<R> {
         lock_and_then(&self.handle, cx, |l, cx| l.poll_read(cx, buf))
     }
 
-    fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, vec: &mut [IoSliceMut<'_>])
+    fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
         -> Poll<io::Result<usize>>
     {
-        lock_and_then(&self.handle, cx, |l, cx| l.poll_read_vectored(cx, vec))
+        lock_and_then(&self.handle, cx, |l, cx| l.poll_read_vectored(cx, bufs))
     }
 }
 


### PR DESCRIPTION
Use the same variable name as the document.
https://github.com/rust-lang-nursery/futures-rs/blob/d75f6efd064a30dd8564b7a6927c63606c7ad419/futures-io/src/lib.rs#L119