### PR TITLE
Remove Error::description implementations

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -178,15 +178,7 @@ impl fmt::Display for SendError {
     }
 }
 
-impl Error for SendError {
-    fn description(&self) -> &str {
-        if self.is_full() {
-            "send failed because channel is full"
-        } else {
-            "send failed because receiver is gone"
-        }
-    }
-}
+impl Error for SendError {}
 
 impl SendError {
     /// Returns true if this error is a result of the channel being full.
@@ -224,15 +216,7 @@ impl<T> fmt::Display for TrySendError<T> {
     }
 }
 
-impl<T: Any> Error for TrySendError<T> {
-    fn description(&self) -> &str {
-        if self.is_full() {
-            "send failed because channel is full"
-        } else {
-            "send failed because receiver is gone"
-        }
-    }
-}
+impl<T: Any> Error for TrySendError<T> {}
 
 impl<T> TrySendError<T> {
     /// Returns true if this error is a result of the channel being full.
@@ -265,15 +249,11 @@ impl fmt::Debug for TryRecvError {
 
 impl fmt::Display for TryRecvError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.write_str(self.description())
+        write!(fmt, "receiver channel is empty")
     }
 }
 
-impl Error for TryRecvError {
-    fn description(&self) -> &str {
-        "receiver channel is empty"
-    }
-}
+impl Error for TryRecvError {}
 
 #[derive(Debug)]
 struct Inner<T> {

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -387,11 +387,7 @@ impl fmt::Display for Canceled {
     }
 }
 
-impl Error for Canceled {
-    fn description(&self) -> &str {
-        "oneshot canceled"
-    }
-}
+impl Error for Canceled {}
 
 impl<T> Receiver<T> {
     /// Gracefully close this receiver, preventing any subsequent attempts to

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -213,11 +213,7 @@ impl<T> fmt::Display for ReuniteError<T> {
 }
 
 #[cfg(feature = "std")]
-impl<T: Any> Error for ReuniteError<T> {
-    fn description(&self) -> &str {
-        "tried to reunite two BiLocks that don't form a pair"
-    }
-}
+impl<T: Any> Error for ReuniteError<T> {}
 
 /// Returned RAII guard from the `poll_lock` method.
 ///

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -75,8 +75,7 @@ impl fmt::Display for DrainError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for DrainError {
-}
+impl std::error::Error for DrainError {}
 
 impl DrainError {
     /// Convert this drain error into any type

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -144,8 +144,4 @@ impl<T: Sink<Item>, Item> fmt::Display for ReuniteError<T, Item> {
 }
 
 #[cfg(feature = "std")]
-impl<T: Any + Sink<Item>, Item> Error for ReuniteError<T, Item> {
-    fn description(&self) -> &str {
-        "tried to reunite a SplitStream and SplitSink that don't form a pair"
-    }
-}
+impl<T: Any + Sink<Item>, Item> Error for ReuniteError<T, Item> {}


### PR DESCRIPTION
https://doc.rust-lang.org/nightly/std/error/trait.Error.html#method.description

> **This method is soft-deprecated.**
> 
> Although using it won’t cause compilation warning, new code should use `Display` instead and new `impl`s can omit it.
> 
> To obtain error description as a string, use `to_string()`.

Some implementations are already doing this, but for consistency, it would be better to apply to all implementations.