### PR TITLE
Use #[warn(unreachable_pub)]

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_channel")]

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -41,7 +41,7 @@
 // NOTE: this implementation is lifted from the standard library and only
 //       slightly modified
 
-pub use self::PopResult::*;
+pub(super) use self::PopResult::*;
 use std::prelude::v1::*;
 
 use std::thread;
@@ -50,7 +50,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 /// A result of the `pop` function.
-pub enum PopResult<T> {
+pub(super) enum PopResult<T> {
     /// Some data has been popped
     Data(T),
     /// The queue is empty
@@ -72,7 +72,7 @@ struct Node<T> {
 /// may be safely shared so long as it is guaranteed that there is only one
 /// popper at a time (many pushers are allowed).
 #[derive(Debug)]
-pub struct Queue<T> {
+pub(super) struct Queue<T> {
     head: AtomicPtr<Node<T>>,
     tail: UnsafeCell<*mut Node<T>>,
 }
@@ -92,7 +92,7 @@ impl<T> Node<T> {
 impl<T> Queue<T> {
     /// Creates a new queue that is safe to share among multiple producers and
     /// one consumer.
-    pub fn new() -> Queue<T> {
+    pub(super) fn new() -> Queue<T> {
         let stub = unsafe { Node::new(None) };
         Queue {
             head: AtomicPtr::new(stub),
@@ -101,7 +101,7 @@ impl<T> Queue<T> {
     }
 
     /// Pushes a new value onto this queue.
-    pub fn push(&self, t: T) {
+    pub(super) fn push(&self, t: T) {
         unsafe {
             let n = Node::new(Some(t));
             let prev = self.head.swap(n, Ordering::AcqRel);
@@ -121,7 +121,7 @@ impl<T> Queue<T> {
     /// it does not currently have access to it at this time.
     ///
     /// This function is unsafe because only one thread can call it at a time.
-    pub unsafe fn pop(&self) -> PopResult<T> {
+    pub(super) unsafe fn pop(&self) -> PopResult<T> {
         let tail = *self.tail.get();
         let next = (*tail).next.load(Ordering::Acquire);
 
@@ -141,7 +141,7 @@ impl<T> Queue<T> {
     /// queue state instead of returning `Inconsistent`.
     ///
     /// This function is unsafe because only one thread can call it at a time.
-    pub unsafe fn pop_spin(&self) -> Option<T> {
+    pub(super) unsafe fn pop_spin(&self) -> Option<T> {
         loop {
             match self.pop() {
                 Empty => return None,

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_core")]

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -5,7 +5,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_executor")]

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -297,7 +297,7 @@ struct WakeHandle {
 impl Task {
     /// Actually run the task (invoking `poll` on the future) on the current
     /// thread.
-    pub fn run(self) {
+    fn run(self) {
         let Task { mut future, wake_handle, mut exec } = self;
         let waker = waker_ref(&wake_handle);
         let mut cx = Context::from_waker(&waker);

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -10,7 +10,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_io")]
@@ -27,12 +27,16 @@ mod if_std {
 
     // Re-export some types from `std::io` so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
-    pub use self::StdIo::Error as Error;
-    pub use self::StdIo::ErrorKind as ErrorKind;
-    pub use self::StdIo::Result as Result;
-    pub use self::StdIo::IoSlice as IoSlice;
-    pub use self::StdIo::IoSliceMut as IoSliceMut;
-    pub use self::StdIo::SeekFrom as SeekFrom;
+    #[allow(clippy::useless_attribute)] // https://github.com/rust-lang/rust-clippy/issues/4106
+    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+    pub use self::StdIo::{
+        Error as Error,
+        ErrorKind as ErrorKind,
+        Result as Result,
+        IoSlice as IoSlice,
+        IoSliceMut as IoSliceMut,
+        SeekFrom as SeekFrom,
+    };
 
     /// A type used to conditionally initialize buffers passed to `AsyncRead`
     /// methods, modeled after `std`.

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -1,7 +1,7 @@
 //! The futures-rs `select! macro implementation.
 
 #![recursion_limit="128"]
-#![warn(rust_2018_idioms)]
+#![warn(rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 extern crate proc_macro;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -4,7 +4,7 @@
 //! asynchronously.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_sink")]

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -1,6 +1,6 @@
 //! Utilities to make testing [`Future`s](futures_core::Future) easier
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_test")]

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -12,6 +12,8 @@ use std::task::Context;
 use futures_sink::Sink as Sink03;
 
 #[cfg(feature = "io-compat")]
+#[allow(clippy::useless_attribute)] // https://github.com/rust-lang/rust-clippy/issues/4106
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use io::{AsyncRead01CompatExt, AsyncWrite01CompatExt};
 
 /// Converts a futures 0.1 Future, Stream, AsyncRead, or AsyncWrite

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -31,7 +31,7 @@ fn lock_and_then<T, U, E, F>(
     }
 }
 
-pub fn split<T: AsyncRead + AsyncWrite>(t: T) -> (ReadHalf<T>, WriteHalf<T>) {
+pub(super) fn split<T: AsyncRead + AsyncWrite>(t: T) -> (ReadHalf<T>, WriteHalf<T>) {
     let (a, b) = BiLock::new(t);
     (ReadHalf { handle: a }, WriteHalf { handle: b })
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -6,7 +6,7 @@
 #![cfg_attr(feature = "never-type", feature(never_type))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_util")]

--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -5,6 +5,7 @@ mod mutex;
 #[cfg(feature = "std")]
 pub use self::mutex::{Mutex, MutexLockFuture, MutexGuard};
 
+#[allow(unreachable_pub)]
 mod bilock;
 #[cfg(any(test, feature = "bench"))]
 pub use self::bilock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -118,7 +118,7 @@ impl<S: Sink<Item>, Item> Sink<Item> for SplitSink<S, Item> {
     }
 }
 
-pub fn split<S: Stream + Sink<Item>, Item>(s: S) -> (SplitSink<S, Item>, SplitStream<S>) {
+pub(super) fn split<S: Stream + Sink<Item>, Item>(s: S) -> (SplitSink<S, Item>, SplitStream<S>) {
     let (a, b) = BiLock::new(s);
     let read = SplitStream(a);
     let write = SplitSink(b);

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -26,7 +26,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures")]


### PR DESCRIPTION
I think it helps to avoid problems like https://github.com/rust-lang-nursery/futures-rs/issues/1477. (Seems there are still some false positives, but I think their impact is small)