### PR TITLE
[WIP] Use pin-project instead of unsafe_[un]pinned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
   "futures-util",
   "futures-test",
 ]
+
+[patch.crates-io]
+pin-project = { git = "https://github.com/taiki-e/pin-project", branch = "pin_project" }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -42,6 +42,7 @@ slab = { version = "0.4", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
+pin-project = "0.3.2"
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]

--- a/futures-util/src/future/catch_unwind.rs
+++ b/futures-util/src/future/catch_unwind.rs
@@ -1,20 +1,20 @@
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 use std::any::Any;
-use std::pin::Pin;
 use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
+use std::pin::Pin;
 
 /// Future for the [`catch_unwind`](super::FutureExt::catch_unwind) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct CatchUnwind<Fut> where Fut: Future {
+    #[pin]
     future: Fut,
 }
 
 impl<Fut> CatchUnwind<Fut> where Fut: Future + UnwindSafe {
-    unsafe_pinned!(future: Fut);
-
     pub(super) fn new(future: Fut) -> CatchUnwind<Fut> {
         CatchUnwind { future }
     }
@@ -25,7 +25,8 @@ impl<Fut> Future for CatchUnwind<Fut>
 {
     type Output = Result<Fut::Output, Box<dyn Any + Send>>;
 
+    #[pin_project(self)]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        catch_unwind(AssertUnwindSafe(|| self.future().poll(cx)))?.map(Ok)
+        catch_unwind(AssertUnwindSafe(|| self.future.poll(cx)))?.map(Ok)
     }
 }

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -3,14 +3,16 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`flatten`](super::FutureExt::flatten) method.
+#[unsafe_project]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Flatten<Fut>
     where Fut: Future,
           Fut::Output: Future,
 {
+    #[pin]
     state: Chain<Fut, Fut::Output, ()>,
 }
 
@@ -18,8 +20,6 @@ impl<Fut> Flatten<Fut>
     where Fut: Future,
           Fut::Output: Future,
 {
-    unsafe_pinned!(state: Chain<Fut, Fut::Output, ()>);
-
     pub(super) fn new(future: Fut) -> Flatten<Fut> {
         Flatten {
             state: Chain::new(future, ()),
@@ -51,7 +51,8 @@ impl<Fut> Future for Flatten<Fut>
 {
     type Output = <Fut::Output as Future>::Output;
 
+    #[pin_project(self)]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.state().poll(cx, |a, ()| a)
+        self.state.poll(cx, |a, ()| a)
     }
 }

--- a/futures-util/src/future/into_stream.rs
+++ b/futures-util/src/future/into_stream.rs
@@ -2,18 +2,18 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`into_stream`](super::FutureExt::into_stream) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 #[derive(Debug)]
 pub struct IntoStream<Fut: Future> {
+    #[pin]
     future: Option<Fut>
 }
 
 impl<Fut: Future> IntoStream<Fut> {
-    unsafe_pinned!(future: Option<Fut>);
-
     pub(super) fn new(future: Fut) -> IntoStream<Fut> {
         IntoStream {
             future: Some(future)
@@ -24,13 +24,14 @@ impl<Fut: Future> IntoStream<Fut> {
 impl<Fut: Future> Stream for IntoStream<Fut> {
     type Item = Fut::Output;
 
+    #[pin_project(self)]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let v = match self.as_mut().future().as_pin_mut() {
+        let v = match self.future.as_mut().as_pin_mut() {
             Some(fut) => ready!(fut.poll(cx)),
             None => return Poll::Ready(None),
         };
 
-        self.as_mut().future().set(None);
+        self.future.set(None);
         Poll::Ready(Some(v))
     }
 }

--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -1,27 +1,23 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`map`](super::FutureExt::map) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Map<Fut, F> {
+    #[pin]
     future: Fut,
     f: Option<F>,
 }
 
 impl<Fut, F> Map<Fut, F> {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(f: Option<F>);
-
-    /// Creates a new Map.
     pub(super) fn new(future: Fut, f: F) -> Map<Fut, F> {
         Map { future, f: Some(f) }
     }
 }
-
-impl<Fut: Unpin, F> Unpin for Map<Fut, F> {}
 
 impl<Fut, F> FusedFuture for Map<Fut, F> {
     fn is_terminated(&self) -> bool { self.f.is_none() }
@@ -33,12 +29,13 @@ impl<Fut, F, T> Future for Map<Fut, F>
 {
     type Output = T;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        self.as_mut()
-            .future()
+        self.future
+            .as_mut()
             .poll(cx)
             .map(|output| {
-                let f = self.f().take()
+                let f = self.f.take()
                     .expect("Map must not be polled after it returned `Poll::Ready`");
                 f(output)
             })

--- a/futures-util/src/future/never_error.rs
+++ b/futures-util/src/future/never_error.rs
@@ -2,24 +2,22 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{self, Poll};
 use futures_core::never::Never;
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`never_error`](super::FutureExt::never_error) combinator.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct NeverError<Fut> {
+    #[pin]
     future: Fut,
 }
 
 impl<Fut> NeverError<Fut> {
-    unsafe_pinned!(future: Fut);
-
     pub(super) fn new(future: Fut) -> NeverError<Fut> {
         NeverError { future }
     }
 }
-
-impl<Fut: Unpin> Unpin for NeverError<Fut> {}
 
 impl<Fut: FusedFuture> FusedFuture for NeverError<Fut> {
     fn is_terminated(&self) -> bool { self.future.is_terminated() }
@@ -30,7 +28,8 @@ impl<Fut, T> Future for NeverError<Fut>
 {
     type Output = Result<T, Never>;
 
+    #[pin_project(self)]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        self.future().poll(cx).map(Ok)
+        self.future.poll(cx).map(Ok)
     }
 }

--- a/futures-util/src/io/lines.rs
+++ b/futures-util/src/io/lines.rs
@@ -1,22 +1,23 @@
+use super::read_line::read_line_internal;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use futures_io::AsyncBufRead;
+use pin_project::{pin_project, unsafe_project};
 use std::io;
 use std::mem;
 use std::pin::Pin;
-use super::read_line::read_line_internal;
 
 /// Stream for the [`lines`](super::AsyncBufReadExt::lines) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Lines<R> {
+    #[pin]
     reader: R,
     buf: String,
     bytes: Vec<u8>,
     read: usize,
 }
-
-impl<R: Unpin> Unpin for Lines<R> {}
 
 impl<R: AsyncBufRead> Lines<R> {
     pub(super) fn new(reader: R) -> Self {
@@ -32,9 +33,10 @@ impl<R: AsyncBufRead> Lines<R> {
 impl<R: AsyncBufRead> Stream for Lines<R> {
     type Item = io::Result<String>;
 
+    #[pin_project(self)]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let Self { reader, buf, bytes, read } = unsafe { self.get_unchecked_mut() };
-        let reader = unsafe { Pin::new_unchecked(reader) };
+        #[project]
+        let Lines { reader, buf, bytes, read } = self;
         let n = ready!(read_line_internal(reader, buf, bytes, read, cx))?;
         if n == 0 && buf.is_empty() {
             return Poll::Ready(None)

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -65,28 +65,28 @@ macro_rules! delegate_sink {
             self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context<'_>,
         ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
-            self.$field().poll_ready(cx)
+            self.project().$field.poll_ready(cx)
         }
 
         fn start_send(
             self: Pin<&mut Self>,
             item: $item,
         ) -> Result<(), Self::Error> {
-            self.$field().start_send(item)
+            self.project().$field.start_send(item)
         }
 
         fn poll_flush(
             self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context<'_>,
         ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
-            self.$field().poll_flush(cx)
+            self.project().$field.poll_flush(cx)
         }
 
         fn poll_close(
             self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context<'_>,
         ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
-            self.$field().poll_close(cx)
+            self.project().$field.poll_close(cx)
         }
     }
 }

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -3,12 +3,14 @@ use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use futures_sink::{Sink};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Sink for the [`sink_err_into`](super::SinkExt::sink_err_into) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct SinkErrInto<Si: Sink<Item>, Item, E> {
+    #[pin]
     sink: SinkMapErr<Si, fn(Si::Error) -> E>,
 }
 
@@ -16,8 +18,6 @@ impl<Si, E, Item> SinkErrInto<Si, Item, E>
     where Si: Sink<Item>,
           Si::Error: Into<E>,
 {
-    unsafe_pinned!(sink: SinkMapErr<Si, fn(Si::Error) -> E>);
-
     pub(super) fn new(sink: Si) -> Self {
         SinkErrInto {
             sink: SinkExt::sink_map_err(sink, Into::into),
@@ -35,8 +35,9 @@ impl<Si, E, Item> SinkErrInto<Si, Item, E>
     }
 
     /// Get a pinned mutable reference to the inner sink.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
-        self.sink().get_pin_mut()
+        self.sink.get_pin_mut()
     }
 
     /// Consumes this combinator, returning the underlying sink.
@@ -63,10 +64,11 @@ impl<S, Item, E> Stream for SinkErrInto<S, Item, E>
 {
     type Item = S::Item;
 
+    #[pin_project(self)]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<S::Item>> {
-        self.sink().poll_next(cx)
+        self.sink.poll_next(cx)
     }
 }

--- a/futures-util/src/stream/catch_unwind.rs
+++ b/futures-util/src/stream/catch_unwind.rs
@@ -1,22 +1,21 @@
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 use std::any::Any;
-use std::pin::Pin;
 use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
+use std::pin::Pin;
 
 /// Stream for the [`catch_unwind`](super::StreamExt::catch_unwind) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct CatchUnwind<St: Stream> {
+    #[pin]
     stream: St,
     caught_unwind: bool,
 }
 
 impl<St: Stream + UnwindSafe> CatchUnwind<St> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(caught_unwind: bool);
-
     pub(super) fn new(stream: St) -> CatchUnwind<St> {
         CatchUnwind { stream, caught_unwind: false }
     }
@@ -26,21 +25,22 @@ impl<St: Stream + UnwindSafe> Stream for CatchUnwind<St>
 {
     type Item = Result<St::Item, Box<dyn Any + Send>>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        if self.caught_unwind {
+        if *self.caught_unwind {
             Poll::Ready(None)
         } else {
             let res = catch_unwind(AssertUnwindSafe(|| {
-                self.as_mut().stream().poll_next(cx)
+                self.stream.as_mut().poll_next(cx)
             }));
 
             match res {
                 Ok(poll) => poll.map(|opt| opt.map(Ok)),
                 Err(e) => {
-                    *self.as_mut().caught_unwind() = true;
+                    *self.caught_unwind = true;
                     Poll::Ready(Some(Err(e)))
                 },
             }

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -3,26 +3,23 @@ use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 use core::mem;
 use core::pin::Pin;
 use alloc::vec::Vec;
 
 /// Stream for the [`chunks`](super::StreamExt::chunks) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Chunks<St: Stream> {
+    #[pin]
     stream: Fuse<St>,
     items: Vec<St::Item>,
     cap: usize, // https://github.com/rust-lang-nursery/futures-rs/issues/1475
 }
 
-impl<St: Unpin + Stream> Unpin for Chunks<St> {}
-
 impl<St: Stream> Chunks<St> where St: Stream {
-    unsafe_unpinned!(items:  Vec<St::Item>);
-    unsafe_pinned!(stream: Fuse<St>);
-
     pub(super) fn new(stream: St, capacity: usize) -> Chunks<St> {
         assert!(capacity > 0);
 
@@ -31,11 +28,6 @@ impl<St: Stream> Chunks<St> where St: Stream {
             items: Vec::with_capacity(capacity),
             cap: capacity,
         }
-    }
-
-    fn take(mut self: Pin<&mut Self>) -> Vec<St::Item> {
-        let cap = self.cap;
-        mem::replace(self.as_mut().items(), Vec::with_capacity(cap))
     }
 
     /// Acquires a reference to the underlying stream that this combinator is
@@ -58,8 +50,9 @@ impl<St: Stream> Chunks<St> where St: Stream {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream().get_pin_mut()
+        self.stream.get_pin_mut()
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -74,19 +67,21 @@ impl<St: Stream> Chunks<St> where St: Stream {
 impl<St: Stream> Stream for Chunks<St> {
     type Item = Vec<St::Item>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         loop {
-            match ready!(self.as_mut().stream().poll_next(cx)) {
+            match ready!(self.stream.as_mut().poll_next(cx)) {
                 // Push the item into the buffer and check whether it is full.
                 // If so, replace our buffer with a new and empty one and return
                 // the full one.
                 Some(item) => {
-                    self.as_mut().items().push(item);
-                    if self.items.len() >= self.cap {
-                        return Poll::Ready(Some(self.as_mut().take()))
+                    self.items.push(item);
+                    if self.items.len() >= *self.cap {
+                        let cap = *self.cap;
+                        return Poll::Ready(Some(mem::replace(self.items, Vec::with_capacity(cap))));
                     }
                 }
 
@@ -96,7 +91,7 @@ impl<St: Stream> Stream for Chunks<St> {
                     let last = if self.items.is_empty() {
                         None
                     } else {
-                        let full_buf = mem::replace(self.as_mut().items(), Vec::new());
+                        let full_buf = mem::replace(self.items, Vec::new());
                         Some(full_buf)
                     };
 

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -5,21 +5,18 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct FilterMap<St, Fut, F> {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     pending: Option<Fut>,
 }
-
-impl<St, Fut, F> Unpin for FilterMap<St, Fut, F>
-where
-    St: Unpin,
-    Fut: Unpin,
-{}
 
 impl<St, Fut, F> fmt::Debug for FilterMap<St, Fut, F>
 where
@@ -39,10 +36,6 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
           F: FnMut(St::Item) -> Fut,
           Fut: Future,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(pending: Option<Fut>);
-
     pub(super) fn new(stream: St, f: F) -> FilterMap<St, Fut, F> {
         FilterMap { stream, f, pending: None }
     }
@@ -67,8 +60,9 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -97,22 +91,23 @@ impl<St, Fut, F, T> Stream for FilterMap<St, Fut, F>
 {
     type Item = T;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<T>> {
         loop {
             if self.pending.is_none() {
-                let item = match ready!(self.as_mut().stream().poll_next(cx)) {
+                let item = match ready!(self.stream.as_mut().poll_next(cx)) {
                     Some(e) => e,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(item);
-                self.as_mut().pending().set(Some(fut));
+                let fut = (self.f)(item);
+                self.pending.set(Some(fut));
             }
 
-            let item = ready!(self.as_mut().pending().as_pin_mut().unwrap().poll(cx));
-            self.as_mut().pending().set(None);
+            let item = ready!(self.pending.as_mut().as_pin_mut().unwrap().poll(cx));
+            self.pending.set(None);
             if item.is_some() {
                 return Poll::Ready(item);
             }

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -3,30 +3,25 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`flatten`](super::StreamExt::flatten) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Flatten<St>
     where St: Stream,
 {
+    #[pin]
     stream: St,
+    #[pin]
     next: Option<St::Item>,
 }
-
-impl<St: Stream> Unpin for Flatten<St>
-where St: Stream + Unpin,
-      St::Item: Stream + Unpin,
-{}
 
 impl<St: Stream> Flatten<St>
 where St: Stream,
       St::Item: Stream,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_pinned!(next: Option<St::Item>);
-
     pub(super) fn new(stream: St) -> Flatten<St>{
         Flatten { stream, next: None, }
     }
@@ -51,8 +46,9 @@ where St: Stream,
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -76,22 +72,23 @@ impl<St> Stream for Flatten<St>
 {
     type Item = <St::Item as Stream>::Item;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         loop {
             if self.next.is_none() {
-                match ready!(self.as_mut().stream().poll_next(cx)) {
-                    Some(e) => self.as_mut().next().set(Some(e)),
+                match ready!(self.stream.as_mut().poll_next(cx)) {
+                    Some(e) => self.next.set(Some(e)),
                     None => return Poll::Ready(None),
                 }
             }
-            let item = ready!(self.as_mut().next().as_pin_mut().unwrap().poll_next(cx));
+            let item = ready!(self.next.as_mut().as_pin_mut().unwrap().poll_next(cx));
             if item.is_some() {
                 return Poll::Ready(item);
             } else {
-                self.as_mut().next().set(None);
+                self.next.set(None);
             }
         }
     }

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -3,18 +3,19 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`fold`](super::StreamExt::fold) method.
+#[unsafe_project(Unpin)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Fold<St, Fut, T, F> {
+    #[pin]
     stream: St,
     f: F,
     accum: Option<T>,
+    #[pin]
     future: Option<Fut>,
 }
-
-impl<St: Unpin, Fut: Unpin, T, F> Unpin for Fold<St, Fut, T, F> {}
 
 impl<St, Fut, T, F> fmt::Debug for Fold<St, Fut, T, F>
 where
@@ -36,11 +37,6 @@ where St: Stream,
       F: FnMut(T, St::Item) -> Fut,
       Fut: Future<Output = T>,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_unpinned!(accum: Option<T>);
-    unsafe_pinned!(future: Option<Fut>);
-
     pub(super) fn new(stream: St, f: F, t: T) -> Fold<St, Fut, T, F> {
         Fold {
             stream,
@@ -64,22 +60,22 @@ impl<St, Fut, T, F> Future for Fold<St, Fut, T, F>
 {
     type Output = T;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
         loop {
             // we're currently processing a future to produce a new accum value
             if self.accum.is_none() {
-                let accum = ready!(self.as_mut().future().as_pin_mut().unwrap().poll(cx));
-                *self.as_mut().accum() = Some(accum);
-                self.as_mut().future().set(None);
+                let accum = ready!(self.future.as_mut().as_pin_mut().unwrap().poll(cx));
+                *self.accum = Some(accum);
+                self.future.set(None);
             }
 
-            let item = ready!(self.as_mut().stream().poll_next(cx));
-            let accum = self.as_mut().accum().take()
-                .expect("Fold polled after completion");
+            let item = ready!(self.stream.as_mut().poll_next(cx));
+            let accum = self.accum.take().expect("Fold polled after completion");
 
             if let Some(e) = item {
-                let future = (self.as_mut().f())(accum, e);
-                self.as_mut().future().set(Some(future));
+                let future = (self.f)(accum, e);
+                self.future.set(Some(future));
             } else {
                 return Poll::Ready(accum)
             }

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -3,21 +3,18 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`for_each`](super::StreamExt::for_each) method.
+#[unsafe_project(Unpin)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ForEach<St, Fut, F> {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     future: Option<Fut>,
 }
-
-impl<St, Fut, F> Unpin for ForEach<St, Fut, F>
-where
-    St: Unpin,
-    Fut: Unpin,
-{}
 
 impl<St, Fut, F> fmt::Debug for ForEach<St, Fut, F>
 where
@@ -37,10 +34,6 @@ where St: Stream,
       F: FnMut(St::Item) -> Fut,
       Fut: Future<Output = ()>,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(future: Option<Fut>);
-
     pub(super) fn new(stream: St, f: F) -> ForEach<St, Fut, F> {
         ForEach {
             stream,
@@ -63,17 +56,18 @@ impl<St, Fut, F> Future for ForEach<St, Fut, F>
 {
     type Output = ();
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         loop {
-            if let Some(future) = self.as_mut().future().as_pin_mut() {
+            if let Some(future) = self.future.as_mut().as_pin_mut() {
                 ready!(future.poll(cx));
             }
-            self.as_mut().future().set(None);
+            self.future.set(None);
 
-            match ready!(self.as_mut().stream().poll_next(cx)) {
+            match ready!(self.stream.as_mut().poll_next(cx)) {
                 Some(e) => {
-                    let future = (self.as_mut().f())(e);
-                    self.as_mut().future().set(Some(future));
+                    let future = (self.f)(e);
+                    self.future.set(Some(future));
                 }
                 None => {
                     return Poll::Ready(());

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -5,22 +5,19 @@ use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`for_each_concurrent`](super::StreamExt::for_each_concurrent)
 /// method.
+#[unsafe_project(Unpin)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ForEachConcurrent<St, Fut, F> {
+    #[pin]
     stream: Option<St>,
     f: F,
     futures: FuturesUnordered<Fut>,
     limit: Option<NonZeroUsize>,
 }
-
-impl<St, Fut, F> Unpin for ForEachConcurrent<St, Fut, F>
-where St: Unpin,
-      Fut: Unpin,
-{}
 
 impl<St, Fut, F> fmt::Debug for ForEachConcurrent<St, Fut, F>
 where
@@ -41,11 +38,6 @@ where St: Stream,
       F: FnMut(St::Item) -> Fut,
       Fut: Future<Output = ()>,
 {
-    unsafe_pinned!(stream: Option<St>);
-    unsafe_unpinned!(f: F);
-    unsafe_unpinned!(futures: FuturesUnordered<Fut>);
-    unsafe_unpinned!(limit: Option<NonZeroUsize>);
-
     pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> ForEachConcurrent<St, Fut, F> {
         ForEachConcurrent {
             stream: Some(stream),
@@ -70,6 +62,7 @@ impl<St, Fut, F> Future for ForEachConcurrent<St, Fut, F>
 {
     type Output = ();
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         loop {
             let mut made_progress_this_iter = false;
@@ -79,7 +72,7 @@ impl<St, Fut, F> Future for ForEachConcurrent<St, Fut, F>
             // Check if we've already created a number of futures greater than `limit`
             if self.limit.map(|limit| limit.get() > current_len).unwrap_or(true) {
                 let mut stream_completed = false;
-                let elem = if let Some(stream) = self.as_mut().stream().as_pin_mut() {
+                let elem = if let Some(stream) = self.stream.as_mut().as_pin_mut() {
                     match stream.poll_next(cx) {
                         Poll::Ready(Some(elem)) => {
                             made_progress_this_iter = true;
@@ -95,15 +88,15 @@ impl<St, Fut, F> Future for ForEachConcurrent<St, Fut, F>
                     None
                 };
                 if stream_completed {
-                    self.as_mut().stream().set(None);
+                    self.stream.set(None);
                 }
                 if let Some(elem) = elem {
-                    let next_future = (self.as_mut().f())(elem);
-                    self.as_mut().futures().push(next_future);
+                    let next_future = (self.f)(elem);
+                    self.futures.push(next_future);
                 }
             }
 
-            match self.as_mut().futures().poll_next_unpin(cx) {
+            match self.futures.poll_next_unpin(cx) {
                 Poll::Ready(Some(())) => made_progress_this_iter = true,
                 Poll::Ready(None) => {
                     if self.stream.is_none() {

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -4,16 +4,16 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`inspect`](super::StreamExt::inspect) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Inspect<St, F> {
+    #[pin]
     stream: St,
     f: F,
 }
-
-impl<St: Unpin, F> Unpin for Inspect<St, F> {}
 
 impl<St, F> fmt::Debug for Inspect<St, F>
 where
@@ -30,9 +30,6 @@ impl<St, F> Inspect<St, F>
     where St: Stream,
           F: FnMut(&St::Item),
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-
     pub(super) fn new(stream: St, f: F) -> Inspect<St, F> {
         Inspect { stream, f }
     }
@@ -57,8 +54,9 @@ impl<St, F> Inspect<St, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -89,14 +87,15 @@ impl<St, F> Stream for Inspect<St, F>
 {
     type Item = St::Item;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St::Item>> {
-        self.as_mut()
-            .stream()
+        self.stream
+            .as_mut()
             .poll_next(cx)
-            .map(|opt| opt.map(|e| inspect(e, self.as_mut().f())))
+            .map(|opt| opt.map(|e| inspect(e, self.f)))
     }
 }
 

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -4,16 +4,16 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`map`](super::StreamExt::map) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Map<St, F> {
+    #[pin]
     stream: St,
     f: F,
 }
-
-impl<St: Unpin, F> Unpin for Map<St, F> {}
 
 impl<St, F> fmt::Debug for Map<St, F>
 where
@@ -30,9 +30,6 @@ impl<St, T, F> Map<St, F>
     where St: Stream,
           F: FnMut(St::Item) -> T,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-
     pub(super) fn new(stream: St, f: F) -> Map<St, F> {
         Map { stream, f }
     }
@@ -57,8 +54,9 @@ impl<St, T, F> Map<St, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -82,14 +80,15 @@ impl<St, F, T> Stream for Map<St, F>
 {
     type Item = T;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<T>> {
-        self.as_mut()
-            .stream()
+        self.stream
+            .as_mut()
             .poll_next(cx)
-            .map(|opt| opt.map(|x| self.as_mut().f()(x)))
+            .map(|opt| opt.map(|x| (self.f)(x)))
     }
 }
 

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -2,7 +2,7 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Creates a stream of a single element.
 ///
@@ -24,31 +24,28 @@ pub fn once<Fut: Future>(future: Fut) -> Once<Fut> {
 /// A stream which emits single element and then EOF.
 ///
 /// This stream will never block and is always ready.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Once<Fut> {
+    #[pin]
     future: Option<Fut>
-}
-
-impl<Fut: Unpin> Unpin for Once<Fut> {}
-
-impl<Fut> Once<Fut> {
-    unsafe_pinned!(future: Option<Fut>);
 }
 
 impl<Fut: Future> Stream for Once<Fut> {
     type Item = Fut::Output;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Fut::Output>> {
-        let val = if let Some(f) = self.as_mut().future().as_pin_mut() {
+        let val = if let Some(f) = self.future.as_mut().as_pin_mut() {
             ready!(f.poll(cx))
         } else {
             return Poll::Ready(None)
         };
-        self.future().set(None);
+        self.future.set(None);
         Poll::Ready(Some(val))
     }
 }

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -3,22 +3,19 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`skip`](super::StreamExt::skip) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Skip<St> {
+    #[pin]
     stream: St,
     remaining: u64,
 }
 
-impl<St: Unpin> Unpin for Skip<St> {}
-
 impl<St: Stream> Skip<St> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(remaining: u64);
-
     pub(super) fn new(stream: St, n: u64) -> Skip<St> {
         Skip {
             stream,
@@ -46,8 +43,9 @@ impl<St: Stream> Skip<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -68,18 +66,19 @@ impl<St: FusedStream> FusedStream for Skip<St> {
 impl<St: Stream> Stream for Skip<St> {
     type Item = St::Item;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St::Item>> {
-        while self.remaining > 0 {
-            match ready!(self.as_mut().stream().poll_next(cx)) {
-                Some(_) => *self.as_mut().remaining() -= 1,
+        while *self.remaining > 0 {
+            match ready!(self.stream.as_mut().poll_next(cx)) {
+                Some(_) => *self.remaining -= 1,
                 None => return Poll::Ready(None),
             }
         }
 
-        self.as_mut().stream().poll_next(cx)
+        self.stream.poll_next(cx)
     }
 }
 

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -5,19 +5,20 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`skip_while`](super::StreamExt::skip_while) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct SkipWhile<St, Fut, F> where St: Stream {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     pending_fut: Option<Fut>,
     pending_item: Option<St::Item>,
     done_skipping: bool,
 }
-
-impl<St: Unpin + Stream, Fut: Unpin, F> Unpin for SkipWhile<St, Fut, F> {}
 
 impl<St, Fut, F> fmt::Debug for SkipWhile<St, Fut, F>
 where
@@ -40,12 +41,6 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
           F: FnMut(&St::Item) -> Fut,
           Fut: Future<Output = bool>,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(pending_fut: Option<Fut>);
-    unsafe_unpinned!(pending_item: Option<St::Item>);
-    unsafe_unpinned!(done_skipping: bool);
-
     pub(super) fn new(stream: St, f: F) -> SkipWhile<St, Fut, F> {
         SkipWhile {
             stream,
@@ -76,8 +71,9 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -102,31 +98,32 @@ impl<St, Fut, F> Stream for SkipWhile<St, Fut, F>
 {
     type Item = St::Item;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St::Item>> {
-        if self.done_skipping {
-            return self.as_mut().stream().poll_next(cx);
+        if *self.done_skipping {
+            return self.stream.poll_next(cx);
         }
 
         loop {
             if self.pending_item.is_none() {
-                let item = match ready!(self.as_mut().stream().poll_next(cx)) {
+                let item = match ready!(self.stream.as_mut().poll_next(cx)) {
                     Some(e) => e,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(&item);
-                self.as_mut().pending_fut().set(Some(fut));
-                *self.as_mut().pending_item() = Some(item);
+                let fut = (self.f)(&item);
+                self.pending_fut.set(Some(fut));
+                *self.pending_item = Some(item);
             }
 
-            let skipped = ready!(self.as_mut().pending_fut().as_pin_mut().unwrap().poll(cx));
-            let item = self.as_mut().pending_item().take().unwrap();
-            self.as_mut().pending_fut().set(None);
+            let skipped = ready!(self.pending_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+            let item = self.pending_item.take().unwrap();
+            self.pending_fut.set(None);
 
             if !skipped {
-                *self.as_mut().done_skipping() = true;
+                *self.done_skipping = true;
                 return Poll::Ready(Some(item))
             }
         }

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -5,19 +5,20 @@ use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`take_while`](super::StreamExt::take_while) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TakeWhile<St: Stream , Fut, F> {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     pending_fut: Option<Fut>,
     pending_item: Option<St::Item>,
     done_taking: bool,
 }
-
-impl<St: Unpin + Stream, Fut: Unpin, F> Unpin for TakeWhile<St, Fut, F> {}
 
 impl<St, Fut, F> fmt::Debug for TakeWhile<St, Fut, F>
 where
@@ -33,14 +34,6 @@ where
             .field("done_taking", &self.done_taking)
             .finish()
     }
-}
-
-impl<St: Stream, Fut, F> TakeWhile<St, Fut, F> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(pending_fut: Option<Fut>);
-    unsafe_unpinned!(pending_item: Option<St::Item>);
-    unsafe_unpinned!(done_taking: bool);
 }
 
 impl<St, Fut, F> TakeWhile<St, Fut, F>
@@ -78,8 +71,9 @@ impl<St, Fut, F> TakeWhile<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -98,32 +92,33 @@ impl<St, Fut, F> Stream for TakeWhile<St, Fut, F>
 {
     type Item = St::Item;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St::Item>> {
-        if self.done_taking {
+        if *self.done_taking {
             return Poll::Ready(None);
         }
 
         if self.pending_item.is_none() {
-            let item = match ready!(self.as_mut().stream().poll_next(cx)) {
+            let item = match ready!(self.stream.as_mut().poll_next(cx)) {
                 Some(e) => e,
                 None => return Poll::Ready(None),
             };
-            let fut = (self.as_mut().f())(&item);
-            self.as_mut().pending_fut().set(Some(fut));
-            *self.as_mut().pending_item() = Some(item);
+            let fut = (self.f)(&item);
+            self.pending_fut.set(Some(fut));
+            *self.pending_item = Some(item);
         }
 
-        let take = ready!(self.as_mut().pending_fut().as_pin_mut().unwrap().poll(cx));
-        self.as_mut().pending_fut().set(None);
-        let item = self.as_mut().pending_item().take().unwrap();
+        let take = ready!(self.pending_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+        self.pending_fut.set(None);
+        let item = self.pending_item.take().unwrap();
 
         if take {
             Poll::Ready(Some(item))
         } else {
-            *self.as_mut().done_taking() = true;
+            *self.done_taking = true;
             Poll::Ready(None)
         }
     }

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Creates a `Stream` from a seed and a closure returning a `Future`.
 ///
@@ -62,14 +62,14 @@ pub fn unfold<T, F, Fut, It>(init: T, f: F) -> Unfold<T, F, Fut>
 }
 
 /// Stream for the [`unfold`] function.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Unfold<T, F, Fut> {
     f: F,
     state: Option<T>,
+    #[pin]
     fut: Option<Fut>,
 }
-
-impl<T, F, Fut: Unpin> Unpin for Unfold<T, F, Fut> {}
 
 impl<T, F, Fut> fmt::Debug for Unfold<T, F, Fut>
 where
@@ -84,12 +84,6 @@ where
     }
 }
 
-impl<T, F, Fut> Unfold<T, F, Fut> {
-    unsafe_unpinned!(f: F);
-    unsafe_unpinned!(state: Option<T>);
-    unsafe_pinned!(fut: Option<Fut>);
-}
-
 impl<T, F, Fut> FusedStream for Unfold<T, F, Fut> {
     fn is_terminated(&self) -> bool {
         self.state.is_none() && self.fut.is_none()
@@ -102,20 +96,21 @@ impl<T, F, Fut, It> Stream for Unfold<T, F, Fut>
 {
     type Item = It;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<It>> {
-        if let Some(state) = self.as_mut().state().take() {
-            let fut = (self.as_mut().f())(state);
-            self.as_mut().fut().set(Some(fut));
+        if let Some(state) = self.state.take() {
+            let fut = (self.f)(state);
+            self.fut.set(Some(fut));
         }
 
-        let step = ready!(self.as_mut().fut().as_pin_mut().unwrap().poll(cx));
-        self.as_mut().fut().set(None);
+        let step = ready!(self.fut.as_mut().as_pin_mut().unwrap().poll(cx));
+        self.fut.set(None);
 
         if let Some((item, next_state)) = step {
-            *self.as_mut().state() = Some(next_state);
+            *self.state = Some(next_state);
             Poll::Ready(Some(item))
         } else {
             Poll::Ready(None)

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -2,32 +2,22 @@ use crate::stream::{StreamExt, Fuse};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`zip`](super::StreamExt::zip) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Zip<St1: Stream, St2: Stream> {
+    #[pin]
     stream1: Fuse<St1>,
+    #[pin]
     stream2: Fuse<St2>,
     queued1: Option<St1::Item>,
     queued2: Option<St2::Item>,
 }
 
-impl<St1, St2> Unpin for Zip<St1, St2>
-where
-    St1: Stream,
-    Fuse<St1>: Unpin,
-    St2: Stream,
-    Fuse<St2>: Unpin,
-{}
-
 impl<St1: Stream, St2: Stream> Zip<St1, St2> {
-    unsafe_pinned!(stream1: Fuse<St1>);
-    unsafe_pinned!(stream2: Fuse<St2>);
-    unsafe_unpinned!(queued1: Option<St1::Item>);
-    unsafe_unpinned!(queued2: Option<St2::Item>);
-
     pub(super) fn new(stream1: St1, stream2: St2) -> Zip<St1, St2> {
         Zip {
             stream1: stream1.fuse(),
@@ -86,26 +76,27 @@ impl<St1, St2> Stream for Zip<St1, St2>
 {
     type Item = (St1::Item, St2::Item);
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         if self.queued1.is_none() {
-            match self.as_mut().stream1().poll_next(cx) {
-                Poll::Ready(Some(item1)) => *self.as_mut().queued1() = Some(item1),
+            match self.stream1.as_mut().poll_next(cx) {
+                Poll::Ready(Some(item1)) => *self.queued1 = Some(item1),
                 Poll::Ready(None) | Poll::Pending => {}
             }
         }
         if self.queued2.is_none() {
-            match self.as_mut().stream2().poll_next(cx) {
-                Poll::Ready(Some(item2)) => *self.as_mut().queued2() = Some(item2),
+            match self.stream2.as_mut().poll_next(cx) {
+                Poll::Ready(Some(item2)) => *self.queued2 = Some(item2),
                 Poll::Ready(None) | Poll::Pending => {}
             }
         }
 
         if self.queued1.is_some() && self.queued2.is_some() {
-            let pair = (self.as_mut().queued1().take().unwrap(),
-                        self.as_mut().queued2().take().unwrap());
+            let pair = (self.queued1.take().unwrap(),
+                        self.queued2.take().unwrap());
             Poll::Ready(Some(pair))
         } else if self.stream1.is_done() || self.stream2.is_done() {
             Poll::Ready(None)

--- a/futures-util/src/try_future/and_then.rs
+++ b/futures-util/src/try_future/and_then.rs
@@ -2,12 +2,14 @@ use super::{TryChain, TryChainAction};
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`and_then`](super::TryFutureExt::and_then) method.
+#[unsafe_project]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct AndThen<Fut1, Fut2, F> {
+    #[pin]
     try_chain: TryChain<Fut1, Fut2, F>,
 }
 
@@ -15,9 +17,6 @@ impl<Fut1, Fut2, F> AndThen<Fut1, Fut2, F>
     where Fut1: TryFuture,
           Fut2: TryFuture,
 {
-    unsafe_pinned!(try_chain: TryChain<Fut1, Fut2, F>);
-
-    /// Creates a new `Then`.
     pub(super) fn new(future: Fut1, f: F) -> AndThen<Fut1, Fut2, F> {
         AndThen {
             try_chain: TryChain::new(future, f),
@@ -42,8 +41,9 @@ impl<Fut1, Fut2, F> Future for AndThen<Fut1, Fut2, F>
 {
     type Output = Result<Fut2::Ok, Fut2::Error>;
 
+    #[pin_project(self)]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.try_chain().poll(cx, |result, async_op| {
+        self.try_chain.poll(cx, |result, async_op| {
             match result {
                 Ok(ok) => TryChainAction::Future(async_op(ok)),
                 Err(err) => TryChainAction::Output(Err(err)),

--- a/futures-util/src/try_future/inspect_err.rs
+++ b/futures-util/src/try_future/inspect_err.rs
@@ -1,26 +1,23 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`inspect_err`](super::TryFutureExt::inspect_err) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct InspectErr<Fut, F> {
+    #[pin]
     future: Fut,
     f: Option<F>,
 }
-
-impl<Fut: Unpin, F> Unpin for InspectErr<Fut, F> {}
 
 impl<Fut, F> InspectErr<Fut, F>
 where
     Fut: TryFuture,
     F: FnOnce(&Fut::Error),
 {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(f: Option<F>);
-
     pub(super) fn new(future: Fut, f: F) -> Self {
         Self { future, f: Some(f) }
     }
@@ -39,10 +36,11 @@ where
 {
     type Output = Result<Fut::Ok, Fut::Error>;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let e = ready!(self.as_mut().future().try_poll(cx));
+        let e = ready!(self.future.as_mut().try_poll(cx));
         if let Err(e) = &e {
-            self.as_mut().f().take().expect("cannot poll InspectErr twice")(e);
+            self.f.take().expect("cannot poll InspectErr twice")(e);
         }
         Poll::Ready(e)
     }

--- a/futures-util/src/try_future/inspect_ok.rs
+++ b/futures-util/src/try_future/inspect_ok.rs
@@ -1,26 +1,23 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`inspect_ok`](super::TryFutureExt::inspect_ok) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct InspectOk<Fut, F> {
+    #[pin]
     future: Fut,
     f: Option<F>,
 }
-
-impl<Fut: Unpin, F> Unpin for InspectOk<Fut, F> {}
 
 impl<Fut, F> InspectOk<Fut, F>
 where
     Fut: TryFuture,
     F: FnOnce(&Fut::Ok),
 {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(f: Option<F>);
-
     pub(super) fn new(future: Fut, f: F) -> Self {
         Self { future, f: Some(f) }
     }
@@ -39,10 +36,11 @@ where
 {
     type Output = Result<Fut::Ok, Fut::Error>;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let e = ready!(self.as_mut().future().try_poll(cx));
+        let e = ready!(self.future.as_mut().try_poll(cx));
         if let Ok(e) = &e {
-            self.as_mut().f().take().expect("cannot poll InspectOk twice")(e);
+            self.f.take().expect("cannot poll InspectOk twice")(e);
         }
         Poll::Ready(e)
     }

--- a/futures-util/src/try_future/into_future.rs
+++ b/futures-util/src/try_future/into_future.rs
@@ -1,18 +1,18 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_utils::unsafe_pinned;
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`into_future`](super::TryFutureExt::into_future) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct IntoFuture<Fut> {
+    #[pin]
     future: Fut,
 }
 
 impl<Fut> IntoFuture<Fut> {
-    unsafe_pinned!(future: Fut);
-
     #[inline]
     pub(super) fn new(future: Fut) -> IntoFuture<Fut> {
         IntoFuture { future }
@@ -26,11 +26,12 @@ impl<Fut: FusedFuture> FusedFuture for IntoFuture<Fut> {
 impl<Fut: TryFuture> Future for IntoFuture<Fut> {
     type Output = Result<Fut::Ok, Fut::Error>;
 
+    #[pin_project(self)]
     #[inline]
     fn poll(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
-        self.future().try_poll(cx)
+        self.future.try_poll(cx)
     }
 }

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -1,27 +1,23 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`map_err`](super::TryFutureExt::map_err) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct MapErr<Fut, F> {
+    #[pin]
     future: Fut,
     f: Option<F>,
 }
 
 impl<Fut, F> MapErr<Fut, F> {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(f: Option<F>);
-
-    /// Creates a new MapErr.
     pub(super) fn new(future: Fut, f: F) -> MapErr<Fut, F> {
         MapErr { future, f: Some(f) }
     }
 }
-
-impl<Fut: Unpin, F> Unpin for MapErr<Fut, F> {}
 
 impl<Fut, F> FusedFuture for MapErr<Fut, F> {
     fn is_terminated(&self) -> bool { self.f.is_none() }
@@ -33,15 +29,16 @@ impl<Fut, F, E> Future for MapErr<Fut, F>
 {
     type Output = Result<Fut::Ok, E>;
 
+    #[pin_project(self)]
     fn poll(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
-        self.as_mut()
-            .future()
+        self.future
+            .as_mut()
             .try_poll(cx)
             .map(|result| {
-                let f = self.as_mut().f().take()
+                let f = self.f.take()
                     .expect("MapErr must not be polled after it returned `Poll::Ready`");
                 result.map_err(f)
             })

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -1,27 +1,23 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`map_ok`](super::TryFutureExt::map_ok) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct MapOk<Fut, F> {
+    #[pin]
     future: Fut,
     f: Option<F>,
 }
 
 impl<Fut, F> MapOk<Fut, F> {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(f: Option<F>);
-
-    /// Creates a new MapOk.
     pub(super) fn new(future: Fut, f: F) -> MapOk<Fut, F> {
         MapOk { future, f: Some(f) }
     }
 }
-
-impl<Fut: Unpin, F> Unpin for MapOk<Fut, F> {}
 
 impl<Fut, F> FusedFuture for MapOk<Fut, F> {
     fn is_terminated(&self) -> bool {
@@ -35,15 +31,16 @@ impl<Fut, F, T> Future for MapOk<Fut, F>
 {
     type Output = Result<T, Fut::Error>;
 
+    #[pin_project(self)]
     fn poll(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
-        self.as_mut()
-            .future()
+        self.future
+            .as_mut()
             .try_poll(cx)
             .map(|result| {
-                let op = self.as_mut().f().take()
+                let op = self.f.take()
                     .expect("MapOk must not be polled after it returned `Poll::Ready`");
                 result.map(op)
             })

--- a/futures-util/src/try_stream/inspect_ok.rs
+++ b/futures-util/src/try_stream/inspect_ok.rs
@@ -5,16 +5,16 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`inspect_ok`](super::TryStreamExt::inspect_ok) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct InspectOk<St, F> {
+    #[pin]
     stream: St,
     f: F,
 }
-
-impl<St: Unpin, F> Unpin for InspectOk<St, F> {}
 
 impl<St, F> fmt::Debug for InspectOk<St, F>
 where
@@ -25,11 +25,6 @@ where
             .field("stream", &self.stream)
             .finish()
     }
-}
-
-impl<St, F> InspectOk<St, F> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
 }
 
 impl<St, F> InspectOk<St, F>
@@ -61,8 +56,9 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -87,14 +83,15 @@ where
 {
     type Item = Result<St::Ok, St::Error>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        self.as_mut()
-            .stream()
+        self.stream
+            .as_mut()
             .try_poll_next(cx)
-            .map(|opt| opt.map(|res| res.map(|e| inspect(e, self.as_mut().f()))))
+            .map(|opt| opt.map(|res| res.map(|e| inspect(e, self.f))))
     }
 }
 

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -4,16 +4,16 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`map_err`](super::TryStreamExt::map_err) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct MapErr<St, F> {
+    #[pin]
     stream: St,
     f: F,
 }
-
-impl<St: Unpin, F> Unpin for MapErr<St, F> {}
 
 impl<St, F> fmt::Debug for MapErr<St, F>
 where
@@ -27,9 +27,6 @@ where
 }
 
 impl<St, F> MapErr<St, F> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-
     /// Creates a new MapErr.
     pub(super) fn new(stream: St, f: F) -> Self {
         MapErr { stream, f }
@@ -55,8 +52,9 @@ impl<St, F> MapErr<St, F> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -81,14 +79,15 @@ where
 {
     type Item = Result<St::Ok, E>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        self.as_mut()
-            .stream()
+        self.stream
+            .as_mut()
             .try_poll_next(cx)
-            .map(|opt| opt.map(|res| res.map_err(|e| self.as_mut().f()(e))))
+            .map(|opt| opt.map(|res| res.map_err(|e| (self.f)(e))))
     }
 }
 

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -4,16 +4,16 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`map_ok`](super::TryStreamExt::map_ok) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct MapOk<St, F> {
+    #[pin]
     stream: St,
     f: F,
 }
-
-impl<St: Unpin, F> Unpin for MapOk<St, F> {}
 
 impl<St, F> fmt::Debug for MapOk<St, F>
 where
@@ -27,9 +27,6 @@ where
 }
 
 impl<St, F> MapOk<St, F> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-
     /// Creates a new MapOk.
     pub(super) fn new(stream: St, f: F) -> Self {
         MapOk { stream, f }
@@ -55,8 +52,9 @@ impl<St, F> MapOk<St, F> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -81,14 +79,15 @@ where
 {
     type Item = Result<T, St::Error>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        self.as_mut()
-            .stream()
+        self.stream
+            .as_mut()
             .try_poll_next(cx)
-            .map(|opt| opt.map(|res| res.map(|x| self.as_mut().f()(x))))
+            .map(|opt| opt.map(|res| res.map(|x| (self.f)(x))))
     }
 }
 

--- a/futures-util/src/try_stream/or_else.rs
+++ b/futures-util/src/try_stream/or_else.rs
@@ -5,17 +5,18 @@ use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`or_else`](super::TryStreamExt::or_else) method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct OrElse<St, Fut, F> {
+    #[pin]
     stream: St,
+    #[pin]
     future: Option<Fut>,
     f: F,
 }
-
-impl<St: Unpin, Fut: Unpin, F> Unpin for OrElse<St, Fut, F> {}
 
 impl<St, Fut, F> fmt::Debug for OrElse<St, Fut, F>
 where
@@ -28,12 +29,6 @@ where
             .field("future", &self.future)
             .finish()
     }
-}
-
-impl<St, Fut, F> OrElse<St, Fut, F> {
-    unsafe_pinned!(stream: St);
-    unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(f: F);
 }
 
 impl<St, Fut, F> OrElse<St, Fut, F>
@@ -65,8 +60,9 @@ impl<St, Fut, F> OrElse<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -85,22 +81,23 @@ impl<St, Fut, F> Stream for OrElse<St, Fut, F>
 {
     type Item = Result<St::Ok, Fut::Error>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        if self.future.is_none() {
-            let item = match ready!(self.as_mut().stream().try_poll_next(cx)) {
+       if self.future.is_none() {
+            let item = match ready!(self.stream.as_mut().try_poll_next(cx)) {
                 None => return Poll::Ready(None),
                 Some(Ok(e)) => return Poll::Ready(Some(Ok(e))),
                 Some(Err(e)) => e,
             };
-            let fut = (self.as_mut().f())(item);
-            self.as_mut().future().set(Some(fut));
+            let fut = (self.f)(item);
+            self.future.set(Some(fut));
         }
 
-        let e = ready!(self.as_mut().future().as_pin_mut().unwrap().try_poll(cx));
-        self.as_mut().future().set(None);
+        let e = ready!(self.future.as_mut().as_pin_mut().unwrap().try_poll(cx));
+        self.future.set(None);
         Poll::Ready(Some(e))
     }
 }

--- a/futures-util/src/try_stream/try_concat.rs
+++ b/futures-util/src/try_stream/try_concat.rs
@@ -2,26 +2,23 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`try_concat`](super::TryStreamExt::try_concat) method.
+#[unsafe_project(Unpin)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryConcat<St: TryStream> {
+    #[pin]
     stream: St,
     accum: Option<St::Ok>,
 }
-
-impl<St: TryStream + Unpin> Unpin for TryConcat<St> {}
 
 impl<St> TryConcat<St>
 where
     St: TryStream,
     St::Ok: Extend<<St::Ok as IntoIterator>::Item> + IntoIterator + Default,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(accum: Option<St::Ok>);
-
     pub(super) fn new(stream: St) -> TryConcat<St> {
         TryConcat {
             stream,
@@ -37,19 +34,19 @@ where
 {
     type Output = Result<St::Ok, St::Error>;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
-            match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+            match ready!(self.stream.as_mut().try_poll_next(cx)?) {
                 Some(x) => {
-                    let accum = self.as_mut().accum();
-                    if let Some(a) = accum {
+                    if let Some(a) = self.accum {
                         a.extend(x)
                     } else {
-                        *accum = Some(x)
+                        *self.accum = Some(x)
                     }
                 },
                 None => {
-                    return Poll::Ready(Ok(self.as_mut().accum().take().unwrap_or_default()))
+                    return Poll::Ready(Ok(self.accum.take().unwrap_or_default()))
                 }
             }
         }

--- a/futures-util/src/try_stream/try_filter.rs
+++ b/futures-util/src/try_stream/try_filter.rs
@@ -5,23 +5,22 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`try_filter`](super::TryStreamExt::try_filter)
 /// method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TryFilter<St, Fut, F>
     where St: TryStream
 {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     pending_fut: Option<Fut>,
     pending_item: Option<St::Ok>,
 }
-
-impl<St, Fut, F> Unpin for TryFilter<St, Fut, F>
-    where St: TryStream + Unpin, Fut: Unpin,
-{}
 
 impl<St, Fut, F> fmt::Debug for TryFilter<St, Fut, F>
 where
@@ -41,11 +40,6 @@ where
 impl<St, Fut, F> TryFilter<St, Fut, F>
     where St: TryStream
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(pending_fut: Option<Fut>);
-    unsafe_unpinned!(pending_item: Option<St::Ok>);
-
     pub(super) fn new(stream: St, f: F) -> Self {
         TryFilter {
             stream,
@@ -75,8 +69,9 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -105,24 +100,25 @@ impl<St, Fut, F> Stream for TryFilter<St, Fut, F>
 {
     type Item = Result<St::Ok, St::Error>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<St::Ok, St::Error>>> {
         loop {
             if self.pending_fut.is_none() {
-                let item = match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+                let item = match ready!(self.stream.as_mut().try_poll_next(cx)?) {
                     Some(x) => x,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(&item);
-                self.as_mut().pending_fut().set(Some(fut));
-                *self.as_mut().pending_item() = Some(item);
+                let fut = (self.f)(&item);
+                self.pending_fut.set(Some(fut));
+                *self.pending_item = Some(item);
             }
 
-            let yield_item = ready!(self.as_mut().pending_fut().as_pin_mut().unwrap().poll(cx));
-            self.as_mut().pending_fut().set(None);
-            let item = self.as_mut().pending_item().take().unwrap();
+            let yield_item = ready!(self.pending_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+            self.pending_fut.set(None);
+            let item = self.pending_item.take().unwrap();
 
             if yield_item {
                 return Poll::Ready(Some(Ok(item)));

--- a/futures-util/src/try_stream/try_filter_map.rs
+++ b/futures-util/src/try_stream/try_filter_map.rs
@@ -5,20 +5,19 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Stream for the [`try_filter_map`](super::TryStreamExt::try_filter_map)
 /// method.
+#[unsafe_project(Unpin)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TryFilterMap<St, Fut, F> {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     pending: Option<Fut>,
 }
-
-impl<St, Fut, F> Unpin for TryFilterMap<St, Fut, F>
-    where St: Unpin, Fut: Unpin,
-{}
 
 impl<St, Fut, F> fmt::Debug for TryFilterMap<St, Fut, F>
 where
@@ -34,10 +33,6 @@ where
 }
 
 impl<St, Fut, F> TryFilterMap<St, Fut, F> {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(pending: Option<Fut>);
-
     pub(super) fn new(stream: St, f: F) -> Self {
         TryFilterMap { stream, f, pending: None }
     }
@@ -62,8 +57,9 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
+    #[pin_project(self)]
     pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
-        self.stream()
+        self.stream
     }
 
     /// Consumes this combinator, returning the underlying stream.
@@ -92,22 +88,23 @@ impl<St, Fut, F, T> Stream for TryFilterMap<St, Fut, F>
 {
     type Item = Result<T, St::Error>;
 
+    #[pin_project(self)]
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<T, St::Error>>> {
         loop {
             if self.pending.is_none() {
-                let item = match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+                let item = match ready!(self.stream.as_mut().try_poll_next(cx)?) {
                     Some(x) => x,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(item);
-                self.as_mut().pending().set(Some(fut));
+                let fut = (self.f)(item);
+                self.pending.set(Some(fut));
             }
 
-            let result = ready!(self.as_mut().pending().as_pin_mut().unwrap().try_poll(cx));
-            self.as_mut().pending().set(None);
+            let result = ready!(self.pending.as_mut().as_pin_mut().unwrap().try_poll(cx));
+            self.pending.set(None);
             if let Some(x) = result? {
                 return Poll::Ready(Some(Ok(x)));
             }

--- a/futures-util/src/try_stream/try_fold.rs
+++ b/futures-util/src/try_stream/try_fold.rs
@@ -3,18 +3,19 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`try_fold`](super::TryStreamExt::try_fold) method.
+#[unsafe_project(Unpin)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryFold<St, Fut, T, F> {
+    #[pin]
     stream: St,
     f: F,
     accum: Option<T>,
+    #[pin]
     future: Option<Fut>,
 }
-
-impl<St: Unpin, Fut: Unpin, T, F> Unpin for TryFold<St, Fut, T, F> {}
 
 impl<St, Fut, T, F> fmt::Debug for TryFold<St, Fut, T, F>
 where
@@ -36,11 +37,6 @@ where St: TryStream,
       F: FnMut(T, St::Ok) -> Fut,
       Fut: TryFuture<Ok = T, Error = St::Error>,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_unpinned!(accum: Option<T>);
-    unsafe_pinned!(future: Option<Fut>);
-
     pub(super) fn new(stream: St, f: F, t: T) -> TryFold<St, Fut, T, F> {
         TryFold {
             stream,
@@ -64,40 +60,41 @@ impl<St, Fut, T, F> Future for TryFold<St, Fut, T, F>
 {
     type Output = Result<T, St::Error>;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             // we're currently processing a future to produce a new accum value
             if self.accum.is_none() {
                 let accum = match ready!(
-                    self.as_mut().future().as_pin_mut()
+                    self.future.as_mut().as_pin_mut()
                        .expect("TryFold polled after completion")
                        .try_poll(cx)
                 ) {
                     Ok(accum) => accum,
                     Err(e) => {
                         // Indicate that the future can no longer be polled.
-                        self.as_mut().future().set(None);
+                        self.future.set(None);
                         return Poll::Ready(Err(e));
                     }
                 };
-                *self.as_mut().accum() = Some(accum);
-                self.as_mut().future().set(None);
+                *self.accum = Some(accum);
+                self.future.set(None);
             }
 
-            let item = match ready!(self.as_mut().stream().try_poll_next(cx)) {
+            let item = match ready!(self.stream.as_mut().try_poll_next(cx)) {
                 Some(Ok(item)) => Some(item),
                 Some(Err(e)) => {
                     // Indicate that the future can no longer be polled.
-                    *self.as_mut().accum() = None;
+                    *self.accum = None;
                     return Poll::Ready(Err(e));
                 }
                 None => None,
             };
-            let accum = self.as_mut().accum().take().unwrap();
+            let accum = self.accum.take().unwrap();
 
             if let Some(e) = item {
-                let future = (self.as_mut().f())(accum, e);
-                self.as_mut().future().set(Some(future));
+                let future = (self.f)(accum, e);
+                self.future.set(Some(future));
             } else {
                 return Poll::Ready(Ok(accum))
             }

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -3,17 +3,18 @@ use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, unsafe_project};
 
 /// Future for the [`try_for_each`](super::TryStreamExt::try_for_each) method.
+#[unsafe_project(Unpin)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryForEach<St, Fut, F> {
+    #[pin]
     stream: St,
     f: F,
+    #[pin]
     future: Option<Fut>,
 }
-
-impl<St: Unpin, Fut: Unpin, F> Unpin for TryForEach<St, Fut, F> {}
 
 impl<St, Fut, F> fmt::Debug for TryForEach<St, Fut, F>
 where
@@ -33,10 +34,6 @@ where St: TryStream,
       F: FnMut(St::Ok) -> Fut,
       Fut: TryFuture<Ok = (), Error = St::Error>,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-    unsafe_pinned!(future: Option<Fut>);
-
     pub(super) fn new(stream: St, f: F) -> TryForEach<St, Fut, F> {
         TryForEach {
             stream,
@@ -53,17 +50,18 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
 {
     type Output = Result<(), St::Error>;
 
+    #[pin_project(self)]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
-            if let Some(future) = self.as_mut().future().as_pin_mut() {
+            if let Some(future) = self.future.as_mut().as_pin_mut() {
                 ready!(future.try_poll(cx))?;
             }
-            self.as_mut().future().set(None);
+            self.future.set(None);
 
-            match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+            match ready!(self.stream.as_mut().try_poll_next(cx)?) {
                 Some(e) => {
-                    let future = (self.as_mut().f())(e);
-                    self.as_mut().future().set(Some(future));
+                    let future = (self.f)(e);
+                    self.future.set(Some(future));
                 }
                 None => return Poll::Ready(Ok(())),
             }


### PR DESCRIPTION
Improve the pin-projection related ergonomics.

This is a **work in progress**. Blocked on https://github.com/taiki-e/pin-project/pull/12.

TODO: Explain what code `pin-project` generates.
