### PR TITLE
Added a "same_receiver" method to (Unbounded)Sender

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -758,6 +758,10 @@ impl<T> PartialEq for SenderInner<T> {
     }
 }
 
+impl<T> Eq for Sender<T> {}
+impl<T> Eq for UnboundedSender<T> {}
+impl<T> Eq for SenderInner<T> {}
+
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
         Sender(self.0.clone())

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -740,6 +740,24 @@ impl<T> UnboundedSender<T> {
     }
 }
 
+impl<T> PartialEq for Sender<T> {
+    fn eq(&self, other: &Sender<T>) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> PartialEq for UnboundedSender<T> {
+    fn eq(&self, other: &UnboundedSender<T>) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T> PartialEq for SenderInner<T> {
+    fn eq(&self, other: &SenderInner<T>) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Sender<T> {
         Sender(self.0.clone())

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -521,3 +521,23 @@ fn try_send_recv() {
     rx.try_next().unwrap();
     rx.try_next().unwrap_err(); // should be empty
 }
+
+#[test]
+fn partial_eq() {
+    let (mut txa1, _) = mpsc::channel::<i32>(1);
+    let txa2 = txa1.clone();
+
+    let (mut txb1, _) = mpsc::channel::<i32>(1);
+    let txb2 = txb1.clone();
+
+    assert_eq!(txa1, txa2);
+    assert_eq!(txb1, txb2);
+
+    assert_ne!(txa1, txb1);
+
+    txa1.disconnect();
+    txb1.close_channel();
+
+    assert_ne!(txa1, txa2);
+    assert_eq!(txb1, txb2);
+}

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -523,21 +523,20 @@ fn try_send_recv() {
 }
 
 #[test]
-fn partial_eq() {
+fn same_receiver() {
     let (mut txa1, _) = mpsc::channel::<i32>(1);
     let txa2 = txa1.clone();
 
     let (mut txb1, _) = mpsc::channel::<i32>(1);
     let txb2 = txb1.clone();
 
-    assert_eq!(txa1, txa2);
-    assert_eq!(txb1, txb2);
-
-    assert_ne!(txa1, txb1);
+    assert!(txa1.same_receiver(&txa2));
+    assert!(txb1.same_receiver(&txb2));
+    assert!(!txa1.same_receiver(&txb1));
 
     txa1.disconnect();
     txb1.close_channel();
 
-    assert_ne!(txa1, txa2);
-    assert_eq!(txb1, txb2);
+    assert!(!txa1.same_receiver(&txa2));
+    assert!(txb1.same_receiver(&txb2));
 }


### PR DESCRIPTION
Hello!
This was asked in #1588 and I wanted to make a first contribution :smile:. As proposed by the issue's creator, I used `Arc::eq_ptr` to compare the `inner` field of `SenderInner`. I also added a ~`partial_eq` (though, I'm not really sure about its name)~ `same_receiver` test which compares a `Sender` with a clone of it when both are connected to the channel, when one of them is disconnected and when the channel is closed; it also compares two different channels' `Sender`s.