### PR TITLE
Add TryFutureExt::{inspect_ok, inspect_err}

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -373,7 +373,7 @@ pub trait FutureExt: Future {
     /// # });
     /// ```
     fn inspect<F>(self, f: F) -> Inspect<Self, F>
-        where F: FnOnce(&Self::Output) -> (),
+        where F: FnOnce(&Self::Output),
               Self: Sized,
     {
         assert_future::<Self::Output, _>(Inspect::new(self, f))

--- a/futures-util/src/try_future/inspect_err.rs
+++ b/futures-util/src/try_future/inspect_err.rs
@@ -1,0 +1,49 @@
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future, TryFuture};
+use futures_core::task::{Context, Poll};
+use pin_utils::{unsafe_pinned, unsafe_unpinned};
+
+/// Future for the [`inspect_err`](super::TryFutureExt::inspect_err) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct InspectErr<Fut, F> {
+    future: Fut,
+    f: Option<F>,
+}
+
+impl<Fut: Unpin, F> Unpin for InspectErr<Fut, F> {}
+
+impl<Fut, F> InspectErr<Fut, F>
+where
+    Fut: TryFuture,
+    F: FnOnce(&Fut::Error),
+{
+    unsafe_pinned!(future: Fut);
+    unsafe_unpinned!(f: Option<F>);
+
+    pub(super) fn new(future: Fut, f: F) -> Self {
+        Self { future, f: Some(f) }
+    }
+}
+
+impl<Fut: FusedFuture, F> FusedFuture for InspectErr<Fut, F> {
+    fn is_terminated(&self) -> bool {
+        self.future.is_terminated()
+    }
+}
+
+impl<Fut, F> Future for InspectErr<Fut, F>
+where
+    Fut: TryFuture,
+    F: FnOnce(&Fut::Error),
+{
+    type Output = Result<Fut::Ok, Fut::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let e = ready!(self.as_mut().future().try_poll(cx));
+        if let Err(e) = &e {
+            self.as_mut().f().take().expect("cannot poll InspectErr twice")(e);
+        }
+        Poll::Ready(e)
+    }
+}

--- a/futures-util/src/try_future/inspect_ok.rs
+++ b/futures-util/src/try_future/inspect_ok.rs
@@ -1,0 +1,49 @@
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future, TryFuture};
+use futures_core::task::{Context, Poll};
+use pin_utils::{unsafe_pinned, unsafe_unpinned};
+
+/// Future for the [`inspect_ok`](super::TryFutureExt::inspect_ok) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct InspectOk<Fut, F> {
+    future: Fut,
+    f: Option<F>,
+}
+
+impl<Fut: Unpin, F> Unpin for InspectOk<Fut, F> {}
+
+impl<Fut, F> InspectOk<Fut, F>
+where
+    Fut: TryFuture,
+    F: FnOnce(&Fut::Ok),
+{
+    unsafe_pinned!(future: Fut);
+    unsafe_unpinned!(f: Option<F>);
+
+    pub(super) fn new(future: Fut, f: F) -> Self {
+        Self { future, f: Some(f) }
+    }
+}
+
+impl<Fut: FusedFuture, F> FusedFuture for InspectOk<Fut, F> {
+    fn is_terminated(&self) -> bool {
+        self.future.is_terminated()
+    }
+}
+
+impl<Fut, F> Future for InspectOk<Fut, F>
+where
+    Fut: TryFuture,
+    F: FnOnce(&Fut::Ok),
+{
+    type Output = Result<Fut::Ok, Fut::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let e = ready!(self.as_mut().future().try_poll(cx));
+        if let Ok(e) = &e {
+            self.as_mut().f().take().expect("cannot poll InspectOk twice")(e);
+        }
+        Poll::Ready(e)
+    }
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -251,7 +251,7 @@ pub mod future {
 
         TryFutureExt,
         AndThen, ErrInto, FlattenSink, IntoFuture, MapErr, MapOk, OrElse,
-        TryFlattenStream, UnwrapOrElse,
+        InspectOk, InspectErr, TryFlattenStream, UnwrapOrElse,
     };
 
     #[cfg(feature = "never-type")]


### PR DESCRIPTION
`inspect_ok` is the same as 0.1's `Future::inspect_ok`. `inspect_err` is the same as `Future::inspect_err` added in #908