### PR TITLE
Fix error in Sink documentation

### DIFF
--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -62,7 +62,7 @@ pub trait Sink<Item> {
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>>;
 
     /// Begin the process of sending a value to the sink.
-    /// Each call to this function must be proceeded by a successful call to
+    /// Each call to this function must be preceded by a successful call to
     /// `poll_ready` which returned `Poll::Ready(Ok(()))`.
     ///
     /// As the name suggests, this method only *begins* the process of sending


### PR DESCRIPTION
The use of "proceeded" makes it sound like the opposite of "precede," like how "proscribe" is the opposite of "prescribe," but I don't think that was the intended meaning, since checking for readiness shouldn't come *after* starting a send.