### PR TITLE
Fix doc issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ matrix:
     - name: cargo doc
       rust: nightly
       script:
-        - cargo doc --all --no-deps --all-features
+        - RUSTDOCFLAGS=-Dwarnings cargo doc --all --no-deps --all-features
 
     - name: publish docs
       stage: release

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -47,3 +47,6 @@ futures-preview = { path = "../futures", version = "=0.3.0-alpha.16", features =
 futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.16" }
 futures-test-preview = { path = "../futures-test", version = "=0.3.0-alpha.16" }
 tokio = "0.1.11"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -46,10 +46,10 @@ impl<T> Compat01As03<T> {
     }
 }
 
-/// Extension trait for futures 0.1 [`Future`](futures::future::Future)
+/// Extension trait for futures 0.1 [`Future`](futures_01::future::Future)
 pub trait Future01CompatExt: Future01 {
     /// Converts a futures 0.1
-    /// [`Future<Item = T, Error = E>`](futures::future::Future)
+    /// [`Future<Item = T, Error = E>`](futures_01::future::Future)
     /// into a futures 0.3
     /// [`Future<Output = Result<T, E>>`](futures_core::future::Future).
     ///
@@ -73,10 +73,10 @@ pub trait Future01CompatExt: Future01 {
 }
 impl<Fut: Future01> Future01CompatExt for Fut {}
 
-/// Extension trait for futures 0.1 [`Stream`](futures::stream::Stream)
+/// Extension trait for futures 0.1 [`Stream`](futures_01::stream::Stream)
 pub trait Stream01CompatExt: Stream01 {
     /// Converts a futures 0.1
-    /// [`Stream<Item = T, Error = E>`](futures::stream::Stream)
+    /// [`Stream<Item = T, Error = E>`](futures_01::stream::Stream)
     /// into a futures 0.3
     /// [`Stream<Item = Result<T, E>>`](futures_core::stream::Stream).
     ///
@@ -101,12 +101,12 @@ pub trait Stream01CompatExt: Stream01 {
 }
 impl<St: Stream01> Stream01CompatExt for St {}
 
-/// Extension trait for futures 0.1 [`Sink`](futures::sink::Sink)
+/// Extension trait for futures 0.1 [`Sink`](futures_01::sink::Sink)
 pub trait Sink01CompatExt: Sink01 {
     /// Converts a futures 0.1
-    /// [`Sink<SinkItem = T, SinkError = E>`](futures::sink::Sink)
+    /// [`Sink<SinkItem = T, SinkError = E>`](futures_01::sink::Sink)
     /// into a futures 0.3
-    /// [`Sink<SinkItem = T, SinkError = E>`](futures_sink::sink::Sink).
+    /// [`Sink<SinkItem = T, SinkError = E>`](futures_sink::Sink).
     ///
     /// ```
     /// #![feature(async_await)]

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -25,9 +25,9 @@ use std::{
 /// Converts a futures 0.3 [`TryFuture`](futures_core::future::TryFuture),
 /// [`TryStream`](futures_core::stream::TryStream) or
 /// [`Sink`](futures_sink::Sink) into a futures 0.1
-/// [`Future`](futures::future::Future),
-/// [`Stream`](futures::stream::Stream) or
-/// [`Sink`](futures::sink::Sink).
+/// [`Future`](futures_01::future::Future),
+/// [`Stream`](futures_01::stream::Stream) or
+/// [`Sink`](futures_01::sink::Sink).
 #[derive(Debug, Clone, Copy)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Compat<T> {

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -11,14 +11,14 @@ use futures_core::task::{Spawn as Spawn03, SpawnError as SpawnError03};
 use futures_core::future::FutureObj;
 
 /// A future that can run on a futures 0.1
-/// [`Executor`](futures::future::Executor).
+/// [`Executor`](futures_01::future::Executor).
 pub type Executor01Future = Compat<UnitError<FutureObj<'static, ()>>>;
 
-/// Extension trait for futures 0.1 [`Executor`](futures::future::Executor).
+/// Extension trait for futures 0.1 [`Executor`](futures_01::future::Executor).
 pub trait Executor01CompatExt: Executor01<Executor01Future> +
                                Clone + Send + 'static
 {
-    /// Converts a futures 0.1 [`Executor`](futures::future::Executor) into a
+    /// Converts a futures 0.1 [`Executor`](futures_01::future::Executor) into a
     /// futures 0.3 [`Spawn`](futures_core::task::Spawn).
     ///
     /// ```
@@ -59,7 +59,7 @@ where Ex: Executor01<Executor01Future> + Clone + Send + 'static
     }
 }
 
-/// Converts a futures 0.1 [`Executor`](futures::future::Executor) into a
+/// Converts a futures 0.1 [`Executor`](futures_01::future::Executor) into a
 /// futures 0.3 [`Spawn`](futures_core::task::Spawn).
 #[derive(Clone)]
 pub struct Executor01As03<Ex> {

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -45,3 +45,6 @@ io-compat = ["compat", "futures-util-preview/io-compat"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]
 never-type = ["futures-util-preview/never-type"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-util-preview/alloc"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -166,7 +166,7 @@ pub mod executor {
     //! [`LocalPool`](crate::executor::LocalPool) executor. Aside from cutting
     //! down on synchronization costs, this executor also makes it possible to
     //! spawn non-`Send` tasks, via
-    //! [`spawn_local_obj`](crate::executor::LocalSpawn::spawn_local_obj).
+    //! [`spawn_local_obj`](crate::task::LocalSpawn::spawn_local_obj).
     //! The `LocalPool` is best suited for running I/O-bound tasks that do
     //! relatively little work between I/O operations.
     //!


### PR DESCRIPTION
docs.rs basically uses an older version of rustc, so I don't think we can completely migrate to docs.rs right now, but we can probably do it in the future.

Also, in the [document currently published in docs.rs](https://docs.rs/futures-preview/0.3.0-alpha.16/futures/), `compat` module and `async-await` macros are not displayed, so I will fix it with this PR.

Closes #1166
Closes #1639

cc #1105