### PR TITLE
Add Compat::get_ref method

### DIFF
--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -56,6 +56,12 @@ impl<T> Compat<T> {
     pub fn new(inner: T) -> Compat<T> {
         Compat { inner }
     }
+
+    /// Get a reference to 0.3 Future, Stream, AsyncRead, or AsyncWrite object
+    /// contained within.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
 }
 
 impl<T, Item> CompatSink<T, Item> {


### PR DESCRIPTION
It's currently possible to unwrap the `Compat` wrapper via the `into_inner` method, but not to simply get a reference to the wrapped object as it is with the `Compat01As03` wrappers.

This adds a `get_ref` method to bring it in-line with the others.