### PR TITLE
Add Send + Sync to ArcWake trait to fix unsoundness

### DIFF
--- a/futures-util/src/task/arc_wake.rs
+++ b/futures-util/src/task/arc_wake.rs
@@ -8,7 +8,9 @@ use alloc::sync::Arc;
 /// can be converted into `Waker` objects.
 /// Those Wakers can be used to signal executors that a task it owns
 /// is ready to be `poll`ed again.
-pub trait ArcWake {
+// Note: Send + Sync required because `Arc<T>` doesn't automatically imply
+// those bounds, but `Waker` implements them.
+pub trait ArcWake: Send + Sync {
     /// Indicates that the associated task is ready to make progress and should
     /// be `poll`ed.
     ///


### PR DESCRIPTION
Neither `Arc::new` nor `Arc<T>` itself *requires* `Send + Sync`, but the `into_waker` method assumes them when converting into a `Waker`. So without this change, it's possible to trigger UB with something like `Arc::new(Boom(some_rc)).into_waker()`.