### PR TITLE
Document clarifying StreamExt::forward usage

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -1065,7 +1065,10 @@ pub trait StreamExt: Stream {
     /// This future will drive the stream to keep producing items until it is
     /// exhausted, sending each item to the sink. It will complete once the
     /// stream is exhausted, the sink has received and flushed all items, and
-    /// the sink is closed.
+    /// the sink is closed. Note that neither the original stream nor provided
+    /// sink will be output by this future.  Pass the sink by `Pin<&mut S>`
+    /// (for example, via `forward(&mut sink)` inside an `async` fn/block) in
+    /// order to preserve access to the Sink.
     fn forward<S>(self, sink: S) -> Forward<Self, S>
     where
         S: Sink<<Self as TryStream>::Ok>,


### PR DESCRIPTION
Having just stumbled on this, coming from futures 0.1, I'd like to help the next person.

I was only able to figure this out via hints in #1441. 
