### PR TITLE
Make all extension traits unnamed in the prelude

### DIFF
--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -326,14 +326,14 @@ pub mod prelude {
     //!
     //! The prelude may grow over time as additional items see ubiquitous use.
 
-    pub use crate::future::{self, Future, TryFuture, FutureExt, TryFutureExt};
-    pub use crate::stream::{self, Stream, TryStream, StreamExt, TryStreamExt};
-    pub use crate::sink::{self, Sink, SinkExt};
+    pub use crate::future::{self, Future, TryFuture, FutureExt as _, TryFutureExt as _};
+    pub use crate::stream::{self, Stream, TryStream, StreamExt as _, TryStreamExt as _};
+    pub use crate::sink::{self, Sink, SinkExt as _};
 
     #[cfg(feature = "std")]
     pub use crate::io::{
         AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead,
-        AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt,
+        AsyncReadExt as _, AsyncWriteExt as _, AsyncSeekExt as _, AsyncBufReadExt as _,
     };
 }
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -326,13 +326,25 @@ pub mod prelude {
     //!
     //! The prelude may grow over time as additional items see ubiquitous use.
 
-    pub use crate::future::{self, Future, TryFuture, FutureExt as _, TryFutureExt as _};
-    pub use crate::stream::{self, Stream, TryStream, StreamExt as _, TryStreamExt as _};
-    pub use crate::sink::{self, Sink, SinkExt as _};
+    pub use crate::future::{self, Future, TryFuture};
+    pub use crate::stream::{self, Stream, TryStream};
+    pub use crate::sink::{self, Sink};
+
+    #[doc(no_inline)]
+    pub use crate::future::{FutureExt as _, TryFutureExt as _};
+    #[doc(no_inline)]
+    pub use crate::stream::{StreamExt as _, TryStreamExt as _};
+    #[doc(no_inline)]
+    pub use crate::sink::SinkExt as _;
 
     #[cfg(feature = "std")]
     pub use crate::io::{
         AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead,
+    };
+
+    #[cfg(feature = "std")]
+    #[doc(no_inline)]
+    pub use crate::io::{
         AsyncReadExt as _, AsyncWriteExt as _, AsyncSeekExt as _, AsyncBufReadExt as _,
     };
 }


### PR DESCRIPTION
This is useful for avoiding accidental shadowing of glob imported preludes, the methods will be brought into scope but the trait itself will have no name so can't be shadowed by things like `use futures_timer::FutureExt;`.

Unfortunately `rustdoc` doesn't render these well, but hopefully that can get fixed at some point

<img width="401" alt="Screenshot 2019-06-06 at 18 50 37" src="https://user-images.githubusercontent.com/81079/59050952-fb551680-888b-11e9-8093-184d2eea1a36.png">