### PR TITLE
Provide global back-pressure on mpsc::Sender::send

### DIFF
--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -93,7 +93,7 @@ impl Stream for TestSender {
         ready!(tx.as_mut().poll_ready(cx)).unwrap();
         tx.as_mut().start_send(this.last + 1).unwrap();
         this.last += 1;
-        assert_eq!(Poll::Ready(Ok(())), tx.as_mut().poll_flush(cx));
+        assert_eq!(Poll::Pending, tx.as_mut().poll_flush(cx));
         Poll::Ready(Some(this.last))
     }
 }

--- a/futures-sink/src/channel_impls.rs
+++ b/futures-sink/src/channel_impls.rs
@@ -1,24 +1,42 @@
-use crate::{Sink, Poll};
+use crate::{Poll, Sink};
+use futures_channel::mpsc::{SendError, Sender, TrySendError, UnboundedSender};
 use futures_core::task::Context;
-use futures_channel::mpsc::{Sender, SendError, TrySendError, UnboundedSender};
 use std::pin::Pin;
 
 impl<T> Sink<T> for Sender<T> {
     type SinkError = SendError;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         (*self).poll_ready(cx)
     }
 
-    fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::SinkError> {
+    fn start_send(
+        mut self: Pin<&mut Self>,
+        msg: T,
+    ) -> Result<(), Self::SinkError> {
         (*self).start_send(msg)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
-        Poll::Ready(Ok(()))
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
+        match (*self).poll_ready(cx) {
+            Poll::Ready(Err(ref e)) if e.is_disconnected() => {
+                // If the receiver disconnected, we consider the sink to be flushed.
+                Poll::Ready(Ok(()))
+            }
+            x => x,
+        }
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         self.disconnect();
         Poll::Ready(Ok(()))
     }
@@ -27,19 +45,31 @@ impl<T> Sink<T> for Sender<T> {
 impl<T> Sink<T> for UnboundedSender<T> {
     type SinkError = SendError;
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         UnboundedSender::poll_ready(&*self, cx)
     }
 
-    fn start_send(mut self: Pin<&mut Self>, msg: T) -> Result<(), Self::SinkError> {
+    fn start_send(
+        mut self: Pin<&mut Self>,
+        msg: T,
+    ) -> Result<(), Self::SinkError> {
         UnboundedSender::start_send(&mut *self, msg)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         self.disconnect();
         Poll::Ready(Ok(()))
     }
@@ -48,7 +78,10 @@ impl<T> Sink<T> for UnboundedSender<T> {
 impl<T> Sink<T> for &UnboundedSender<T> {
     type SinkError = SendError;
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         UnboundedSender::poll_ready(*self, cx)
     }
 
@@ -57,11 +90,17 @@ impl<T> Sink<T> for &UnboundedSender<T> {
             .map_err(TrySendError::into_send_error)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Result<(), Self::SinkError>> {
         self.close_channel();
         Poll::Ready(Ok(()))
     }


### PR DESCRIPTION
Previously the bounded mpsc channels don't provide back-pressure for every new cloned sender where the capacity check is bypassed. It's an issue when use it with combinators, like `buffer_unordered` and causes OOM eventually.
There are great discussions in https://github.com/rust-lang-nursery/futures-rs/pull/984 about global vs local limits and more. From what I can see, it seems we all agree on the solution to call `poll_ready` in `poll_flush` so that it does the capacity check in every `send` call. The fix got merged into 0.1 in https://github.com/rust-lang-nursery/futures-rs/commit/4b0e21785a567b40cdf6b8c083625c88626b2a5d and merged into 0.2 in https://github.com/rust-lang-nursery/futures-rs/commit/62827f1776e833a948cb81582988cb7a70a8b700. But the latest 0.3 still has the issue. This PR is to fix that and also add tests to cover the back-pressure cases.