### PR TITLE
Deny warnings for doc tests

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -11,6 +11,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_channel")]
 
 #[cfg(feature = "std")]

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -7,6 +7,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_core")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -183,7 +183,7 @@ impl AtomicWaker {
     /// impl Future for Flag {
     ///     type Output = ();
     ///
-    ///     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+    ///     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
     ///         // Register **before** checking `set` to avoid a race condition
     ///         // that would result in lost notifications.
     ///         self.waker.register(cx.waker());

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -8,6 +8,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_executor")]
 
 #[cfg(feature = "std")]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -175,16 +175,16 @@ impl LocalPool {
     /// let mut pool = LocalPool::new();
     /// let mut spawner = pool.spawner();
     ///
-    /// spawner.spawn_local(ready(()));
-    /// spawner.spawn_local(ready(()));
-    /// spawner.spawn_local(empty());
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(empty()).unwrap();
     ///
     /// // Run the two ready tasks and return true for them.
     /// pool.try_run_one(); // returns true after completing one of the ready futures
     /// pool.try_run_one(); // returns true after completing the other ready future
     ///
     /// // the remaining task can not be completed
-    /// pool.try_run_one(); // returns false
+    /// assert!(!pool.try_run_one()); // returns false
     /// ```
     ///
     /// This function will not block the calling thread and will return the moment
@@ -215,9 +215,9 @@ impl LocalPool {
     /// let mut pool = LocalPool::new();
     /// let mut spawner = pool.spawner();
     ///
-    /// spawner.spawn_local(ready(()));
-    /// spawner.spawn_local(ready(()));
-    /// spawner.spawn_local(empty());
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(empty()).unwrap();
     ///
     /// // Runs the two ready task and returns.
     /// // The empty task remains in the pool.

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -13,6 +13,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_io")]
 
 #[cfg(feature = "std")]

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -7,6 +7,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_sink")]
 
 #[cfg(feature = "alloc")]

--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -17,7 +17,7 @@ pub fn assert_is_unpin_stream<S: Stream + Unpin>(_: &mut S) {}
 /// };
 /// use pin_utils::pin_mut;
 ///
-/// let mut stream = stream::once((async { 5 }).pending_once());
+/// let stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
 ///
 /// assert_stream_pending!(stream);
@@ -54,7 +54,7 @@ macro_rules! assert_stream_pending {
 /// };
 /// use pin_utils::pin_mut;
 ///
-/// let mut stream = stream::once((async { 5 }).pending_once());
+/// let stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
 ///
 /// assert_stream_pending!(stream);
@@ -97,7 +97,7 @@ macro_rules! assert_stream_next {
 /// };
 /// use pin_utils::pin_mut;
 ///
-/// let mut stream = stream::once((async { 5 }).pending_once());
+/// let stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
 ///
 /// assert_stream_pending!(stream);

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -3,6 +3,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_test")]
 
 #[cfg(not(feature = "std"))]

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -28,7 +28,7 @@ pub fn panic_context() -> Context<'static> {
 /// use futures_test::task::noop_context;
 /// use pin_utils::pin_mut;
 ///
-/// let mut future = async { 5 };
+/// let future = async { 5 };
 /// pin_mut!(future);
 ///
 /// assert_eq!(future.poll(&mut noop_context()), Poll::Ready(5));

--- a/futures-test/src/task/noop_spawner.rs
+++ b/futures-test/src/task/noop_spawner.rs
@@ -12,7 +12,7 @@ use futures_core::task::{Spawn, SpawnError};
 /// use futures_test::task::NoopSpawner;
 ///
 /// let mut spawner = NoopSpawner::new();
-/// spawner.spawn(async { });
+/// spawner.spawn(async { }).unwrap();
 /// ```
 #[derive(Debug)]
 pub struct NoopSpawner {
@@ -51,7 +51,7 @@ impl Default for NoopSpawner {
 /// use futures_test::task::noop_spawner_mut;
 ///
 /// let spawner = noop_spawner_mut();
-/// spawner.spawn(async { });
+/// spawner.spawn(async { }).unwrap();
 /// ```
 pub fn noop_spawner_mut() -> &'static mut NoopSpawner {
     Box::leak(Box::new(NoopSpawner::new()))

--- a/futures-test/src/task/panic_spawner.rs
+++ b/futures-test/src/task/panic_spawner.rs
@@ -12,7 +12,8 @@ use futures_core::task::{Spawn, SpawnError};
 /// use futures_test::task::PanicSpawner;
 ///
 /// let mut spawn = PanicSpawner::new();
-/// spawn.spawn(async { }); // Will panic
+/// spawn.spawn(async { })?; // Will panic
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[derive(Debug)]
 pub struct PanicSpawner {
@@ -51,7 +52,8 @@ impl Default for PanicSpawner {
 /// use futures_test::task::panic_spawner_mut;
 ///
 /// let spawner = panic_spawner_mut();
-/// spawner.spawn(async { }); // Will panic
+/// spawner.spawn(async { })?; // Will panic
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub fn panic_spawner_mut() -> &'static mut PanicSpawner {
     Box::leak(Box::new(PanicSpawner::new()))

--- a/futures-test/src/task/panic_waker.rs
+++ b/futures-test/src/task/panic_waker.rs
@@ -47,7 +47,6 @@ pub fn panic_waker() -> Waker {
 ///
 /// ```should_panic
 /// #![feature(async_await)]
-/// use futures::task;
 /// use futures_test::task::panic_waker_ref;
 ///
 /// let waker = panic_waker_ref();

--- a/futures-test/src/task/record_spawner.rs
+++ b/futures-test/src/task/record_spawner.rs
@@ -12,7 +12,7 @@ use futures_core::task::{Spawn, SpawnError};
 /// use futures_test::task::RecordSpawner;
 ///
 /// let mut recorder = RecordSpawner::new();
-/// recorder.spawn(async { });
+/// recorder.spawn(async { }).unwrap();
 /// assert_eq!(recorder.spawned().len(), 1);
 /// ```
 #[derive(Debug)]

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -29,7 +29,7 @@ macro_rules! document_select_macro {
         /// ```
         /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
-        /// use futures::future::{self, FutureExt};
+        /// use futures::future;
         /// use futures::select;
         /// let mut a = future::ready(4);
         /// let mut b = future::empty::<()>();
@@ -45,7 +45,7 @@ macro_rules! document_select_macro {
         /// ```
         /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
-        /// use futures::future::{self, FutureExt};
+        /// use futures::future;
         /// use futures::stream::{self, StreamExt};
         /// use futures::select;
         /// let mut st = stream::iter(vec![2]).fuse();
@@ -67,7 +67,7 @@ macro_rules! document_select_macro {
         /// ```
         /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
-        /// use futures::future::{self, FutureExt};
+        /// use futures::future;
         /// use futures::select;
         /// let mut a_fut = future::ready(4);
         /// let mut b_fut = future::ready(6);

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -23,7 +23,6 @@ pub trait Executor01CompatExt: Executor01<Executor01Future> +
     ///
     /// ```
     /// #![feature(async_await)]
-    /// use futures::Future;
     /// use futures::task::SpawnExt;
     /// use futures::future::{FutureExt, TryFutureExt};
     /// use futures_util::compat::Executor01CompatExt;

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -397,9 +397,7 @@ pub trait FutureExt: Future {
     ///
     /// # Examples
     ///
-    // TODO: minimize and open rust-lang/rust ticket, currently errors:
-    //       'assertion failed: !value.has_escaping_regions()'
-    /// ```ignore
+    /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::future::{self, FutureExt, Ready};

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -102,7 +102,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// assert_eq!(bytes, 4);
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn copy_into<'a, W>(
         &'a mut self,
@@ -137,7 +137,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// // `output.len()` bytes in a single read.
     /// assert_eq!(bytes, 4);
     /// assert_eq!(output, [1, 2, 3, 4, 0]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn read<'a>(&'a mut self, buf: &'a mut [u8]) -> Read<'a, Self>
         where Self: Unpin,
@@ -178,7 +178,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// reader.read_exact(&mut output).await?;
     ///
     /// assert_eq!(output, [1, 2, 3, 4]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     ///
     /// ## EOF is hit before `buf` is filled
@@ -222,7 +222,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// reader.read_to_end(&mut output).await?;
     ///
     /// assert_eq!(output, vec![1, 2, 3, 4]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn read_to_end<'a>(
         &'a mut self,
@@ -262,7 +262,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// assert_eq!(buffer.into_inner(), [1, 2, 3, 4, 5, 6, 7, 8]);
     /// assert_eq!(writer.into_inner(), [5, 6, 7, 8, 0]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn split(self) -> (ReadHalf<Self>, WriteHalf<Self>)
         where Self: AsyncWrite + Sized,
@@ -301,7 +301,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// let mut output = [0u8; 5];
     ///
     /// {
-    ///     let mut writer = Cursor::new(&mut output[..]);
+    ///     let writer = Cursor::new(&mut output[..]);
     ///     let mut buffered = AllowStdIo::new(BufWriter::new(writer));
     ///     buffered.write_all(&[1, 2]).await?;
     ///     buffered.write_all(&[3, 4]).await?;
@@ -309,7 +309,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// }
     ///
     /// assert_eq!(output, [1, 2, 3, 4, 0]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn flush(&mut self) -> Flush<'_, Self>
         where Self: Unpin,
@@ -365,7 +365,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// writer.write_all(&[1, 2, 3, 4]).await?;
     ///
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn write_all<'a>(&'a mut self, buf: &'a [u8]) -> WriteAll<'a, Self>
         where Self: Unpin,
@@ -445,7 +445,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// let num_bytes = cursor.read_until(b'-', &mut buf).await?;
     /// assert_eq!(num_bytes, 0);
     /// assert_eq!(buf, b"");
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn read_until<'a>(
         &'a mut self,
@@ -508,7 +508,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// let num_bytes = cursor.read_line(&mut buf).await?;
     /// assert_eq!(num_bytes, 0);
     /// assert_eq!(buf, "");
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn read_line<'a>(&'a mut self, buf: &'a mut String) -> ReadLine<'a, Self>
         where Self: Unpin,
@@ -548,7 +548,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// assert_eq!(lines_stream.next().await, Some(String::from("ipsum")));
     /// assert_eq!(lines_stream.next().await, Some(String::from("dolor")));
     /// assert_eq!(lines_stream.next().await, None);
-    /// # Ok::<(), Box<std::error::Error>>(()) }).unwrap();
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     fn lines(self) -> Lines<Self>
         where Self: Sized,

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -9,6 +9,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures_util")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]

--- a/futures-util/src/stream/iter.rs
+++ b/futures-util/src/stream/iter.rs
@@ -22,7 +22,7 @@ impl<I> Unpin for Iter<I> {}
 /// # futures::executor::block_on(async {
 /// use futures::stream::{self, StreamExt};
 ///
-/// let mut stream = stream::iter(vec![17, 19]);
+/// let stream = stream::iter(vec![17, 19]);
 /// assert_eq!(vec![17, 19], stream.collect::<Vec<i32>>().await);
 /// # });
 /// ```

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -944,14 +944,14 @@ pub trait StreamExt: Stream {
     /// let stream_of_futures = stream::iter(vec![recv_one, recv_two]);
     /// let mut buffered = stream_of_futures.buffer_unordered(10);
     ///
-    /// send_two.send(2i32);
+    /// send_two.send(2i32)?;
     /// assert_eq!(buffered.next().await, Some(Ok(2i32)));
     ///
-    /// send_one.send(1i32);
+    /// send_one.send(1i32)?;
     /// assert_eq!(buffered.next().await, Some(Ok(1i32)));
     ///
     /// assert_eq!(buffered.next().await, None);
-    /// # })
+    /// # Ok::<(), i32>(()) }).unwrap();
     /// ```
     #[cfg_attr(
         feature = "cfg-target-has-atomic",

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -12,7 +12,7 @@ use pin_utils::unsafe_pinned;
 /// use futures::future;
 /// use futures::stream::{self, StreamExt};
 ///
-/// let mut stream = stream::once(future::ready(17));
+/// let stream = stream::once(future::ready(17));
 /// let collected = stream.collect::<Vec<i32>>().await;
 /// assert_eq!(collected, vec![17]);
 /// # });

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -20,7 +20,7 @@ pub struct Repeat<T> {
 /// # futures::executor::block_on(async {
 /// use futures::stream::{self, StreamExt};
 ///
-/// let mut stream = stream::repeat(9);
+/// let stream = stream::repeat(9);
 /// assert_eq!(vec![9, 9, 9], stream.take(3).collect::<Vec<i32>>().await);
 /// # });
 /// ```

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -35,7 +35,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// use futures::future;
 /// use futures::stream::{self, StreamExt};
 ///
-/// let mut stream = stream::unfold(0, |state| {
+/// let stream = stream::unfold(0, |state| {
 ///     if state <= 2 {
 ///         let next_state = state + 1;
 ///         let yielded = state  * 2;

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -365,7 +365,7 @@ pub trait TryStreamExt: TryStream {
     /// use futures::stream::{self, TryStreamExt};
     ///
     /// let stream = stream::iter(vec![Ok::<i32, i32>(1), Ok(3), Ok(2)]);
-    /// let mut stream = stream.try_skip_while(|x| future::ready(Ok(*x < 3)));
+    /// let stream = stream.try_skip_while(|x| future::ready(Ok(*x < 3)));
     ///
     /// let output: Result<Vec<i32>, i32> = stream.try_collect().await;
     /// assert_eq!(output, Ok(vec![3, 2]));
@@ -670,14 +670,14 @@ pub trait TryStreamExt: TryStream {
     ///
     /// let mut buffered = stream_of_futures.try_buffer_unordered(10);
     ///
-    /// send_two.send(2i32);
+    /// send_two.send(2i32)?;
     /// assert_eq!(buffered.next().await, Some(Ok(2i32)));
     ///
-    /// send_one.send(1i32);
+    /// send_one.send(1i32)?;
     /// assert_eq!(buffered.next().await, Some(Ok(1i32)));
     ///
     /// assert_eq!(buffered.next().await, None);
-    /// # })
+    /// # Ok::<(), i32>(()) }).unwrap();
     /// ```
     ///
     /// Errors from the underlying stream itself are propagated:
@@ -691,12 +691,12 @@ pub trait TryStreamExt: TryStream {
     /// let (sink, stream_of_futures) = mpsc::unbounded();
     /// let mut buffered = stream_of_futures.try_buffer_unordered(10);
     ///
-    /// sink.unbounded_send(Ok(future::ready(Ok(7i32))));
+    /// sink.unbounded_send(Ok(future::ready(Ok(7i32))))?;
     /// assert_eq!(buffered.next().await, Some(Ok(7i32)));
     ///
-    /// sink.unbounded_send(Err("error in the stream"));
+    /// sink.unbounded_send(Err("error in the stream"))?;
     /// assert_eq!(buffered.next().await, Some(Err("error in the stream")));
-    /// # })
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     #[cfg_attr(
         feature = "cfg-target-has-atomic",
@@ -767,10 +767,8 @@ pub trait TryStreamExt: TryStream {
     /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
-    /// use futures::future::lazy;
-    /// use futures::stream::{self, StreamExt, TryStreamExt};
-    /// use futures::io::{AsyncRead, AsyncReadExt};
-    /// use std::io::Error;
+    /// use futures::stream::{self, TryStreamExt};
+    /// use futures::io::AsyncReadExt;
     ///
     /// let stream = stream::iter(vec![Ok(vec![1, 2, 3, 4, 5])]);
     /// let mut reader = stream.into_async_read();

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -29,6 +29,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
 #![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.16/futures")]
 
 #[cfg(all(feature = "async-await", not(feature = "nightly")))]
@@ -140,7 +142,7 @@ pub mod executor {
     //!
     //! ```
     //! use futures::executor::ThreadPool;
-    //! # use futures::future::{Future, lazy};
+    //! # use futures::future::lazy;
     //! # let my_app = lazy(|_| 42);
     //!
     //! // assuming `my_app: Future`
@@ -321,6 +323,7 @@ pub mod prelude {
     //! standard library's prelude you'll have to do so manually:
     //!
     //! ```
+    //! # #[allow(unused_imports)]
     //! use futures::prelude::*;
     //! ```
     //!


### PR DESCRIPTION
We cleaned this up with some PRs (#1590, #1381, etc.), ~~so we are not warned at the moment~~, but it will be useful to maintain the quality of the examples. (EDIT: I missed `unused` being allowed by default.)

It would have been nice if this was supported as a `cargo doc` or `clippy` option (maybe like `cargo doc --test -- --Dwarnings`?), but it does not seem to be supported yet (https://github.com/rust-lang/rust/issues/56232).