### PR TITLE
Change ArcWake::into_waker to a free function

### DIFF
--- a/futures-test/src/task/wake_counter.rs
+++ b/futures-test/src/task/wake_counter.rs
@@ -1,7 +1,7 @@
-use futures_core::task::{Waker};
+use futures_core::task::Waker;
+use futures_util::task::{self, ArcWake};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use futures_util::task::ArcWake;
 
 /// Number of times the waker was awoken.
 ///
@@ -55,5 +55,5 @@ impl ArcWake for WakerInner {
 /// ```
 pub fn new_count_waker() -> (Waker, AwokenCount) {
     let inner = Arc::new(WakerInner { count: AtomicUsize::new(0) });
-    (ArcWake::into_waker(inner.clone()), AwokenCount { inner })
+    (task::waker(inner.clone()), AwokenCount { inner })
 }

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -7,17 +7,17 @@ use futures_01::{
     AsyncSink as AsyncSink01, Sink as Sink01, StartSend as StartSend01,
 };
 use futures_core::{
-    task::{
-        self as task03,
-        RawWaker,
-        RawWakerVTable,
-    },
+    task::{RawWaker, RawWakerVTable},
     TryFuture as TryFuture03,
     TryStream as TryStream03,
 };
 #[cfg(feature = "sink")]
 use futures_sink::Sink as Sink03;
-use crate::task::{ArcWake as ArcWake03, WakerRef};
+use crate::task::{
+    self as task03,
+    ArcWake as ArcWake03,
+    WakerRef,
+};
 #[cfg(feature = "sink")]
 use std::marker::PhantomData;
 use std::{
@@ -85,7 +85,7 @@ impl<T, Item> CompatSink<T, Item> {
             _phantom: PhantomData,
         }
     }
-    
+
     /// Get a reference to 0.3 Sink contained within.
     pub fn get_ref(&self) -> &T {
         &self.inner
@@ -192,7 +192,7 @@ impl Current {
             // FIXME: remove `transmute` when a `Waker` -> `RawWaker` conversion
             // function is landed in `core`.
             mem::transmute::<task03::Waker, RawWaker>(
-                Arc::new(ptr_to_current(ptr).clone()).into_waker()
+                task03::waker(Arc::new(ptr_to_current(ptr).clone()))
             )
         }
         unsafe fn drop(_: *const ()) {}

--- a/futures-util/src/task/arc_wake.rs
+++ b/futures-util/src/task/arc_wake.rs
@@ -3,9 +3,18 @@ use alloc::sync::Arc;
 /// A way of waking up a specific task.
 ///
 /// By implementing this trait, types that are expected to be wrapped in an `Arc`
-/// can be converted into `Waker` objects.
+/// can be converted into [`Waker`] objects.
 /// Those Wakers can be used to signal executors that a task it owns
 /// is ready to be `poll`ed again.
+///
+/// Currently, there are two ways to convert `ArcWake` into [`Waker`]:
+///
+/// * [`waker`](crate::task::waker()) converts `Arc<impl ArcWake>` into [`Waker`].
+/// * [`waker_ref`](crate::task::waker_ref()) converts `&Arc<impl ArcWake>` into [`WakerRef`] that
+///   provides access to a [`&Waker`][`Waker`].
+///
+/// [`Waker`]: std::task::Waker
+/// [`WakerRef`]: crate::task::WakerRef
 // Note: Send + Sync required because `Arc<T>` doesn't automatically imply
 // those bounds, but `Waker` implements them.
 pub trait ArcWake: Send + Sync {
@@ -13,10 +22,12 @@ pub trait ArcWake: Send + Sync {
     /// be `poll`ed.
     ///
     /// This function can be called from an arbitrary thread, including threads which
-    /// did not create the `ArcWake` based `Waker`.
+    /// did not create the `ArcWake` based [`Waker`].
     ///
     /// Executors generally maintain a queue of "ready" tasks; `wake` should place
     /// the associated task onto this queue.
+    ///
+    /// [`Waker`]: std::task::Waker
     fn wake(self: Arc<Self>) {
         Self::wake_by_ref(&self)
     }
@@ -25,12 +36,14 @@ pub trait ArcWake: Send + Sync {
     /// be `poll`ed.
     ///
     /// This function can be called from an arbitrary thread, including threads which
-    /// did not create the `ArcWake` based `Waker`.
+    /// did not create the `ArcWake` based [`Waker`].
     ///
     /// Executors generally maintain a queue of "ready" tasks; `wake_by_ref` should place
     /// the associated task onto this queue.
     ///
-    /// This function is similar to `wake`, but must not consume the provided data
+    /// This function is similar to [`wake`](ArcWake::wake), but must not consume the provided data
     /// pointer.
+    ///
+    /// [`Waker`]: std::task::Waker
     fn wake_by_ref(arc_self: &Arc<Self>);
 }

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -21,6 +21,11 @@ cfg_target_has_atomic! {
     pub use self::arc_wake::ArcWake;
 
     #[cfg(feature = "alloc")]
+    mod waker;
+    #[cfg(feature = "alloc")]
+    pub use self::waker::waker;
+
+    #[cfg(feature = "alloc")]
     mod waker_ref;
     #[cfg(feature = "alloc")]
     pub use self::waker_ref::{waker_ref, WakerRef};

--- a/futures-util/src/task/noop_waker.rs
+++ b/futures-util/src/task/noop_waker.rs
@@ -16,7 +16,7 @@ fn noop_raw_waker() -> RawWaker {
     RawWaker::new(null(), &NOOP_WAKER_VTABLE)
 }
 
-/// Create a new [`Waker`](futures_core::task::Waker) which does
+/// Create a new [`Waker`] which does
 /// nothing when `wake()` is called on it.
 ///
 /// # Examples
@@ -33,7 +33,7 @@ pub fn noop_waker() -> Waker {
     }
 }
 
-/// Get a static reference to a [`Waker`](futures_core::task::Waker) which
+/// Get a static reference to a [`Waker`] which
 /// does nothing when `wake()` is called on it.
 ///
 /// # Examples

--- a/futures-util/src/task/waker.rs
+++ b/futures-util/src/task/waker.rs
@@ -1,0 +1,53 @@
+use super::arc_wake::ArcWake;
+use core::mem;
+use core::task::{Waker, RawWaker, RawWakerVTable};
+use alloc::sync::Arc;
+
+/// Creates a [`Waker`] from an `Arc<impl ArcWake>`.
+///
+/// The returned [`Waker`] will call
+/// [`ArcWake.wake()`](ArcWake::wake) if awoken.
+pub fn waker<W>(wake: Arc<W>) -> Waker
+where
+    W: ArcWake,
+{
+    let ptr = Arc::into_raw(wake) as *const ();
+
+    unsafe {
+        Waker::from_raw(RawWaker::new(ptr, waker_vtable!(W)))
+    }
+}
+
+// FIXME: panics on Arc::clone / refcount changes could wreak havoc on the
+// code here. We should guard against this by aborting.
+
+unsafe fn increase_refcount<T: ArcWake>(data: *const ()) {
+    // Retain Arc by creating a copy
+    let arc: Arc<T> = Arc::from_raw(data as *const T);
+    let arc_clone = arc.clone();
+    // Forget the Arcs again, so that the refcount isn't decrased
+    mem::forget(arc);
+    mem::forget(arc_clone);
+}
+
+// used by `waker_ref`
+pub(super) unsafe fn clone_arc_raw<T: ArcWake>(data: *const ()) -> RawWaker {
+    increase_refcount::<T>(data);
+    RawWaker::new(data, waker_vtable!(T))
+}
+
+unsafe fn wake_arc_raw<T: ArcWake>(data: *const ()) {
+    let arc: Arc<T> = Arc::from_raw(data as *const T);
+    ArcWake::wake(arc);
+}
+
+// used by `waker_ref`
+pub(super) unsafe fn wake_by_ref_arc_raw<T: ArcWake>(data: *const ()) {
+    let arc: Arc<T> = Arc::from_raw(data as *const T);
+    ArcWake::wake_by_ref(&arc);
+    mem::forget(arc);
+}
+
+unsafe fn drop_arc_raw<T: ArcWake>(data: *const ()) {
+    drop(Arc::<T>::from_raw(data as *const T))
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -491,7 +491,7 @@ pub mod task {
         cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
     )]
     #[cfg(feature = "alloc")]
-    pub use futures_util::task::{WakerRef, waker_ref, ArcWake};
+    pub use futures_util::task::{waker, waker_ref, WakerRef, ArcWake};
 
     #[cfg_attr(
         feature = "cfg-target-has-atomic",

--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -1,4 +1,4 @@
-use futures::task::{ArcWake, Waker};
+use futures::task::{self, ArcWake, Waker};
 use std::sync::{Arc, Mutex};
 
 struct CountingWaker {
@@ -28,7 +28,7 @@ impl ArcWake for CountingWaker {
 fn create_waker_from_arc() {
     let some_w = Arc::new(CountingWaker::new());
 
-    let w1: Waker = ArcWake::into_waker(some_w.clone());
+    let w1: Waker = task::waker(some_w.clone());
     assert_eq!(2, Arc::strong_count(&some_w));
     w1.wake_by_ref();
     assert_eq!(1, some_w.wakes());


### PR DESCRIPTION
I feel this to be more consistent.

```rust
pub fn waker<W>(wake: Arc<W>) -> Waker where W: ArcWake;

pub fn waker_ref<W>(wake: &Arc<W>) -> WakerRef<'_> where W: ArcWake;
```
