### PR TITLE
Adjust Debug implementations

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -168,11 +168,11 @@ pub struct TryRecvError {
 }
 
 impl fmt::Display for SendError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_full() {
-            write!(fmt, "send failed because channel is full")
+            write!(f, "send failed because channel is full")
         } else {
-            write!(fmt, "send failed because receiver is gone")
+            write!(f, "send failed because receiver is gone")
         }
     }
 }
@@ -198,19 +198,19 @@ impl SendError {
 }
 
 impl<T> fmt::Debug for TrySendError<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("TrySendError")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrySendError")
             .field("kind", &self.err.kind)
             .finish()
     }
 }
 
 impl<T> fmt::Display for TrySendError<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_full() {
-            write!(fmt, "send failed because channel is full")
+            write!(f, "send failed because channel is full")
         } else {
-            write!(fmt, "send failed because receiver is gone")
+            write!(f, "send failed because receiver is gone")
         }
     }
 }
@@ -240,15 +240,15 @@ impl<T> TrySendError<T> {
 }
 
 impl fmt::Debug for TryRecvError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_tuple("TryRecvError")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TryRecvError")
             .finish()
     }
 }
 
 impl fmt::Display for TryRecvError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "receiver channel is empty")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "receiver channel is empty")
     }
 }
 

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -382,8 +382,8 @@ impl<T> Drop for Sender<T> {
 pub struct Canceled;
 
 impl fmt::Display for Canceled {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "oneshot canceled")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "oneshot canceled")
     }
 }
 

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -313,8 +313,8 @@ impl Default for AtomicWaker {
 }
 
 impl fmt::Debug for AtomicWaker {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "AtomicWaker")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AtomicWaker")
     }
 }
 

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -307,6 +307,7 @@ where
 
 struct NotifyWaker(task03::Waker);
 
+#[allow(missing_debug_implementations)] // false positive: this is private type
 #[derive(Clone)]
 struct WakerToHandle<'a>(&'a task03::Waker);
 

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -60,7 +60,7 @@ where Ex: Executor01<Executor01Future> + Clone + Send + 'static
 
 /// Converts a futures 0.1 [`Executor`](futures_01::future::Executor) into a
 /// futures 0.3 [`Spawn`](futures_core::task::Spawn).
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Executor01As03<Ex> {
     executor01: Ex
 }

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -3,8 +3,6 @@
 //! This module is only available when the `compat` feature of this
 //! library is activated.
 
-#![allow(missing_debug_implementations)]
-
 mod executor;
 pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 

--- a/futures-util/src/future/flatten.rs
+++ b/futures-util/src/future/flatten.rs
@@ -31,8 +31,8 @@ impl<Fut> fmt::Debug for Flatten<Fut>
     where Fut: Future + fmt::Debug,
           Fut::Output: Future + fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Flatten")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Flatten")
             .field("state", &self.state)
             .finish()
     }

--- a/futures-util/src/future/flatten_stream.rs
+++ b/futures-util/src/future/flatten_stream.rs
@@ -25,8 +25,8 @@ impl<Fut> fmt::Debug for FlattenStream<Fut>
     where Fut: Future + fmt::Debug,
           Fut::Output: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("FlattenStream")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlattenStream")
             .field("state", &self.state)
             .finish()
     }

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -26,8 +26,8 @@ macro_rules! generate {
                 $Fut::Output: fmt::Debug,
             )*
         {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt.debug_struct(stringify!($Join))
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($Join))
                     $(.field(stringify!($Fut), &self.$Fut))*
                     .finish()
             }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -70,8 +70,8 @@ where
     F: Future + fmt::Debug,
     F::Output: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("JoinAll")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JoinAll")
             .field("elems", &self.elems)
             .finish()
     }

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -1,11 +1,11 @@
 //! Definition of the `PollFn` adapter combinator
 
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
 
 /// Future for the [`poll_fn`] function.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct PollFn<F> {
     f: F,
@@ -38,6 +38,12 @@ where
     F: FnMut(&mut Context<'_>) -> Poll<T>
 {
     PollFn { f }
+}
+
+impl<F> fmt::Debug for PollFn<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PollFn").finish()
+    }
 }
 
 impl<T, F> Future for PollFn<F>

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -31,8 +31,8 @@ struct Notifier {
 impl<Fut: Future> Unpin for Shared<Fut> {}
 
 impl<Fut: Future> fmt::Debug for Shared<Fut> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Shared")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Shared")
             .field("inner", &self.inner)
             .field("waker_key", &self.waker_key)
             .finish()
@@ -40,8 +40,8 @@ impl<Fut: Future> fmt::Debug for Shared<Fut> {
 }
 
 impl<Fut: Future> fmt::Debug for Inner<Fut> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Inner").finish()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Inner").finish()
     }
 }
 

--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -197,8 +197,8 @@ impl<R: AsyncRead> AsyncBufRead for BufReader<R> {
 }
 
 impl<R: AsyncRead + fmt::Debug> fmt::Debug for BufReader<R> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("BufReader")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufReader")
             .field("reader", &self.inner)
             .field("buffer", &format_args!("{}/{}", self.cap - self.pos, self.buf.len()))
             .finish()

--- a/futures-util/src/io/buf_writer.rs
+++ b/futures-util/src/io/buf_writer.rs
@@ -157,8 +157,8 @@ impl<W: AsyncWrite> AsyncWrite for BufWriter<W> {
 }
 
 impl<W: AsyncWrite + fmt::Debug> fmt::Debug for BufWriter<W> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("BufWriter")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufWriter")
             .field("writer", &self.inner)
             .field("buffer", &format_args!("{}/{}", self.buf.len(), self.buf.capacity()))
             .field("written", &self.written)

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -199,16 +199,16 @@ impl<T> Drop for Inner<T> {
 pub struct ReuniteError<T>(pub BiLock<T>, pub BiLock<T>);
 
 impl<T> fmt::Debug for ReuniteError<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_tuple("ReuniteError")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ReuniteError")
             .field(&"...")
             .finish()
     }
 }
 
 impl<T> fmt::Display for ReuniteError<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "tried to reunite two BiLocks that don't form a pair")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "tried to reunite two BiLocks that don't form a pair")
     }
 }
 

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -31,8 +31,8 @@ where
     St: Stream + fmt::Debug,
     St::Item: Future,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("BufferUnordered")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufferUnordered")
             .field("stream", &self.stream)
             .field("in_progress_queue", &self.in_progress_queue)
             .field("max", &self.max)

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -30,8 +30,8 @@ where
     St: Stream + fmt::Debug,
     St::Item: Future,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Buffered")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Buffered")
             .field("stream", &self.stream)
             .field("in_progress_queue", &self.in_progress_queue)
             .field("max", &self.max)

--- a/futures-util/src/stream/concat.rs
+++ b/futures-util/src/stream/concat.rs
@@ -1,4 +1,3 @@
-use core::fmt::{Debug, Formatter, Result as FmtResult};
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
@@ -6,6 +5,7 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`concat`](super::StreamExt::concat) method.
+#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Concat<St: Stream> {
     stream: St,
@@ -27,17 +27,6 @@ where St: Stream,
             stream,
             accum: None,
         }
-    }
-}
-
-impl<St> Debug for Concat<St>
-where St: Stream + Debug,
-      St::Item: Debug,
-{
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> FmtResult {
-        fmt.debug_struct("Concat")
-            .field("accum", &self.accum)
-            .finish()
     }
 }
 

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -6,23 +7,31 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
-pub struct FilterMap<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future,
-{
+pub struct FilterMap<St, Fut, F> {
     stream: St,
     f: F,
     pending: Option<Fut>,
 }
 
 impl<St, Fut, F> Unpin for FilterMap<St, Fut, F>
-    where St: Stream + Unpin,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future + Unpin,
+where
+    St: Unpin,
+    Fut: Unpin,
 {}
+
+impl<St, Fut, F> fmt::Debug for FilterMap<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FilterMap")
+            .field("stream", &self.stream)
+            .field("pending", &self.pending)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> FilterMap<St, Fut, F>
     where St: Stream,

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
@@ -5,7 +6,6 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`fold`](super::StreamExt::fold) method.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Fold<St, Fut, T, F> {
     stream: St,
@@ -15,6 +15,21 @@ pub struct Fold<St, Fut, T, F> {
 }
 
 impl<St: Unpin, Fut: Unpin, T, F> Unpin for Fold<St, Fut, T, F> {}
+
+impl<St, Fut, T, F> fmt::Debug for Fold<St, Fut, T, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Fold")
+            .field("stream", &self.stream)
+            .field("accum", &self.accum)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, T, F> Fold<St, Fut, T, F>
 where St: Stream,

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
@@ -5,7 +6,6 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`for_each`](super::StreamExt::for_each) method.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ForEach<St, Fut, F> {
     stream: St,
@@ -14,10 +14,23 @@ pub struct ForEach<St, Fut, F> {
 }
 
 impl<St, Fut, F> Unpin for ForEach<St, Fut, F>
-where St: Stream + Unpin,
-      F: FnMut(St::Item) -> Fut,
-      Fut: Future<Output = ()> + Unpin,
+where
+    St: Unpin,
+    Fut: Unpin,
 {}
+
+impl<St, Fut, F> fmt::Debug for ForEach<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ForEach")
+            .field("stream", &self.stream)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> ForEach<St, Fut, F>
 where St: Stream,

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -1,4 +1,5 @@
 use crate::stream::{FuturesUnordered, StreamExt};
+use core::fmt;
 use core::pin::Pin;
 use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};
@@ -8,7 +9,6 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`for_each_concurrent`](super::StreamExt::for_each_concurrent)
 /// method.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ForEachConcurrent<St, Fut, F> {
     stream: Option<St>,
@@ -21,6 +21,20 @@ impl<St, Fut, F> Unpin for ForEachConcurrent<St, Fut, F>
 where St: Unpin,
       Fut: Unpin,
 {}
+
+impl<St, Fut, F> fmt::Debug for ForEachConcurrent<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ForEachConcurrent")
+            .field("stream", &self.stream)
+            .field("futures", &self.futures)
+            .field("limit", &self.limit)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> ForEachConcurrent<St, Fut, F>
 where St: Stream,

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -184,8 +184,8 @@ impl<Fut: Future> Stream for FuturesOrdered<Fut> {
 }
 
 impl<Fut: Future> Debug for FuturesOrdered<Fut> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "FuturesOrdered {{ ... }}")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FuturesOrdered {{ ... }}")
     }
 }
 

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -430,8 +430,8 @@ impl<Fut: Future> Stream for FuturesUnordered<Fut> {
 }
 
 impl<Fut> Debug for FuturesUnordered<Fut> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "FuturesUnordered {{ ... }}")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FuturesUnordered {{ ... }}")
     }
 }
 

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -5,14 +6,24 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`inspect`](super::StreamExt::inspect) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
-pub struct Inspect<St, F> where St: Stream {
+pub struct Inspect<St, F> {
     stream: St,
     f: F,
 }
 
-impl<St: Stream + Unpin, F> Unpin for Inspect<St, F> {}
+impl<St: Unpin, F> Unpin for Inspect<St, F> {}
+
+impl<St, F> fmt::Debug for Inspect<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Inspect")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
 
 impl<St, F> Inspect<St, F>
     where St: Stream,

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -5,7 +6,6 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`map`](super::StreamExt::map) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Map<St, F> {
     stream: St,
@@ -13,6 +13,17 @@ pub struct Map<St, F> {
 }
 
 impl<St: Unpin, F> Unpin for Map<St, F> {}
+
+impl<St, F> fmt::Debug for Map<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Map")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
 
 impl<St, T, F> Map<St, F>
     where St: Stream,

--- a/futures-util/src/stream/poll_fn.rs
+++ b/futures-util/src/stream/poll_fn.rs
@@ -1,17 +1,23 @@
 //! Definition of the `PollFn` combinator
 
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 
 /// Stream for the [`poll_fn`] function.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct PollFn<F> {
     f: F,
 }
 
 impl<F> Unpin for PollFn<F> {}
+
+impl<F> fmt::Debug for PollFn<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PollFn").finish()
+    }
+}
 
 /// Creates a new stream wrapping a function returning `Poll<Option<T>>`.
 ///

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -27,8 +27,8 @@ pub struct SelectAll<St> {
 }
 
 impl<St: Debug> Debug for SelectAll<St> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "SelectAll {{ ... }}")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SelectAll {{ ... }}")
     }
 }
 

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -6,7 +7,6 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`skip_while`](super::StreamExt::skip_while) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct SkipWhile<St, Fut, F> where St: Stream {
     stream: St,
@@ -17,6 +17,22 @@ pub struct SkipWhile<St, Fut, F> where St: Stream {
 }
 
 impl<St: Unpin + Stream, Fut: Unpin, F> Unpin for SkipWhile<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for SkipWhile<St, Fut, F>
+where
+    St: Stream + fmt::Debug,
+    St::Item: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SkipWhile")
+            .field("stream", &self.stream)
+            .field("pending_fut", &self.pending_fut)
+            .field("pending_item", &self.pending_item)
+            .field("done_skipping", &self.done_skipping)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> SkipWhile<St, Fut, F>
     where St: Stream,

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -115,16 +115,16 @@ pub(super) fn split<S: Stream + Sink<Item>, Item>(s: S) -> (SplitSink<S, Item>, 
 pub struct ReuniteError<T: Sink<Item>, Item>(pub SplitSink<T, Item>, pub SplitStream<T>);
 
 impl<T: Sink<Item>, Item> fmt::Debug for ReuniteError<T, Item> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_tuple("ReuniteError")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ReuniteError")
             .field(&"...")
             .finish()
     }
 }
 
 impl<T: Sink<Item>, Item> fmt::Display for ReuniteError<T, Item> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "tried to reunite a SplitStream and SplitSink that don't form a pair")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "tried to reunite a SplitStream and SplitSink that don't form a pair")
     }
 }
 

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
@@ -6,7 +7,6 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`take_while`](super::StreamExt::take_while) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TakeWhile<St: Stream , Fut, F> {
     stream: St,
@@ -17,6 +17,22 @@ pub struct TakeWhile<St: Stream , Fut, F> {
 }
 
 impl<St: Unpin + Stream, Fut: Unpin, F> Unpin for TakeWhile<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for TakeWhile<St, Fut, F>
+where
+    St: Stream + fmt::Debug,
+    St::Item: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TakeWhile")
+            .field("stream", &self.stream)
+            .field("pending_fut", &self.pending_fut)
+            .field("pending_item", &self.pending_item)
+            .field("done_taking", &self.done_taking)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> TakeWhile<St, Fut, F>
     where St: Stream,

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -6,7 +7,6 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`then`](super::StreamExt::then) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Then<St, Fut, F> {
     stream: St,
@@ -15,6 +15,19 @@ pub struct Then<St, Fut, F> {
 }
 
 impl<St: Unpin, Fut: Unpin, F> Unpin for Then<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for Then<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Then")
+            .field("stream", &self.stream)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> Then<St, Fut, F>
     where St: Stream,

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -61,7 +62,6 @@ pub fn unfold<T, F, Fut, It>(init: T, f: F) -> Unfold<T, F, Fut>
 }
 
 /// Stream for the [`unfold`] function.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Unfold<T, F, Fut> {
     f: F,
@@ -70,6 +70,19 @@ pub struct Unfold<T, F, Fut> {
 }
 
 impl<T, F, Fut: Unpin> Unpin for Unfold<T, F, Fut> {}
+
+impl<T, F, Fut> fmt::Debug for Unfold<T, F, Fut>
+where
+    T: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Unfold")
+            .field("state", &self.state)
+            .field("fut", &self.fut)
+            .finish()
+    }
+}
 
 impl<T, F, Fut> Unfold<T, F, Fut> {
     unsafe_unpinned!(f: F);

--- a/futures-util/src/try_future/flatten_stream_sink.rs
+++ b/futures-util/src/try_future/flatten_stream_sink.rs
@@ -26,8 +26,8 @@ where
     Fut: TryFuture + fmt::Debug,
     Fut::Ok: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("FlattenStreamSink")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlattenStreamSink")
             .field("state", &self.state)
             .finish()
     }

--- a/futures-util/src/try_future/try_flatten_stream.rs
+++ b/futures-util/src/try_future/try_flatten_stream.rs
@@ -35,8 +35,8 @@ where
     Fut: TryFuture + fmt::Debug,
     Fut::Ok: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("TryFlattenStream")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryFlattenStream")
             .field("inner", &self.inner)
             .finish()
     }

--- a/futures-util/src/try_future/try_join.rs
+++ b/futures-util/src/try_future/try_join.rs
@@ -31,8 +31,8 @@ macro_rules! generate {
                 $Fut::Error: fmt::Debug,
             )*
         {
-            fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-                fmt.debug_struct(stringify!($Join))
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($Join))
                     .field("Fut1", &self.Fut1)
                     $(.field(stringify!($Fut), &self.$Fut))*
                     .finish()

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -75,8 +75,8 @@ where
     F::Ok: fmt::Debug,
     F::Error: fmt::Debug,
 {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("TryJoinAll")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryJoinAll")
             .field("elems", &self.elems)
             .finish()
     }

--- a/futures-util/src/try_stream/and_then.rs
+++ b/futures-util/src/try_stream/and_then.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream};
@@ -6,7 +7,6 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`and_then`](super::TryStreamExt::and_then) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct AndThen<St, Fut, F> {
     stream: St,
@@ -15,6 +15,19 @@ pub struct AndThen<St, Fut, F> {
 }
 
 impl<St: Unpin, Fut: Unpin, F> Unpin for AndThen<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for AndThen<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AndThen")
+            .field("stream", &self.stream)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> AndThen<St, Fut, F>
     where St: TryStream,

--- a/futures-util/src/try_stream/inspect_err.rs
+++ b/futures-util/src/try_stream/inspect_err.rs
@@ -1,4 +1,5 @@
 use crate::stream::inspect;
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
@@ -6,14 +7,24 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`inspect_err`](super::TryStreamExt::inspect_err) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct InspectErr<St, F> {
     stream: St,
     f: F,
 }
 
-impl<St: TryStream + Unpin, F> Unpin for InspectErr<St, F> {}
+impl<St: Unpin, F> Unpin for InspectErr<St, F> {}
+
+impl<St, F> fmt::Debug for InspectErr<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InspectErr")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
 
 impl<St, F> InspectErr<St, F>
 where

--- a/futures-util/src/try_stream/inspect_ok.rs
+++ b/futures-util/src/try_stream/inspect_ok.rs
@@ -1,4 +1,5 @@
 use crate::stream::inspect;
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
@@ -6,14 +7,24 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`inspect_ok`](super::TryStreamExt::inspect_ok) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct InspectOk<St, F> {
     stream: St,
     f: F,
 }
 
-impl<St: TryStream + Unpin, F> Unpin for InspectOk<St, F> {}
+impl<St: Unpin, F> Unpin for InspectOk<St, F> {}
+
+impl<St, F> fmt::Debug for InspectOk<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InspectOk")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
 
 impl<St, F> InspectOk<St, F>
 where

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
@@ -5,11 +6,23 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`map_err`](super::TryStreamExt::map_err) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct MapErr<St, F> {
     stream: St,
     f: F,
+}
+
+impl<St: Unpin, F> Unpin for MapErr<St, F> {}
+
+impl<St, F> fmt::Debug for MapErr<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapErr")
+            .field("stream", &self.stream)
+            .finish()
+    }
 }
 
 impl<St, F> MapErr<St, F> {
@@ -53,8 +66,6 @@ impl<St, F> MapErr<St, F> {
         self.stream
     }
 }
-
-impl<St: Unpin, F> Unpin for MapErr<St, F> {}
 
 impl<St: FusedStream, F> FusedStream for MapErr<St, F> {
     fn is_terminated(&self) -> bool {

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
@@ -5,11 +6,23 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`map_ok`](super::TryStreamExt::map_ok) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct MapOk<St, F> {
     stream: St,
     f: F,
+}
+
+impl<St: Unpin, F> Unpin for MapOk<St, F> {}
+
+impl<St, F> fmt::Debug for MapOk<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MapOk")
+            .field("stream", &self.stream)
+            .finish()
+    }
 }
 
 impl<St, F> MapOk<St, F> {
@@ -53,8 +66,6 @@ impl<St, F> MapOk<St, F> {
         self.stream
     }
 }
-
-impl<St: Unpin, F> Unpin for MapOk<St, F> {}
 
 impl<St: FusedStream, F> FusedStream for MapOk<St, F> {
     fn is_terminated(&self) -> bool {

--- a/futures-util/src/try_stream/or_else.rs
+++ b/futures-util/src/try_stream/or_else.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream};
@@ -6,7 +7,6 @@ use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`or_else`](super::TryStreamExt::or_else) method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct OrElse<St, Fut, F> {
     stream: St,
@@ -15,6 +15,19 @@ pub struct OrElse<St, Fut, F> {
 }
 
 impl<St: Unpin, Fut: Unpin, F> Unpin for OrElse<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for OrElse<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OrElse")
+            .field("stream", &self.stream)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> OrElse<St, Fut, F>
     where St: TryStream,

--- a/futures-util/src/try_stream/try_filter.rs
+++ b/futures-util/src/try_stream/try_filter.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{Stream, TryStream, FusedStream};
@@ -7,7 +8,6 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`try_filter`](super::TryStreamExt::try_filter)
 /// method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TryFilter<St, Fut, F>
     where St: TryStream
@@ -21,6 +21,21 @@ pub struct TryFilter<St, Fut, F>
 impl<St, Fut, F> Unpin for TryFilter<St, Fut, F>
     where St: TryStream + Unpin, Fut: Unpin,
 {}
+
+impl<St, Fut, F> fmt::Debug for TryFilter<St, Fut, F>
+where
+    St: TryStream + fmt::Debug,
+    St::Ok: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryFilter")
+            .field("stream", &self.stream)
+            .field("pending_fut", &self.pending_fut)
+            .field("pending_item", &self.pending_item)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> TryFilter<St, Fut, F>
     where St: TryStream

--- a/futures-util/src/try_stream/try_filter_map.rs
+++ b/futures-util/src/try_stream/try_filter_map.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{TryFuture};
 use futures_core::stream::{Stream, TryStream, FusedStream};
@@ -7,7 +8,6 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`try_filter_map`](super::TryStreamExt::try_filter_map)
 /// method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TryFilterMap<St, Fut, F> {
     stream: St,
@@ -18,6 +18,19 @@ pub struct TryFilterMap<St, Fut, F> {
 impl<St, Fut, F> Unpin for TryFilterMap<St, Fut, F>
     where St: Unpin, Fut: Unpin,
 {}
+
+impl<St, Fut, F> fmt::Debug for TryFilterMap<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryFilterMap")
+            .field("stream", &self.stream)
+            .field("pending", &self.pending)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     unsafe_pinned!(stream: St);

--- a/futures-util/src/try_stream/try_fold.rs
+++ b/futures-util/src/try_stream/try_fold.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::stream::TryStream;
@@ -5,7 +6,6 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_fold`](super::TryStreamExt::try_fold) method.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryFold<St, Fut, T, F> {
     stream: St,
@@ -15,6 +15,21 @@ pub struct TryFold<St, Fut, T, F> {
 }
 
 impl<St: Unpin, Fut: Unpin, T, F> Unpin for TryFold<St, Fut, T, F> {}
+
+impl<St, Fut, T, F> fmt::Debug for TryFold<St, Fut, T, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryFold")
+            .field("stream", &self.stream)
+            .field("accum", &self.accum)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, T, F> TryFold<St, Fut, T, F>
 where St: TryStream,

--- a/futures-util/src/try_stream/try_for_each.rs
+++ b/futures-util/src/try_stream/try_for_each.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::stream::TryStream;
@@ -5,7 +6,6 @@ use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Future for the [`try_for_each`](super::TryStreamExt::try_for_each) method.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryForEach<St, Fut, F> {
     stream: St,
@@ -14,6 +14,19 @@ pub struct TryForEach<St, Fut, F> {
 }
 
 impl<St: Unpin, Fut: Unpin, F> Unpin for TryForEach<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for TryForEach<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryForEach")
+            .field("stream", &self.stream)
+            .field("future", &self.future)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> TryForEach<St, Fut, F>
 where St: TryStream,

--- a/futures-util/src/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/try_stream/try_for_each_concurrent.rs
@@ -1,4 +1,5 @@
 use crate::stream::{FuturesUnordered, StreamExt};
+use core::fmt;
 use core::mem;
 use core::pin::Pin;
 use core::num::NonZeroUsize;
@@ -10,7 +11,6 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// Future for the
 /// [`try_for_each_concurrent`](super::TryStreamExt::try_for_each_concurrent)
 /// method.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TryForEachConcurrent<St, Fut, F> {
     stream: Option<St>,
@@ -23,6 +23,20 @@ impl<St, Fut, F> Unpin for TryForEachConcurrent<St, Fut, F>
 where St: Unpin,
       Fut: Unpin,
 {}
+
+impl<St, Fut, F> fmt::Debug for TryForEachConcurrent<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryForEachConcurrent")
+            .field("stream", &self.stream)
+            .field("futures", &self.futures)
+            .field("limit", &self.limit)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> FusedFuture for TryForEachConcurrent<St, Fut, F> {
     fn is_terminated(&self) -> bool {

--- a/futures-util/src/try_stream/try_skip_while.rs
+++ b/futures-util/src/try_stream/try_skip_while.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream};
@@ -7,7 +8,6 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`try_skip_while`](super::TryStreamExt::try_skip_while)
 /// method.
-#[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct TrySkipWhile<St, Fut, F> where St: TryStream {
     stream: St,
@@ -18,6 +18,22 @@ pub struct TrySkipWhile<St, Fut, F> where St: TryStream {
 }
 
 impl<St: Unpin + TryStream, Fut: Unpin, F> Unpin for TrySkipWhile<St, Fut, F> {}
+
+impl<St, Fut, F> fmt::Debug for TrySkipWhile<St, Fut, F>
+where
+    St: TryStream + fmt::Debug,
+    St::Ok: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrySkipWhile")
+            .field("stream", &self.stream)
+            .field("pending_fut", &self.pending_fut)
+            .field("pending_item", &self.pending_item)
+            .field("done_skipping", &self.done_skipping)
+            .finish()
+    }
+}
 
 impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     where St: TryStream,


### PR DESCRIPTION
[std `Iterator` adaptor's `Debug` implementations](https://github.com/rust-lang/rust/blob/master/src/libcore/iter/adapters/mod.rs#L556-L562) seems not to print closures.

Changes:
  * Do not to print closures in `Debug` implementations.
  * Unify variable name in Debug implementations. (`fmt` -> `f`)
  * Sort trait impls to be in the order of `impl Unpin`, `impl fmt::Debug`.

Closes #737