### PR TITLE
Replace empty enums with Never type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 sudo: false
-cache: cargo
+# TODO: https://github.com/rust-lang-nursery/futures-rs/pull/1681#issuecomment-507791279
+# cache: cargo
 
 stages:
   - name: test

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -29,6 +29,9 @@ pub mod stream;
 pub mod task;
 #[doc(hidden)] pub use self::task::Poll;
 
+pub mod never;
+#[doc(hidden)] pub use self::never::Never;
+
 #[doc(hidden)]
 pub mod core_reexport {
     #[doc(hidden)]

--- a/futures-core/src/never.rs
+++ b/futures-core/src/never.rs
@@ -1,0 +1,17 @@
+//! Definition of the `Never` type,
+//! a stand-in for the `!` type until it becomes stable.
+
+/// A type with no possible values.
+///
+/// This is used to indicate values which can never be created, such as the
+/// error type of infallible futures.
+///
+/// This type is a stable equivalent to the `!` type from `std`.
+///
+/// This is currently an alias for [`std::convert::Infallible`], but in
+/// the future it may be an alias for [`!`][never].
+/// See ["Future compatibility" section of `std::convert::Infallible`][infallible] for more.
+///
+/// [never]: https://doc.rust-lang.org/nightly/std/primitive.never.html
+/// [infallible]: https://doc.rust-lang.org/nightly/std/convert/enum.Infallible.html#future-compatibility
+pub type Never = core::convert::Infallible;

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -165,14 +165,10 @@ mod channel_impls;
 #[cfg(feature = "alloc")]
 mod if_alloc {
     use super::*;
+    use futures_core::never::Never;
 
-    /// The error type for `Vec` and `VecDequeue` when used as `Sink`s.
-    /// Values of this type can never be created.
-    #[derive(Copy, Clone, Debug)]
-    pub enum VecSinkError {}
-
-    impl<T> Sink<T> for ::alloc::vec::Vec<T> {
-        type SinkError = VecSinkError;
+    impl<T> Sink<T> for alloc::vec::Vec<T> {
+        type SinkError = Never;
 
         fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
@@ -193,8 +189,8 @@ mod if_alloc {
         }
     }
 
-    impl<T> Sink<T> for ::alloc::collections::VecDeque<T> {
-        type SinkError = VecSinkError;
+    impl<T> Sink<T> for alloc::collections::VecDeque<T> {
+        type SinkError = Never;
 
         fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
             Poll::Ready(Ok(()))
@@ -215,7 +211,7 @@ mod if_alloc {
         }
     }
 
-    impl<S: ?Sized + Sink<Item> + Unpin, Item> Sink<Item> for ::alloc::boxed::Box<S> {
+    impl<S: ?Sized + Sink<Item> + Unpin, Item> Sink<Item> for alloc::boxed::Box<S> {
         type SinkError = S::SinkError;
 
         fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
@@ -235,6 +231,3 @@ mod if_alloc {
         }
     }
 }
-
-#[cfg(feature = "alloc")]
-pub use self::if_alloc::*;

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -23,7 +23,6 @@ io-compat = ["compat", "tokio-io"]
 bench = []
 nightly = ["futures-core-preview/nightly", "futures-sink-preview/nightly"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic"]
-never-type = []
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc"]
 
 [dependencies]

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -76,9 +76,7 @@ pub use self::inspect::Inspect;
 mod unit_error;
 pub use self::unit_error::UnitError;
 
-#[cfg(feature = "never-type")]
 mod never_error;
-#[cfg(feature = "never-type")]
 pub use self::never_error::NeverError;
 
 mod either;
@@ -516,9 +514,8 @@ pub trait FutureExt: Future {
         UnitError::new(self)
     }
 
-    #[cfg(feature = "never-type")]
     /// Turns a [`Future<Output = T>`](Future) into a
-    /// [`TryFuture<Ok = T, Error = !`>](futures_core::future::TryFuture).
+    /// [`TryFuture<Ok = T, Error = Never`>](futures_core::future::TryFuture).
     fn never_error(self) -> NeverError<Self>
         where Self: Sized
     {

--- a/futures-util/src/future/never_error.rs
+++ b/futures-util/src/future/never_error.rs
@@ -1,6 +1,7 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{self, Poll};
+use futures_core::never::Never;
 use pin_utils::unsafe_pinned;
 
 /// Future for the [`never_error`](super::FutureExt::never_error) combinator.
@@ -27,9 +28,9 @@ impl<Fut: FusedFuture> FusedFuture for NeverError<Fut> {
 impl<Fut, T> Future for NeverError<Fut>
     where Fut: Future<Output = T>,
 {
-    type Output = Result<T, !>;
+    type Output = Result<T, Never>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<T, !>> {
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         self.future().poll(cx).map(Ok)
     }
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![cfg_attr(feature = "async-await", feature(async_await))]
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(feature = "never-type", feature(never_type))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
@@ -17,9 +16,6 @@
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
-
-#[cfg(all(feature = "never-type", not(feature = "nightly")))]
-compile_error!("The `never-type` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[cfg(all(feature = "async-await", not(feature = "nightly")))]
 compile_error!("The `async-await` feature requires the `nightly` feature as an explicit opt-in to unstable features");

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -1,7 +1,7 @@
-use core::fmt;
 use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::task::{Context, Poll};
+use futures_core::never::Never;
 use futures_sink::Sink;
 
 /// Sink for the [`drain`] function.
@@ -9,11 +9,6 @@ use futures_sink::Sink;
 #[must_use = "sinks do nothing unless polled"]
 pub struct Drain<T> {
     marker: PhantomData<T>,
-}
-
-/// The error type for the [`Drain`] sink.
-#[derive(Debug)]
-pub enum DrainError {
 }
 
 /// Create a sink that will just discard all items given to it.
@@ -29,14 +24,14 @@ pub enum DrainError {
 ///
 /// let mut drain = sink::drain();
 /// drain.send(5).await?;
-/// # Ok::<(), futures::sink::DrainError>(()) }).unwrap();
+/// # Ok::<(), futures::never::Never>(()) }).unwrap();
 /// ```
 pub fn drain<T>() -> Drain<T> {
     Drain { marker: PhantomData }
 }
 
 impl<T> Sink<T> for Drain<T> {
-    type SinkError = DrainError;
+    type SinkError = Never;
 
     fn poll_ready(
         self: Pin<&mut Self>,
@@ -64,23 +59,5 @@ impl<T> Sink<T> for Drain<T> {
         _cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::SinkError>> {
         Poll::Ready(Ok(()))
-    }
-}
-
-impl fmt::Display for DrainError {
-    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for DrainError {}
-
-impl DrainError {
-    /// Convert this drain error into any type
-    pub fn into_any<T>(self) -> T {
-        match self {
-        }
     }
 }

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -15,7 +15,7 @@ mod close;
 pub use self::close::Close;
 
 mod drain;
-pub use self::drain::{drain, Drain, DrainError};
+pub use self::drain::{drain, Drain};
 
 mod fanout;
 pub use self::fanout::Fanout;

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -44,7 +44,6 @@ default = ["std"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]
-never-type = ["futures-util-preview/never-type"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-util-preview/alloc"]
 
 [package.metadata.docs.rs]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -22,7 +22,6 @@
 //! completion, but *do not block* the thread running them.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(feature = "never-type", feature(never_type))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -40,9 +39,6 @@ compile_error!("The `async-await` feature requires the `nightly` feature as an e
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "nightly")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `nightly` feature as an explicit opt-in to unstable features");
-
-#[cfg(all(feature = "never-type", not(feature = "nightly")))]
-compile_error!("The `never-type` feature requires the `nightly` feature as an explicit opt-in to unstable features");
 
 #[doc(hidden)] pub use futures_core::core_reexport;
 
@@ -227,6 +223,7 @@ pub mod future {
 
         FutureExt,
         FlattenStream, Flatten, Fuse, Inspect, IntoStream, Map, Then, UnitError,
+        NeverError,
     };
 
     #[cfg(feature = "alloc")]
@@ -260,9 +257,6 @@ pub mod future {
         AndThen, ErrInto, FlattenSink, IntoFuture, MapErr, MapOk, OrElse,
         InspectOk, InspectErr, TryFlattenStream, UnwrapOrElse,
     };
-
-    #[cfg(feature = "never-type")]
-    pub use futures_util::future::NeverError;
 
     #[cfg(feature = "alloc")]
     pub use futures_util::try_future::{

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -66,6 +66,8 @@ compile_error!("The `never-type` feature requires the `nightly` feature as an ex
 
 #[doc(hidden)] pub use futures_core::task::Poll;
 
+#[doc(hidden)] pub use futures_core::never::Never;
+
 // Macro reexports
 pub use futures_core::ready; // Readiness propagation
 pub use futures_util::pin_mut;
@@ -369,7 +371,7 @@ pub mod sink {
 
     pub use futures_util::sink::{
         Close, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
-        SinkExt, Fanout, Drain, DrainError, drain,
+        SinkExt, Fanout, Drain, drain,
         WithFlatMap,
     };
 
@@ -502,6 +504,14 @@ pub mod task {
         cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
     )]
     pub use futures_util::task::AtomicWaker;
+}
+
+pub mod never {
+    //! This module contains the `Never` type.
+    //!
+    //! Values of this type can never be created and will never exist.
+
+    pub use futures_core::never::Never;
 }
 
 // `select!` re-export --------------------------------------


### PR DESCRIPTION
We have two empty enums. It should be preferable to unify this.