### PR TITLE
Revert "Ignore doc tests which "Broken MIR" ICE occurred"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,16 @@ matrix:
     - name: cargo test
       rust: nightly
       os: osx
+      before_script:
+        # TODO: https://github.com/rust-lang-nursery/futures-rs/pull/1685#issuecomment-506927847
+        - rustup update
 
     - name: cargo test
       rust: nightly
       os: linux
+      before_script:
+        # TODO: https://github.com/rust-lang-nursery/futures-rs/pull/1685#issuecomment-506927847
+        - rustup update
 
     - name: cargo build (with minimal versions)
       rust: nightly

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -420,7 +420,7 @@ pub trait StreamExt: Stream {
     /// let (tx, rx) = mpsc::unbounded();
     ///
     /// thread::spawn(move || {
-    ///     for i in (1..=5) {
+    ///     for i in 1..=5 {
     ///         tx.unbounded_send(i).unwrap();
     ///     }
     /// });

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -410,8 +410,7 @@ pub trait StreamExt: Stream {
     ///
     /// # Examples
     ///
-    // TODO: https://github.com/rust-lang-nursery/futures-rs/issues/1657
-    /// ```ignore
+    /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;
@@ -448,8 +447,7 @@ pub trait StreamExt: Stream {
     ///
     /// # Examples
     ///
-    // TODO: https://github.com/rust-lang-nursery/futures-rs/issues/1657
-    /// ```ignore
+    /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;
@@ -512,8 +510,7 @@ pub trait StreamExt: Stream {
     ///
     /// # Examples
     ///
-    // TODO: https://github.com/rust-lang-nursery/futures-rs/issues/1657
-    /// ```ignore
+    /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -456,10 +456,10 @@ pub trait TryStreamExt: TryStream {
     /// use futures::stream::TryStreamExt;
     /// use std::thread;
     ///
-    /// let (mut tx, rx) = mpsc::unbounded();
+    /// let (tx, rx) = mpsc::unbounded();
     ///
     /// thread::spawn(move || {
-    ///     for i in (1..=5) {
+    ///     for i in 1..=5 {
     ///         tx.unbounded_send(Ok(i)).unwrap();
     ///     }
     ///     tx.unbounded_send(Err(6)).unwrap();
@@ -614,7 +614,7 @@ pub trait TryStreamExt: TryStream {
     /// use futures::stream::TryStreamExt;
     /// use std::thread;
     ///
-    /// let (mut tx, rx) = mpsc::unbounded::<Result<Vec<i32>, ()>>();
+    /// let (tx, rx) = mpsc::unbounded::<Result<Vec<i32>, ()>>();
     ///
     /// thread::spawn(move || {
     ///     for i in (0..3).rev() {

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -449,8 +449,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// # Examples
     ///
-    // TODO: https://github.com/rust-lang-nursery/futures-rs/issues/1657
-    /// ```ignore
+    /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;
@@ -608,8 +607,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// # Examples
     ///
-    // TODO: https://github.com/rust-lang-nursery/futures-rs/issues/1657
-    /// ```ignore
+    /// ```
     /// #![feature(async_await)]
     /// # futures::executor::block_on(async {
     /// use futures::channel::mpsc;


### PR DESCRIPTION
This reverts commit 2d12746b684617aaca7fcc379d9643d60a21a533.

ICE has been fixed in https://github.com/rust-lang/rust/pull/61872.

Closes #1657