### PR TITLE
feat: Rename `future::empty` to `pending` and add `stream::pending`

### DIFF
--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -170,14 +170,14 @@ impl LocalPool {
     /// ```
     /// use futures::executor::LocalPool;
     /// use futures::task::LocalSpawnExt;
-    /// use futures::future::{ready, empty};
+    /// use futures::future::{ready, pending};
     ///
     /// let mut pool = LocalPool::new();
     /// let mut spawner = pool.spawner();
     ///
     /// spawner.spawn_local(ready(())).unwrap();
     /// spawner.spawn_local(ready(())).unwrap();
-    /// spawner.spawn_local(empty()).unwrap();
+    /// spawner.spawn_local(pending()).unwrap();
     ///
     /// // Run the two ready tasks and return true for them.
     /// pool.try_run_one(); // returns true after completing one of the ready futures
@@ -210,14 +210,14 @@ impl LocalPool {
     /// ```
     /// use futures::executor::LocalPool;
     /// use futures::task::LocalSpawnExt;
-    /// use futures::future::{ready, empty};
+    /// use futures::future::{ready, pending};
     ///
     /// let mut pool = LocalPool::new();
     /// let mut spawner = pool.spawner();
     ///
     /// spawner.spawn_local(ready(())).unwrap();
     /// spawner.spawn_local(ready(())).unwrap();
-    /// spawner.spawn_local(empty()).unwrap();
+    /// spawner.spawn_local(pending()).unwrap();
     ///
     /// // Runs the two ready task and returns.
     /// // The empty task remains in the pool.

--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -63,7 +63,7 @@ impl<Fut> Drop for AssertUnmoved<Fut> {
 mod tests {
     use futures_core::future::Future;
     use futures_core::task::{Context, Poll};
-    use futures_util::future::empty;
+    use futures_util::future::pending;
     use futures_util::task::noop_waker;
     use std::pin::Pin;
 
@@ -72,7 +72,7 @@ mod tests {
     #[test]
     fn dont_panic_when_not_polled() {
         // This shouldn't panic.
-        let future = AssertUnmoved::new(empty::<()>());
+        let future = AssertUnmoved::new(pending::<()>());
         drop(future);
     }
 
@@ -84,7 +84,7 @@ mod tests {
         let mut cx = Context::from_waker(&waker);
 
         // First we allocate the future on the stack and poll it.
-        let mut future = AssertUnmoved::new(empty::<()>());
+        let mut future = AssertUnmoved::new(pending::<()>());
         let pinned_future = unsafe { Pin::new_unchecked(&mut future) };
         assert_eq!(pinned_future.poll(&mut cx), Poll::Pending);
 

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -32,7 +32,7 @@ macro_rules! document_select_macro {
         /// use futures::future;
         /// use futures::select;
         /// let mut a = future::ready(4);
-        /// let mut b = future::empty::<()>();
+        /// let mut b = future::pending::<()>();
         ///
         /// let res = select! {
         ///     a_res = a => a_res + 1,
@@ -49,7 +49,7 @@ macro_rules! document_select_macro {
         /// use futures::stream::{self, StreamExt};
         /// use futures::select;
         /// let mut st = stream::iter(vec![2]).fuse();
-        /// let mut fut = future::empty::<()>();
+        /// let mut fut = future::pending::<()>();
         ///
         /// select! {
         ///     x = st.next() => assert_eq!(Some(2), x),

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -17,11 +17,11 @@ use futures_core::future::{BoxFuture, LocalBoxFuture};
 pub use futures_core::future::FusedFuture;
 
 // Primitive futures
-mod empty;
-pub use self::empty::{empty, Empty};
-
 mod lazy;
 pub use self::lazy::{lazy, Lazy};
+
+mod pending;
+pub use self::pending::{pending, Pending};
 
 mod maybe_done;
 pub use self::maybe_done::{maybe_done, MaybeDone};

--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -1,17 +1,19 @@
 use core::marker;
 use core::pin::Pin;
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 
-/// Future for the [`empty`] function.
+/// Future for the [`pending`] function.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Empty<T> {
+pub struct Pending<T> {
     _data: marker::PhantomData<T>,
 }
 
-impl<T> FusedFuture for Empty<T> {
-    fn is_terminated(&self) -> bool { false }
+impl<T> FusedFuture for Pending<T> {
+    fn is_terminated(&self) -> bool {
+        false
+    }
 }
 
 /// Creates a future which never resolves, representing a computation that never
@@ -26,16 +28,18 @@ impl<T> FusedFuture for Empty<T> {
 /// # futures::executor::block_on(async {
 /// use futures::future;
 ///
-/// let future = future::empty();
+/// let future = future::pending();
 /// let () = future.await;
 /// unreachable!();
 /// # });
 /// ```
-pub fn empty<T>() -> Empty<T> {
-    Empty { _data: marker::PhantomData }
+pub fn pending<T>() -> Pending<T> {
+    Pending {
+        _data: marker::PhantomData,
+    }
 }
 
-impl<T> Future for Empty<T> {
+impl<T> Future for Pending<T> {
     type Output = T;
 
     fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<T> {

--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 
-/// Future for the [`pending`] function.
+/// Future for the [`pending()`] function.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Pending<T> {

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -76,6 +76,9 @@ pub use self::once::{once, Once};
 mod peek;
 pub use self::peek::Peekable;
 
+mod pending;
+pub use self::pending::{pending, Pending};
+
 mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
 

--- a/futures-util/src/stream/pending.rs
+++ b/futures-util/src/stream/pending.rs
@@ -4,9 +4,7 @@ use core::pin::Pin;
 use futures_core::{Stream, Poll};
 use futures_core::task;
 
-/// A stream which never returns any elements.
-///
-/// This stream can be created with the `stream::pending` function.
+/// Stream for the [`pending()`] function.
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Pending<T> {

--- a/futures-util/src/stream/pending.rs
+++ b/futures-util/src/stream/pending.rs
@@ -1,0 +1,29 @@
+use core::marker;
+use core::pin::Pin;
+
+use futures_core::{Stream, Poll};
+use futures_core::task;
+
+/// A stream which never returns any elements.
+///
+/// This stream can be created with the `stream::pending` function.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Pending<T> {
+    _data: marker::PhantomData<T>,
+}
+
+/// Creates a stream which never returns any elements.
+///
+/// The returned stream will always return `Pending` when polled.
+pub fn pending<T>() -> Pending<T> {
+    Pending { _data: marker::PhantomData }
+}
+
+impl<T> Stream for Pending<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -211,9 +211,9 @@ pub mod future {
     pub use futures_core::future::BoxFuture;
 
     pub use futures_util::future::{
-        empty, Empty,
         lazy, Lazy,
         maybe_done, MaybeDone,
+        pending, Pending,
         poll_fn, PollFn,
         ready, ok, err, Ready,
         select, Select,

--- a/futures/tests/unfold.rs
+++ b/futures/tests/unfold.rs
@@ -1,10 +1,10 @@
 use futures::future;
 use futures::stream;
 
-use futures_test::{
-    assert_stream_pending, assert_stream_next, assert_stream_done,
-};
 use futures_test::future::FutureTestExt;
+use futures_test::{
+    assert_stream_done, assert_stream_next, assert_stream_pending,
+};
 
 #[test]
 fn unfold1() {


### PR DESCRIPTION
Fixes the inconsistency between `future::empty` and `stream::empty`.
I went with `pending` over `never` since there are already a future
called `Never` in the library.

Don't know where to put tests for this as the one place that tested `empty` seems to be disabled?

Closes #1624