### PR TITLE
Make BoxFuture and LocalBoxFuture a concrete type with #[must_use]

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -495,7 +495,7 @@ pub trait FutureExt: Future {
     fn boxed<'a>(self) -> BoxFuture<'a, Self::Output>
         where Self: Sized + Send + 'a
     {
-        Box::pin(self)
+        BoxFuture::new(Box::pin(self))
     }
 
     /// Wrap the future in a Box, pinning it.
@@ -505,7 +505,7 @@ pub trait FutureExt: Future {
     fn boxed_local<'a>(self) -> LocalBoxFuture<'a, Self::Output>
         where Self: Sized + 'a
     {
-        Box::pin(self)
+        LocalBoxFuture::new(Box::pin(self))
     }
 
     /// Turns a [`Future<Output = T>`](Future) into a


### PR DESCRIPTION
Currently BoxFuture is type alias for Pin<Box<...>>, so it can not have `#[must_wait]`. That leads to accidental mistakes, when user does not call await/poll on result of function that returns BoxFuture. We had multiple problems with that

Some notes on PR:

* I understand that for some projects this might be breaking change - if someone have hardcoded Pin<Box<...>> as a type of variable returned by .boxed, they would have to change it BoxedFuture once this diff lands, but I believe this is reasonable trade off.

* I am not sure what to do with Debug implementation for BoxFuture - ok to just suppress warning for this type?

* I don't fully understand what UnsafeFutureObj is, I mostly copied implementation from Pin<Box<...>>, but please take a look at it carefully to make sure I did not miss something.