### PR TITLE
Update rand dependency to 0.7

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -17,7 +17,7 @@ name = "futures_util"
 [features]
 std = ["alloc", "futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "slab", "memchr"]
 default = ["std"]
-async-await = ["std", "futures-select-macro-preview", "proc-macro-hack", "proc-macro-nested", "rand", "rand_core"]
+async-await = ["std", "futures-select-macro-preview", "proc-macro-hack", "proc-macro-nested", "rand"]
 compat = ["std", "futures_01"]
 io-compat = ["compat", "tokio-io"]
 bench = []
@@ -34,8 +34,7 @@ futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.16", 
 futures-select-macro-preview = { path = "../futures-select-macro", version = "=0.3.0-alpha.16", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
-rand = { version = "0.6.4", optional = true }
-rand_core = { version = ">=0.2.2, <0.4", optional = true } # See https://github.com/rust-random/rand/issues/645
+rand = { version = "0.7.0", optional = true }
 slab = { version = "0.4", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }


### PR DESCRIPTION
Hopefully, we won't need [a hack for `-Zminimal-versions`](https://github.com/rust-lang-nursery/futures-rs/pull/1425#issue-245369055).