### PR TITLE
Use `use futures::pin_mut` instead of `use pin_utils::pin_mut` in examples

### DIFF
--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -15,7 +15,7 @@ pub fn assert_is_unpin_stream<S: Stream + Unpin>(_: &mut S) {}
 /// use futures_test::{
 ///     assert_stream_pending, assert_stream_next, assert_stream_done,
 /// };
-/// use pin_utils::pin_mut;
+/// use futures::pin_mut;
 ///
 /// let stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
@@ -52,7 +52,7 @@ macro_rules! assert_stream_pending {
 /// use futures_test::{
 ///     assert_stream_pending, assert_stream_next, assert_stream_done,
 /// };
-/// use pin_utils::pin_mut;
+/// use futures::pin_mut;
 ///
 /// let stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);
@@ -95,7 +95,7 @@ macro_rules! assert_stream_next {
 /// use futures_test::{
 ///     assert_stream_pending, assert_stream_next, assert_stream_done,
 /// };
-/// use pin_utils::pin_mut;
+/// use futures::pin_mut;
 ///
 /// let stream = stream::once((async { 5 }).pending_once());
 /// pin_mut!(stream);

--- a/futures-test/src/future/mod.rs
+++ b/futures-test/src/future/mod.rs
@@ -40,7 +40,7 @@ pub trait FutureTestExt: Future {
     /// use futures::future::FutureExt;
     /// use futures_test::task::noop_context;
     /// use futures_test::future::FutureTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let future = (async { 5 }).pending_once();
     /// pin_mut!(future);
@@ -93,7 +93,7 @@ pub trait FutureTestExt: Future {
     /// use futures::future::{self, Future};
     /// use futures_test::task::noop_context;
     /// use futures_test::future::FutureTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let future = future::ready(1).interleave_pending();
     /// pin_mut!(future);

--- a/futures-test/src/io/read/mod.rs
+++ b/futures-test/src/io/read/mod.rs
@@ -18,7 +18,7 @@ pub trait AsyncReadTestExt: AsyncRead {
     /// use futures::io::AsyncRead;
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let reader = std::io::Cursor::new(&[1, 2, 3]).interleave_pending();
     /// pin_mut!(reader);
@@ -49,7 +49,7 @@ pub trait AsyncReadTestExt: AsyncRead {
     /// use futures::io::AsyncBufRead;
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let reader = std::io::Cursor::new(&[1, 2, 3]).interleave_pending();
     /// pin_mut!(reader);
@@ -84,7 +84,7 @@ pub trait AsyncReadTestExt: AsyncRead {
     /// use futures::io::AsyncRead;
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let reader = std::io::Cursor::new(&[1, 2, 3, 4, 5]).limited(2);
     /// pin_mut!(reader);

--- a/futures-test/src/io/write/mod.rs
+++ b/futures-test/src/io/write/mod.rs
@@ -18,7 +18,7 @@ pub trait AsyncWriteTestExt: AsyncWrite {
     /// use futures::io::AsyncWrite;
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncWriteTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let writer = std::io::Cursor::new([0u8; 4]).interleave_pending_write();
     /// pin_mut!(writer);
@@ -59,7 +59,7 @@ pub trait AsyncWriteTestExt: AsyncWrite {
     /// use futures::io::AsyncWrite;
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncWriteTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let writer = std::io::Cursor::new([0u8; 4]).limited_write(2);
     /// pin_mut!(writer);

--- a/futures-test/src/stream/mod.rs
+++ b/futures-test/src/stream/mod.rs
@@ -17,7 +17,7 @@ pub trait StreamTestExt: Stream {
     /// use futures::stream::{self, Stream};
     /// use futures_test::task::noop_context;
     /// use futures_test::stream::StreamTestExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let stream = stream::iter(vec![1, 2]).interleave_pending();
     /// pin_mut!(stream);

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -26,7 +26,7 @@ pub fn panic_context() -> Context<'static> {
 /// use futures::future::Future;
 /// use futures::task::Poll;
 /// use futures_test::task::noop_context;
-/// use pin_utils::pin_mut;
+/// use futures::pin_mut;
 ///
 /// let future = async { 5 };
 /// pin_mut!(future);

--- a/futures-util/src/future/fuse.rs
+++ b/futures-util/src/future/fuse.rs
@@ -33,7 +33,7 @@ impl<Fut: Future> Fuse<Fut> {
     /// use futures::future::{Fuse, FusedFuture, FutureExt};
     /// use futures::select;
     /// use futures::stream::StreamExt;
-    /// use pin_utils::pin_mut;
+    /// use futures::pin_mut;
     ///
     /// let (sender, mut stream) = mpsc::unbounded();
     ///

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -30,7 +30,7 @@ impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
 /// #![feature(async_await)]
 /// # futures::executor::block_on(async {
 /// use futures::future;
-/// use pin_utils::pin_mut;
+/// use futures::pin_mut;
 ///
 /// let future = future::maybe_done(future::ready(5));
 /// pin_mut!(future);


### PR DESCRIPTION
Related: https://github.com/rust-lang-nursery/futures-rs/pull/1686