### PR TITLE
Compat wrapper methods

### DIFF
--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -46,6 +46,18 @@ impl<T> Compat01As03<T> {
     pub fn get_ref(&self) -> &T {
         self.inner.get_ref()
     }
+
+    /// Get a mutable reference to 0.1 Future, Stream, AsyncRead or AsyncWrite object contained
+    /// within.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    /// Consume this wrapper to return the underlying 0.1 Future, Stream, AsyncRead, or
+    /// AsyncWrite object.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
 }
 
 /// Extension trait for futures 0.1 [`Future`](futures_01::future::Future)
@@ -205,6 +217,16 @@ impl<S, SinkItem> Compat01As03Sink<S, SinkItem> {
     /// Get a reference to 0.1 Sink object contained within.
     pub fn get_ref(&self) -> &S {
         self.inner.get_ref()
+    }
+
+    /// Get a mutable reference to 0.1 Sink contained within.
+    pub fn get_mut(&mut self) -> &mut S {
+        self.inner.get_mut()
+    }
+
+    /// Consume this wrapper to return the underlying 0.1 Sink.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner()
     }
 }
 

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -49,11 +49,6 @@ pub struct CompatSink<T, Item> {
 }
 
 impl<T> Compat<T> {
-    /// Returns the inner item.
-    pub fn into_inner(self) -> T {
-        self.inner
-    }
-
     /// Creates a new [`Compat`].
     ///
     /// For types which implement appropriate futures `0.3`
@@ -68,21 +63,42 @@ impl<T> Compat<T> {
     pub fn get_ref(&self) -> &T {
         &self.inner
     }
-}
 
-#[cfg(feature = "sink")]
-impl<T, Item> CompatSink<T, Item> {
+    /// Get a mutable reference to 0.3 Future, Stream, AsyncRead, or AsyncWrite object
+    /// contained within.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
     /// Returns the inner item.
     pub fn into_inner(self) -> T {
         self.inner
     }
+}
 
+#[cfg(feature = "sink")]
+impl<T, Item> CompatSink<T, Item> {
     /// Creates a new [`CompatSink`].
     pub fn new(inner: T) -> Self {
         CompatSink {
             inner,
             _phantom: PhantomData,
         }
+    }
+    
+    /// Get a reference to 0.3 Sink contained within.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to 0.3 Sink contained within.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Returns the inner item.
+    pub fn into_inner(self) -> T {
+        self.inner
     }
 }
 


### PR DESCRIPTION
Made sure the `Compat01As03` and `Compat03As01` wrappers have the following methods:
- `get_ref`
- `get_mut`
- `into_inner`

Closes #1704 