### PR TITLE
Remove channel_impl from futures-sink

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -16,10 +16,12 @@ name = "futures_channel"
 
 [features]
 std = ["futures-core-preview/std"]
+sink = ["futures-sink-preview"]
 default = ["std"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
+futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.16", default-features = false, optional = true }
 
 [dev-dependencies]
 futures-preview = { path = "../futures", version = "=0.3.0-alpha.16", default-features = true }

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -92,6 +92,8 @@ use std::sync::atomic::Ordering::SeqCst;
 use crate::mpsc::queue::Queue;
 
 mod queue;
+#[cfg(feature = "sink")]
+mod sink_impl;
 
 #[derive(Debug)]
 struct SenderInner<T> {

--- a/futures-channel/src/mpsc/sink_impl.rs
+++ b/futures-channel/src/mpsc/sink_impl.rs
@@ -1,6 +1,6 @@
-use crate::{Poll, Sink};
-use futures_channel::mpsc::{SendError, Sender, TrySendError, UnboundedSender};
-use futures_core::task::Context;
+use super::{SendError, Sender, TrySendError, UnboundedSender};
+use futures_core::task::{Context, Poll};
+use futures_sink::Sink;
 use std::pin::Pin;
 
 impl<T> Sink<T> for Sender<T> {

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -15,11 +15,10 @@ The asynchronous `Sink` trait for the futures-rs library.
 name = "futures_sink"
 
 [features]
-std = ["alloc", "futures-core-preview/std", "futures-channel-preview/std"]
+std = ["alloc", "futures-core-preview/std"]
 default = ["std"]
 nightly = ["futures-core-preview/nightly"]
 alloc = ["futures-core-preview/alloc"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -159,9 +159,6 @@ where
     }
 }
 
-#[cfg(feature = "std")]
-mod channel_impls;
-
 #[cfg(feature = "alloc")]
 mod if_alloc {
     use super::*;

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -24,7 +24,7 @@ appveyor = { repository = "rust-lang-nursery/futures-rs" }
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.16", default-features = false }
-futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false }
+futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.16", default-features = false, features = ["sink"] }
 futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.16", default-features = false }
 futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.16", default-features = false }
 futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.16", default-features = false }


### PR DESCRIPTION
Add an optional `sink` feature to futures-channel that implements `Sink`
for the mpsc channel.

Closes #1700 