### PR TITLE
Rename `Sink::SinkError` to `Sink::Error`

### DIFF
--- a/futures-channel/src/mpsc/sink_impl.rs
+++ b/futures-channel/src/mpsc/sink_impl.rs
@@ -4,26 +4,26 @@ use futures_sink::Sink;
 use std::pin::Pin;
 
 impl<T> Sink<T> for Sender<T> {
-    type SinkError = SendError;
+    type Error = SendError;
 
     fn poll_ready(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         (*self).poll_ready(cx)
     }
 
     fn start_send(
         mut self: Pin<&mut Self>,
         msg: T,
-    ) -> Result<(), Self::SinkError> {
+    ) -> Result<(), Self::Error> {
         (*self).start_send(msg)
     }
 
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         match (*self).poll_ready(cx) {
             Poll::Ready(Err(ref e)) if e.is_disconnected() => {
                 // If the receiver disconnected, we consider the sink to be flushed.
@@ -36,56 +36,56 @@ impl<T> Sink<T> for Sender<T> {
     fn poll_close(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.disconnect();
         Poll::Ready(Ok(()))
     }
 }
 
 impl<T> Sink<T> for UnboundedSender<T> {
-    type SinkError = SendError;
+    type Error = SendError;
 
     fn poll_ready(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         UnboundedSender::poll_ready(&*self, cx)
     }
 
     fn start_send(
         mut self: Pin<&mut Self>,
         msg: T,
-    ) -> Result<(), Self::SinkError> {
+    ) -> Result<(), Self::Error> {
         UnboundedSender::start_send(&mut *self, msg)
     }
 
     fn poll_flush(
         self: Pin<&mut Self>,
         _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn poll_close(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.disconnect();
         Poll::Ready(Ok(()))
     }
 }
 
 impl<T> Sink<T> for &UnboundedSender<T> {
-    type SinkError = SendError;
+    type Error = SendError;
 
     fn poll_ready(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         UnboundedSender::poll_ready(*self, cx)
     }
 
-    fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), Self::Error> {
         self.unbounded_send(msg)
             .map_err(TrySendError::into_send_error)
     }
@@ -93,14 +93,14 @@ impl<T> Sink<T> for &UnboundedSender<T> {
     fn poll_flush(
         self: Pin<&mut Self>,
         _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn poll_close(
         self: Pin<&mut Self>,
         _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.close_channel();
         Poll::Ready(Ok(()))
     }

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -121,7 +121,7 @@ where
     T: Sink03<Item> + Unpin,
 {
     type SinkItem = Item;
-    type SinkError = T::SinkError;
+    type SinkError = T::Error;
 
     fn start_send(
         &mut self,

--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -111,11 +111,11 @@ where
 impl<A, B, Item> Sink<Item> for Either<A, B>
 where
     A: Sink<Item>,
-    B: Sink<Item, SinkError = A::SinkError>,
+    B: Sink<Item, Error = A::Error>,
 {
-    type SinkError = A::SinkError;
+    type Error = A::Error;
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         unsafe {
             match self.get_unchecked_mut() {
                 Either::Left(x) => Pin::new_unchecked(x).poll_ready(cx),
@@ -124,7 +124,7 @@ where
         }
     }
 
-    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
         unsafe {
             match self.get_unchecked_mut() {
                 Either::Left(x) => Pin::new_unchecked(x).start_send(item),
@@ -133,7 +133,7 @@ where
         }
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         unsafe {
             match self.get_unchecked_mut() {
                 Either::Left(x) => Pin::new_unchecked(x).poll_flush(cx),
@@ -142,7 +142,7 @@ where
         }
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         unsafe {
             match self.get_unchecked_mut() {
                 Either::Left(x) => Pin::new_unchecked(x).poll_close(cx),

--- a/futures-util/src/io/into_sink.rs
+++ b/futures-util/src/io/into_sink.rs
@@ -64,12 +64,12 @@ impl<W: AsyncWrite, Item: AsRef<[u8]>> IntoSink<W, Item> {
 }
 
 impl<W: AsyncWrite, Item: AsRef<[u8]>> Sink<Item> for IntoSink<W, Item> {
-    type SinkError = io::Error;
+    type Error = io::Error;
 
     fn poll_ready(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>>
+    ) -> Poll<Result<(), Self::Error>>
     {
         ready!(self.as_mut().poll_flush_buffer(cx))?;
         Poll::Ready(Ok(()))
@@ -78,7 +78,7 @@ impl<W: AsyncWrite, Item: AsRef<[u8]>> Sink<Item> for IntoSink<W, Item> {
     fn start_send(
         mut self: Pin<&mut Self>,
         item: Item,
-    ) -> Result<(), Self::SinkError>
+    ) -> Result<(), Self::Error>
     {
         debug_assert!(self.as_mut().buffer().is_none());
         *self.as_mut().buffer() = Some(Block { offset: 0, bytes: item });
@@ -88,7 +88,7 @@ impl<W: AsyncWrite, Item: AsRef<[u8]>> Sink<Item> for IntoSink<W, Item> {
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>>
+    ) -> Poll<Result<(), Self::Error>>
     {
         ready!(self.as_mut().poll_flush_buffer(cx))?;
         ready!(self.as_mut().writer().poll_flush(cx))?;
@@ -98,7 +98,7 @@ impl<W: AsyncWrite, Item: AsRef<[u8]>> Sink<Item> for IntoSink<W, Item> {
     fn poll_close(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>>
+    ) -> Poll<Result<(), Self::Error>>
     {
         ready!(self.as_mut().poll_flush_buffer(cx))?;
         ready!(self.as_mut().writer().poll_close(cx))?;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -63,28 +63,28 @@ macro_rules! delegate_sink {
         fn poll_ready(
             self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Result<(), Self::SinkError>> {
+        ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
             self.$field().poll_ready(cx)
         }
 
         fn start_send(
             self: Pin<&mut Self>,
             item: $item,
-        ) -> Result<(), Self::SinkError> {
+        ) -> Result<(), Self::Error> {
             self.$field().start_send(item)
         }
 
         fn poll_flush(
             self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Result<(), Self::SinkError>> {
+        ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
             self.$field().poll_flush(cx)
         }
 
         fn poll_close(
             self: Pin<&mut Self>,
             cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Result<(), Self::SinkError>> {
+        ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
             self.$field().poll_close(cx)
         }
     }

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -25,7 +25,7 @@ impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Close<'a, Si, Item> {
 }
 
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Close<'_, Si, Item> {
-    type Output = Result<(), Si::SinkError>;
+    type Output = Result<(), Si::Error>;
 
     fn poll(
         mut self: Pin<&mut Self>,

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -31,33 +31,33 @@ pub fn drain<T>() -> Drain<T> {
 }
 
 impl<T> Sink<T> for Drain<T> {
-    type SinkError = Never;
+    type Error = Never;
 
     fn poll_ready(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn start_send(
         self: Pin<&mut Self>,
         _item: T,
-    ) -> Result<(), Self::SinkError> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
     fn poll_flush(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn poll_close(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 }

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -9,14 +9,14 @@ use pin_utils::unsafe_pinned;
 #[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct SinkErrInto<Si: Sink<Item>, Item, E> {
-    sink: SinkMapErr<Si, fn(Si::SinkError) -> E>,
+    sink: SinkMapErr<Si, fn(Si::Error) -> E>,
 }
 
 impl<Si, E, Item> SinkErrInto<Si, Item, E>
     where Si: Sink<Item>,
-          Si::SinkError: Into<E>,
+          Si::Error: Into<E>,
 {
-    unsafe_pinned!(sink: SinkMapErr<Si, fn(Si::SinkError) -> E>);
+    unsafe_pinned!(sink: SinkMapErr<Si, fn(Si::Error) -> E>);
 
     pub(super) fn new(sink: Si) -> Self {
         SinkErrInto {
@@ -50,16 +50,16 @@ impl<Si, E, Item> SinkErrInto<Si, Item, E>
 
 impl<Si, Item, E> Sink<Item> for SinkErrInto<Si, Item, E>
     where Si: Sink<Item>,
-          Si::SinkError: Into<E>,
+          Si::Error: Into<E>,
 {
-    type SinkError = E;
+    type Error = E;
 
     delegate_sink!(sink, Item);
 }
 
 impl<S, Item, E> Stream for SinkErrInto<S, Item, E>
     where S: Sink<Item> + Stream,
-          S::SinkError: Into<E>
+          S::Error: Into<E>
 {
     type Item = S::Item;
 

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -61,14 +61,14 @@ impl<Si1: Debug, Si2: Debug> Debug for Fanout<Si1, Si2> {
 impl<Si1, Si2, Item> Sink<Item> for Fanout<Si1, Si2>
     where Si1: Sink<Item>,
           Item: Clone,
-          Si2: Sink<Item, SinkError=Si1::SinkError>
+          Si2: Sink<Item, Error=Si1::Error>
 {
-    type SinkError = Si1::SinkError;
+    type Error = Si1::Error;
 
     fn poll_ready(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         let sink1_ready = self.as_mut().sink1().poll_ready(cx)?.is_ready();
         let sink2_ready = self.as_mut().sink2().poll_ready(cx)?.is_ready();
         let ready = sink1_ready && sink2_ready;
@@ -78,7 +78,7 @@ impl<Si1, Si2, Item> Sink<Item> for Fanout<Si1, Si2>
     fn start_send(
         mut self: Pin<&mut Self>,
         item: Item,
-    ) -> Result<(), Self::SinkError> {
+    ) -> Result<(), Self::Error> {
         self.as_mut().sink1().start_send(item.clone())?;
         self.as_mut().sink2().start_send(item)?;
         Ok(())
@@ -87,7 +87,7 @@ impl<Si1, Si2, Item> Sink<Item> for Fanout<Si1, Si2>
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         let sink1_ready = self.as_mut().sink1().poll_flush(cx)?.is_ready();
         let sink2_ready = self.as_mut().sink2().poll_flush(cx)?.is_ready();
         let ready = sink1_ready && sink2_ready;
@@ -97,7 +97,7 @@ impl<Si1, Si2, Item> Sink<Item> for Fanout<Si1, Si2>
     fn poll_close(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         let sink1_ready = self.as_mut().sink1().poll_close(cx)?.is_ready();
         let sink2_ready = self.as_mut().sink2().poll_close(cx)?.is_ready();
         let ready = sink1_ready && sink2_ready;

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -31,7 +31,7 @@ impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Flush<'a, Si, Item> {
 }
 
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Flush<'_, Si, Item> {
-    type Output = Result<(), Si::SinkError>;
+    type Output = Result<(), Si::Error>;
 
     fn poll(
         mut self: Pin<&mut Self>,

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -52,35 +52,35 @@ impl<Si, F> SinkMapErr<Si, F> {
 
 impl<Si, F, E, Item> Sink<Item> for SinkMapErr<Si, F>
     where Si: Sink<Item>,
-          F: FnOnce(Si::SinkError) -> E,
+          F: FnOnce(Si::Error) -> E,
 {
-    type SinkError = E;
+    type Error = E;
 
     fn poll_ready(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.as_mut().sink().poll_ready(cx).map_err(|e| self.as_mut().take_f()(e))
     }
 
     fn start_send(
         mut self: Pin<&mut Self>,
         item: Item,
-    ) -> Result<(), Self::SinkError> {
+    ) -> Result<(), Self::Error> {
         self.as_mut().sink().start_send(item).map_err(|e| self.as_mut().take_f()(e))
     }
 
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.as_mut().sink().poll_flush(cx).map_err(|e| self.as_mut().take_f()(e))
     }
 
     fn poll_close(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.as_mut().sink().poll_close(cx).map_err(|e| self.as_mut().take_f()(e))
     }
 }

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -65,7 +65,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     fn with<U, Fut, F, E>(self, f: F) -> With<Self, Item, U, Fut, F>
         where F: FnMut(U) -> Fut,
               Fut: Future<Output = Result<Item, E>>,
-              E: From<Self::SinkError>,
+              E: From<Self::Error>,
               Self: Sized
     {
         With::new(self, f)
@@ -107,7 +107,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// ```
     fn with_flat_map<U, St, F>(self, f: F) -> WithFlatMap<Self, Item, U, St, F>
         where F: FnMut(U) -> St,
-              St: Stream<Item = Result<Item, Self::SinkError>>,
+              St: Stream<Item = Result<Item, Self::Error>>,
               Self: Sized
     {
         WithFlatMap::new(self, f)
@@ -129,7 +129,7 @@ pub trait SinkExt<Item>: Sink<Item> {
 
     /// Transforms the error returned by the sink.
     fn sink_map_err<E, F>(self, f: F) -> SinkMapErr<Self, F>
-        where F: FnOnce(Self::SinkError) -> E,
+        where F: FnOnce(Self::Error) -> E,
               Self: Sized,
     {
         SinkMapErr::new(self, f)
@@ -140,7 +140,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// If wanting to map errors of a `Sink + Stream`, use `.sink_err_into().err_into()`.
     fn sink_err_into<E>(self) -> err_into::SinkErrInto<Self, Item, E>
         where Self: Sized,
-              Self::SinkError: Into<E>,
+              Self::Error: Into<E>,
     {
         SinkErrInto::new(self)
     }
@@ -179,7 +179,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     fn fanout<Si>(self, other: Si) -> Fanout<Self, Si>
         where Self: Sized,
               Item: Clone,
-              Si: Sink<Item, SinkError=Self::SinkError>
+              Si: Sink<Item, Error=Self::Error>
     {
         Fanout::new(self, other)
     }
@@ -233,7 +233,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// This can be used in combination with the `right_sink` method to write `if`
     /// statements that evaluate to different streams in different branches.
     fn left_sink<Si2>(self) -> Either<Self, Si2>
-        where Si2: Sink<Item, SinkError = Self::SinkError>,
+        where Si2: Sink<Item, Error = Self::Error>,
               Self: Sized
     {
         Either::Left(self)
@@ -245,7 +245,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// This can be used in combination with the `left_sink` method to write `if`
     /// statements that evaluate to different streams in different branches.
     fn right_sink<Si1>(self) -> Either<Si1, Self>
-        where Si1: Sink<Item, SinkError = Self::SinkError>,
+        where Si1: Sink<Item, Error = Self::Error>,
               Self: Sized
     {
         Either::Right(self)

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -24,7 +24,7 @@ impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Send<'a, Si, Item> {
 }
 
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Send<'_, Si, Item> {
-    type Output = Result<(), Si::SinkError>;
+    type Output = Result<(), Si::Error>;
 
     fn poll(
         mut self: Pin<&mut Self>,

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -45,7 +45,7 @@ where
         &mut self,
         cx: &mut Context<'_>,
         item: St::Item,
-    ) -> Poll<Result<(), Si::SinkError>> {
+    ) -> Poll<Result<(), Si::Error>> {
         debug_assert!(self.buffered.is_none());
         match Pin::new(&mut self.sink).poll_ready(cx)? {
             Poll::Ready(()) => {
@@ -64,7 +64,7 @@ where
     Si: Sink<St::Item> + Unpin + ?Sized,
     St: Stream + Unpin + ?Sized,
 {
-    type Output = Result<(), Si::SinkError>;
+    type Output = Result<(), Si::Error>;
 
     fn poll(
         mut self: Pin<&mut Self>,

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -144,7 +144,7 @@ where
     S: Stream + Sink<Item>,
     S::Item: Future,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -129,7 +129,7 @@ where
     S: Stream + Sink<Item>,
     S::Item: Future,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -111,7 +111,7 @@ impl<S, Item> Sink<Item> for Chunks<S>
 where
     S: Stream + Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/enumerate.rs
+++ b/futures-util/src/stream/enumerate.rs
@@ -87,7 +87,7 @@ impl<S, Item> Sink<Item> for Enumerate<S>
 where
     S: Stream + Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/filter.rs
+++ b/futures-util/src/stream/filter.rs
@@ -139,7 +139,7 @@ impl<S, Fut, F, Item> Sink<Item> for Filter<S, Fut, F>
           F: FnMut(&S::Item) -> Fut,
           Fut: Future<Output = bool>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -125,7 +125,7 @@ impl<S, Fut, F, Item> Sink<Item> for FilterMap<S, Fut, F>
           F: FnMut(S::Item) -> Fut,
           Fut: Future,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -101,7 +101,7 @@ impl<S, Item> Sink<Item> for Flatten<S>
     where S: Stream + Sink<Item>,
           S::Item: Stream,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -19,10 +19,10 @@ pub struct Forward<St: TryStream, Si: Sink<St::Ok>> {
 
 impl<St: TryStream + Unpin, Si: Sink<St::Ok> + Unpin> Unpin for Forward<St, Si> {}
 
-impl<St, Si> Forward<St, Si>
+impl<St, Si, E> Forward<St, Si>
 where
-    Si: Sink<St::Ok, SinkError = St::Error>,
-    St: TryStream + Stream,
+    Si: Sink<St::Ok, Error = E>,
+    St: TryStream<Error = E> + Stream,
 {
     unsafe_pinned!(sink: Option<Si>);
     unsafe_pinned!(stream: Fuse<St>);
@@ -40,7 +40,7 @@ where
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         item: St::Ok,
-    ) -> Poll<Result<(), Si::SinkError>> {
+    ) -> Poll<Result<(), E>> {
         debug_assert!(self.buffered_item.is_none());
         {
             let mut sink = self.as_mut().sink().as_pin_mut().unwrap();
@@ -61,10 +61,10 @@ impl<St: TryStream, Si: Sink<St::Ok> + Unpin> FusedFuture for Forward<St, Si> {
 
 impl<St, Si, Item, E> Future for Forward<St, Si>
 where
-    Si: Sink<Item, SinkError = E>,
+    Si: Sink<Item, Error = E>,
     St: Stream<Item = Result<Item, E>>,
 {
-    type Output = Result<(), Si::SinkError>;
+    type Output = Result<(), E>;
 
     fn poll(
         mut self: Pin<&mut Self>,

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -91,7 +91,7 @@ impl<S: Stream> Stream for Fuse<S> {
 
 // Forwarding impl of Sink from the underlying stream
 impl<S: Stream + Sink<Item>, Item> Sink<Item> for Fuse<S> {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -104,7 +104,7 @@ impl<S, F, Item> Sink<Item> for Inspect<S, F>
     where S: Stream + Sink<Item>,
           F: FnMut(&S::Item),
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -97,7 +97,7 @@ impl<S, F, T, Item> Sink<Item> for Map<S, F>
     where S: Stream + Sink<Item>,
           F: FnMut(S::Item) -> T,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -1073,7 +1073,7 @@ pub trait StreamExt: Stream {
     fn forward<S>(self, sink: S) -> Forward<Self, S>
     where
         S: Sink<<Self as TryStream>::Ok>,
-        Self: TryStream<Error = S::SinkError> + Sized,
+        Self: TryStream<Error = S::Error> + Sized,
     {
         Forward::new(self, sink)
     }

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -109,7 +109,7 @@ impl<S: Stream> Stream for Peekable<S> {
 impl<S, Item> Sink<Item> for Peekable<S>
     where S: Sink<Item> + Stream
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -87,7 +87,7 @@ impl<S, Item> Sink<Item> for Skip<S>
 where
     S: Stream + Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -138,7 +138,7 @@ impl<S, Fut, F, Item> Sink<Item> for SkipWhile<S, Fut, F>
           F: FnMut(&S::Item) -> Fut,
           Fut: Future<Output = bool>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -84,7 +84,7 @@ impl<St> Stream for Take<St>
 impl<S, Item> Sink<Item> for Take<S>
     where S: Stream + Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -34,17 +34,19 @@ where
     }
 }
 
-impl<St, Fut, F> TakeWhile<St, Fut, F>
-    where St: Stream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
-{
+impl<St: Stream, Fut, F> TakeWhile<St, Fut, F> {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Item>);
     unsafe_unpinned!(done_taking: bool);
+}
 
+impl<St, Fut, F> TakeWhile<St, Fut, F>
+    where St: Stream,
+          F: FnMut(&St::Item) -> Fut,
+          Fut: Future<Output = bool>,
+{
     pub(super) fn new(stream: St, f: F) -> TakeWhile<St, Fut, F> {
         TakeWhile {
             stream,
@@ -129,10 +131,8 @@ impl<St, Fut, F> Stream for TakeWhile<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 impl<S, Fut, F, Item> Sink<Item> for TakeWhile<S, Fut, F>
     where S: Stream + Sink<Item>,
-          F: FnMut(&S::Item) -> Fut,
-          Fut: Future<Output = bool>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -29,14 +29,16 @@ where
     }
 }
 
+impl<St, Fut, F> Then<St, Fut, F> {
+    unsafe_pinned!(stream: St);
+    unsafe_pinned!(future: Option<Fut>);
+    unsafe_unpinned!(f: F);
+}
+
 impl<St, Fut, F> Then<St, Fut, F>
     where St: Stream,
           F: FnMut(St::Item) -> Fut,
 {
-    unsafe_pinned!(stream: St);
-    unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(f: F);
-
     pub(super) fn new(stream: St, f: F) -> Then<St, Fut, F> {
         Then {
             stream,
@@ -112,11 +114,9 @@ impl<St, Fut, F> Stream for Then<St, Fut, F>
 
 // Forwarding impl of Sink from the underlying stream
 impl<S, Fut, F, Item> Sink<Item> for Then<S, Fut, F>
-    where S: Stream + Sink<Item>,
-          F: FnMut(S::Item) -> Fut,
-          Fut: Future,
+    where S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -54,23 +54,23 @@ where
 impl<Fut, Si, Item> Sink<Item> for FlattenSink<Fut, Si>
 where
     Fut: TryFuture<Ok = Si>,
-    Si: Sink<Item, SinkError = Fut::Error>,
+    Si: Sink<Item, Error = Fut::Error>,
 {
-    type SinkError = Fut::Error;
+    type Error = Fut::Error;
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner().poll_ready(cx)
     }
 
-    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
         self.inner().start_send(item)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner().poll_flush(cx)
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner().poll_close(cx)
     }
 }

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -95,20 +95,20 @@ pub trait TryFutureExt: TryFuture {
     /// # type E = SendError;
     ///
     /// fn make_sink_async() -> impl Future<Output = Result<
-    ///     impl Sink<T, SinkError = E>,
+    ///     impl Sink<T, Error = E>,
     ///     E,
     /// >> { // ... }
     /// # let (tx, _rx) = mpsc::unbounded::<i32>();
     /// # futures::future::ready(Ok(tx))
     /// # }
-    /// fn take_sink(sink: impl Sink<T, SinkError = E>) { /* ... */ }
+    /// fn take_sink(sink: impl Sink<T, Error = E>) { /* ... */ }
     ///
     /// let fut = make_sink_async();
     /// take_sink(fut.flatten_sink())
     /// ```
     fn flatten_sink<Item>(self) -> FlattenSink<Self, Self::Ok>
     where
-        Self::Ok: Sink<Item, SinkError = Self::Error>,
+        Self::Ok: Sink<Item, Error = Self::Error>,
         Self: Sized,
     {
         FlattenSink::new(self)

--- a/futures-util/src/try_future/try_flatten_stream.rs
+++ b/futures-util/src/try_future/try_flatten_stream.rs
@@ -67,23 +67,23 @@ where
 impl<Fut, Item> Sink<Item> for TryFlattenStream<Fut>
 where
     Fut: TryFuture,
-    Fut::Ok: TryStream<Error = Fut::Error> + Sink<Item, SinkError = Fut::Error>,
+    Fut::Ok: TryStream<Error = Fut::Error> + Sink<Item, Error = Fut::Error>,
 {
-    type SinkError = Fut::Error;
+    type Error = Fut::Error;
 
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner().poll_ready(cx)
     }
 
-    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
         self.inner().start_send(item)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner().poll_flush(cx)
     }
 
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner().poll_close(cx)
     }
 }

--- a/futures-util/src/try_stream/err_into.rs
+++ b/futures-util/src/try_stream/err_into.rs
@@ -80,10 +80,9 @@ where
 // Forwarding impl of Sink from the underlying stream
 impl<S, E, Item> Sink<Item> for ErrInto<S, E>
 where
-    S: TryStream + Sink<Item>,
-    S::Error: Into<E>,
+    S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/inspect_err.rs
+++ b/futures-util/src/try_stream/inspect_err.rs
@@ -26,14 +26,16 @@ where
     }
 }
 
+impl<St, F> InspectErr<St, F> {
+    unsafe_pinned!(stream: St);
+    unsafe_unpinned!(f: F);
+}
+
 impl<St, F> InspectErr<St, F>
 where
     St: TryStream,
     F: FnMut(&St::Error),
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-
     pub(super) fn new(stream: St, f: F) -> Self {
         Self { stream, f }
     }
@@ -98,10 +100,9 @@ where
 // Forwarding impl of Sink from the underlying stream
 impl<S, F, Item> Sink<Item> for InspectErr<S, F>
 where
-    S: TryStream + Sink<Item>,
-    F: FnMut(&S::Error),
+    S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/inspect_ok.rs
+++ b/futures-util/src/try_stream/inspect_ok.rs
@@ -26,14 +26,16 @@ where
     }
 }
 
+impl<St, F> InspectOk<St, F> {
+    unsafe_pinned!(stream: St);
+    unsafe_unpinned!(f: F);
+}
+
 impl<St, F> InspectOk<St, F>
 where
     St: TryStream,
     F: FnMut(&St::Ok),
 {
-    unsafe_pinned!(stream: St);
-    unsafe_unpinned!(f: F);
-
     pub(super) fn new(stream: St, f: F) -> Self {
         Self { stream, f }
     }
@@ -98,10 +100,9 @@ where
 // Forwarding impl of Sink from the underlying stream
 impl<S, F, Item> Sink<Item> for InspectOk<S, F>
 where
-    S: TryStream + Sink<Item>,
-    F: FnMut(&S::Ok),
+    S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/into_stream.rs
+++ b/futures-util/src/try_stream/into_stream.rs
@@ -71,8 +71,8 @@ impl<St: TryStream> Stream for IntoStream<St> {
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S: TryStream + Sink<Item>, Item> Sink<Item> for IntoStream<S> {
-    type SinkError = S::SinkError;
+impl<S: Sink<Item>, Item> Sink<Item> for IntoStream<S> {
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -92,12 +92,11 @@ where
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S, F, E, Item> Sink<Item> for MapErr<S, F>
+impl<S, F, Item> Sink<Item> for MapErr<S, F>
 where
-    S: TryStream + Sink<Item>,
-    F: FnMut(S::Error) -> E,
+    S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -92,12 +92,11 @@ where
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S, F, T, Item> Sink<Item> for MapOk<S, F>
+impl<S, F, Item> Sink<Item> for MapOk<S, F>
 where
-    S: TryStream + Sink<Item>,
-    F: FnMut(S::Ok) -> T,
+    S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/try_stream/try_buffer_unordered.rs
@@ -107,11 +107,11 @@ impl<St> Stream for TryBufferUnordered<St>
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S, Item> Sink<Item> for TryBufferUnordered<S>
-    where S: TryStream + Sink<Item>,
-          S::Ok: TryFuture<Error = S::Error>,
+impl<S, Item, E> Sink<Item> for TryBufferUnordered<S>
+    where S: TryStream + Sink<Item, Error = E>,
+          S::Ok: TryFuture<Error = E>,
 {
-    type SinkError = S::SinkError;
+    type Error = E;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/try_filter.rs
+++ b/futures-util/src/try_stream/try_filter.rs
@@ -131,12 +131,10 @@ impl<St, Fut, F> Stream for TryFilter<St, Fut, F>
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S, Fut, F, Item> Sink<Item> for TryFilter<S, Fut, F>
-    where S: TryStream + Sink<Item>,
-          Fut: Future<Output = bool>,
-          F: FnMut(&S::Ok) -> Fut,
+impl<S, Fut, F, Item, E> Sink<Item> for TryFilter<S, Fut, F>
+    where S: TryStream + Sink<Item, Error = E>,
 {
-    type SinkError = S::SinkError;
+    type Error = E;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/try_filter_map.rs
+++ b/futures-util/src/try_stream/try_filter_map.rs
@@ -115,12 +115,10 @@ impl<St, Fut, F, T> Stream for TryFilterMap<St, Fut, F>
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S, Fut, F, T, Item> Sink<Item> for TryFilterMap<S, Fut, F>
-    where S: TryStream + Sink<Item>,
-          Fut: TryFuture<Ok = Option<T>, Error = S::Error>,
-          F: FnMut(S::Ok) -> Fut,
+impl<S, Fut, F, Item> Sink<Item> for TryFilterMap<S, Fut, F>
+    where S: Sink<Item>,
 {
-    type SinkError = S::SinkError;
+    type Error = S::Error;
 
     delegate_sink!(stream, Item);
 }

--- a/futures-util/src/try_stream/try_skip_while.rs
+++ b/futures-util/src/try_stream/try_skip_while.rs
@@ -37,10 +37,15 @@ where
 
 impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     where St: TryStream,
+{
+    unsafe_pinned!(stream: St);
+}
+
+impl<St, Fut, F> TrySkipWhile<St, Fut, F>
+    where St: TryStream,
           F: FnMut(&St::Ok) -> Fut,
           Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
-    unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Ok>);
@@ -128,12 +133,10 @@ impl<St, Fut, F> Stream for TrySkipWhile<St, Fut, F>
 }
 
 // Forwarding impl of Sink from the underlying stream
-impl<S, Fut, F, Item> Sink<Item> for TrySkipWhile<S, Fut, F>
-    where S: TryStream + Sink<Item>,
-          F: FnMut(&S::Ok) -> Fut,
-          Fut: TryFuture<Ok = bool, Error = S::Error>,
+impl<S, Fut, F, Item, E> Sink<Item> for TrySkipWhile<S, Fut, F>
+    where S: TryStream + Sink<Item, Error = E>,
 {
-    type SinkError = S::SinkError;
+    type Error = E;
 
     delegate_sink!(stream, Item);
 }

--- a/futures/tests/future_try_flatten_stream.rs
+++ b/futures/tests/future_try_flatten_stream.rs
@@ -50,17 +50,17 @@ impl<T, E, Item> Stream for StreamSink<T, E, Item> {
 }
 
 impl<T, E, Item> Sink<Item> for StreamSink<T, E, Item> {
-    type SinkError = E;
-    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    type Error = E;
+    fn poll_ready(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         panic!()
     }
-    fn start_send(self: Pin<&mut Self>, _: Item) -> Result<(), Self::SinkError> {
+    fn start_send(self: Pin<&mut Self>, _: Item) -> Result<(), Self::Error> {
         panic!()
     }
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         panic!()
     }
-    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::SinkError>> {
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         panic!()
     }
 }

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -27,33 +27,33 @@ impl<T: Stream, U> Stream for Join<T, U> {
 }
 
 impl<T, U: Sink<Item>, Item> Sink<Item> for Join<T, U> {
-    type SinkError = U::SinkError;
+    type Error = U::Error;
 
     fn poll_ready(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.sink().poll_ready(cx)
     }
 
     fn start_send(
         self: Pin<&mut Self>,
         item: Item,
-    ) -> Result<(), Self::SinkError> {
+    ) -> Result<(), Self::Error> {
         self.sink().start_send(item)
     }
 
     fn poll_flush(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.sink().poll_flush(cx)
     }
 
     fn poll_close(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::SinkError>> {
+    ) -> Poll<Result<(), Self::Error>> {
         self.sink().poll_close(cx)
     }
 }


### PR DESCRIPTION
Closes #1707 