### PR TITLE
Update asserted size of join! futures

### DIFF
--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -175,7 +175,7 @@ fn join_size() {
         let ready2 = future::ready(0i32);
         join!(ready1, ready2)
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 44);
+    assert_eq!(::std::mem::size_of_val(&fut), 32);
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn try_join_size() {
         let ready2 = future::ready(Ok::<i32, i32>(0));
         try_join!(ready1, ready2)
     };
-    assert_eq!(::std::mem::size_of_val(&fut), 44);
+    assert_eq!(::std::mem::size_of_val(&fut), 32);
 }
 
 


### PR DESCRIPTION
Generator optimizations have made these smaller (yay!).