### PR TITLE
Revert "Workaround for broken initialization script of travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,10 @@ matrix:
     - name: cargo test
       rust: nightly
       os: osx
-      before_script:
-        # TODO: https://github.com/rust-lang-nursery/futures-rs/pull/1685#issuecomment-506927847
-        - rustup update
 
     - name: cargo test
       rust: nightly
       os: linux
-      before_script:
-        # TODO: https://github.com/rust-lang-nursery/futures-rs/pull/1685#issuecomment-506927847
-        - rustup update
 
     - name: cargo build (with minimal versions)
       rust: nightly


### PR DESCRIPTION
This reverts commit efcae3b9e61b64ac4078e7d146be165025de8d7b.

[The problem](https://github.com/rust-lang-nursery/futures-rs/pull/1685#issuecomment-506927847) seems to be fixed: https://travis-ci.com/rust-lang-nursery/futures-rs/jobs/213079852