### PR TITLE
Stream::copy_into

### DIFF
--- a/futures-util/src/stream/copy_into.rs
+++ b/futures-util/src/stream/copy_into.rs
@@ -1,5 +1,3 @@
-// https://github.com/Nemo157/futures-rs/blob/93223f5a2c8d34d1ba7bfc96479ae77f3580d399/futures-util/src/io/copy_into.rs
-
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
 use futures_core::Stream;

--- a/futures-util/src/stream/copy_into.rs
+++ b/futures-util/src/stream/copy_into.rs
@@ -1,0 +1,83 @@
+// https://github.com/Nemo157/futures-rs/blob/93223f5a2c8d34d1ba7bfc96479ae77f3580d399/futures-util/src/io/copy_into.rs
+
+use futures_core::future::Future;
+use futures_core::task::{Context, Poll};
+use futures_core::Stream;
+use futures_io::AsyncWrite;
+use std::io;
+use std::pin::Pin;
+
+/// Future for the [`copy_into`](super::StreamExt::copy_into) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct CopyInto<'a, S: Unpin, W: ?Sized + Unpin> {
+    stream: S,
+    read_done: bool,
+    writer: &'a mut W,
+    pos: usize,
+    cap: usize,
+    amt: u64,
+    buf: Option<Vec<u8>>,
+}
+
+impl<S: Unpin, W: ?Sized + Unpin> Unpin for CopyInto<'_, S, W> {}
+
+impl<'a, S: Unpin, W: ?Sized + Unpin> CopyInto<'a, S, W> {
+    pub(super) fn new(stream: S, writer: &'a mut W) -> Self {
+        CopyInto {
+            stream,
+            read_done: false,
+            writer,
+            amt: 0,
+            pos: 0,
+            cap: 0,
+            buf: None,
+        }
+    }
+}
+
+impl<S, W> Future for CopyInto<'_, S, W>
+    where S: Stream<Item = Vec<u8>> + Unpin,
+          W: AsyncWrite + ?Sized + Unpin,
+{
+    type Output = io::Result<u64>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+        loop {
+            // If our buffer is empty, then we need to read some data to
+            // continue.
+            if this.pos == this.cap && !this.read_done {
+                match ready!(Pin::new(&mut this.stream).poll_next(cx)) {
+                    Some(buf) => {
+                        this.pos = 0;
+                        this.cap = buf.len();
+                        this.buf = Some(buf);
+                    }
+                    None => this.read_done = true,
+                }
+            }
+
+            // If our buffer has some data, let's write it out!
+            if let Some(buf) = &this.buf {
+                while this.pos < this.cap {
+                    let i = ready!(Pin::new(&mut this.writer).poll_write(cx, &buf[this.pos..this.cap]))?;
+                    if i == 0 {
+                        return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
+                    } else {
+                        this.pos += i;
+                        this.amt += i as u64;
+                    }
+                }
+            }
+
+            // If we've written al the data and we've seen EOF, flush out the
+            // data and finish the transfer.
+            // done with the entire transfer.
+            if this.pos == this.cap && this.read_done {
+                ready!(Pin::new(&mut this.writer).poll_flush(cx))?;
+                return Poll::Ready(Ok(this.amt));
+            }
+        }
+    }
+}

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -32,6 +32,9 @@ pub use self::collect::Collect;
 mod concat;
 pub use self::concat::Concat;
 
+mod copy_into;
+pub use self::copy_into::CopyInto;
+
 mod empty;
 pub use self::empty::{empty, Empty};
 


### PR DESCRIPTION
Implementation of https://github.com/rust-lang-nursery/futures-rs/issues/1661. Based on an older impl of [`AsyncRead::copy_into`](https://github.com/Nemo157/futures-rs/blob/93223f5a2c8d34d1ba7bfc96479ae77f3580d399/futures-util/src/io/copy_into.rs).

Input would be quite helpful at this point, especially towards tackling the todos. Thanks heaps!

## Todos
- [ ] Implement over `item = AsRef<[u8]>` instead of `item = Vec<u8>`
- [ ] Implement for a `item = Result<T>` in addition to `item = T`
- [ ] Loosen stream constraint to `S: ?Sized + Unpin`

## Notes
I'm not quite sure how to change the impl from `Vec<u8>` to `AsRef<[u8]>`. I've tried a few things, but it's not quite working out.

Similarly I'm not sure how to best approach being able to iterate over both `Item = T` and `Item = Result<T, E>`. Should we implement this method for `TryStream` too? Or is there perhaps a way to do an automatic mapping of one type to the other?