### PR TITLE
Add check for object safety

### DIFF
--- a/futures/tests/object_safety.rs
+++ b/futures/tests/object_safety.rs
@@ -1,0 +1,49 @@
+fn assert_is_object_safe<T>() {}
+
+#[test]
+fn future() {
+    // `FutureExt`, `TryFutureExt` and `UnsafeFutureObj` are not object safe.
+    use futures::future::{FusedFuture, Future, TryFuture};
+
+    assert_is_object_safe::<&dyn Future<Output = ()>>();
+    assert_is_object_safe::<&dyn TryFuture<Ok = (), Error = ()>>();
+    assert_is_object_safe::<&dyn FusedFuture>();
+}
+
+#[test]
+fn stream() {
+    // `StreamExt` and `StreamExt` are not object safe.
+    use futures::stream::{FusedStream, Stream, TryStream};
+
+    assert_is_object_safe::<&dyn Stream<Item = ()>>();
+    assert_is_object_safe::<&dyn TryStream<Ok = (), Error = ()>>();
+    assert_is_object_safe::<&dyn FusedStream>();
+}
+
+#[test]
+fn sink() {
+    // `SinkExt` is not object safe.
+    use futures::sink::Sink;
+
+    assert_is_object_safe::<&dyn Sink<(), Error = ()>>();
+}
+
+#[test]
+fn io() {
+    // `AsyncReadExt`, `AsyncWriteExt`, `AsyncSeekExt` and `AsyncBufReadExt` are not object safe.
+    use futures::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
+
+    assert_is_object_safe::<&dyn AsyncRead>();
+    assert_is_object_safe::<&dyn AsyncWrite>();
+    assert_is_object_safe::<&dyn AsyncSeek>();
+    assert_is_object_safe::<&dyn AsyncBufRead>();
+}
+
+#[test]
+fn task() {
+    // `ArcWake`, `SpawnExt` and `LocalSpawnExt` are not object safe.
+    use futures::task::{LocalSpawn, Spawn};
+
+    assert_is_object_safe::<&dyn Spawn>();
+    assert_is_object_safe::<&dyn LocalSpawn>();
+}


### PR DESCRIPTION
I think most might be rejected at the review, but it should be nice to ensure that object safety of traits is not accidentally changed.

cc @cramertj 