### PR TITLE
Support trailing commas in macros

### DIFF
--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -3,7 +3,7 @@
 /// This macro bakes in propagation of `Pending` signals by returning early.
 #[macro_export]
 macro_rules! ready {
-    ($e:expr) => (match $e {
+    ($e:expr $(,)?) => (match $e {
         $crate::core_reexport::task::Poll::Ready(t) => t,
         $crate::core_reexport::task::Poll::Pending =>
             return $crate::core_reexport::task::Poll::Pending,

--- a/futures-util/src/async_await/join.rs
+++ b/futures-util/src/async_await/join.rs
@@ -25,7 +25,7 @@
 /// ```
 #[macro_export]
 macro_rules! join {
-    ($($fut:ident),*) => { {
+    ($($fut:ident),* $(,)?) => { {
         $(
             // Move future into a local so that it is pinned in one place and
             // is no longer accessible by the end user.
@@ -91,7 +91,7 @@ macro_rules! join {
 /// ```
 #[macro_export]
 macro_rules! try_join {
-    ($($fut:ident),*) => { {
+    ($($fut:ident),* $(,)?) => { {
         $(
             // Move future into a local so that it is pinned in one place and
             // is no longer accessible by the end user.

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -11,7 +11,7 @@ use futures_core::task::{Context, Poll};
 /// _not_ activated by default.
 #[macro_export]
 macro_rules! poll {
-    ($x:expr) => {
+    ($x:expr $(,)?) => {
         $crate::async_await::poll($x).await
     }
 }

--- a/futures/tests/macro_comma_support.rs
+++ b/futures/tests/macro_comma_support.rs
@@ -1,0 +1,44 @@
+#![feature(async_await)]
+
+#[macro_use]
+extern crate futures;
+
+use futures::{
+    executor::block_on,
+    future::{self, FutureExt},
+    task::Poll,
+};
+
+#[test]
+fn ready() {
+    block_on(future::poll_fn(|_| {
+        ready!(Poll::Ready(()),);
+        Poll::Ready(())
+    }))
+}
+
+#[test]
+fn poll() {
+    block_on(async {
+        let _ = poll!(async { () }.boxed(),);
+    })
+}
+
+#[test]
+fn join() {
+    block_on(async {
+        let future1 = async { 1 };
+        let future2 = async { 2 };
+        join!(future1, future2,);
+    })
+}
+
+#[test]
+fn try_join() {
+    block_on(async {
+        let future1 = async { 1 }.never_error();
+        let future2 = async { 2 }.never_error();
+        try_join!(future1, future2,)
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Like `std/core`'s macros, add support for trailing comma in macros.

Refs: https://github.com/rust-lang/rust/pull/48056