### PR TITLE
Add must_use attributes on Future and Stream (futures 0.1)

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -174,6 +174,7 @@ use {Poll, stream};
 /// More information about combinators can be found [on tokio.rs].
 ///
 /// [on tokio.rs]: https://tokio.rs/docs/going-deeper-futures/futures-mechanics/
+#[must_use = "futures do nothing unless polled"]
 pub trait Future {
     /// The type of value that this future will resolved with if it is
     /// successful.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -180,6 +180,7 @@ if_std! {
 /// please feel welcome to comment on [the issue][being considered]!
 ///
 /// [being considered]: https://github.com/rust-lang-nursery/futures-rs/issues/206
+#[must_use = "streams do nothing unless polled"]
 pub trait Stream {
     /// The type of item this stream will yield on success.
     type Item;


### PR DESCRIPTION
I just found out that when using futures 0.1, a function returning `impl Future<...>` is not tagged as must_use. It took me some times to figure out which future I forgot to poll.

The only downside of this pull request I see is: this requires bumping the minimal rustc version to 1.32.