### PR TITLE
Fix Unpin not implemented for Pending

### DIFF
--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -46,3 +46,6 @@ impl<T> Future for Pending<T> {
         Poll::Pending
     }
 }
+
+impl<T> Unpin for Pending<T> {
+}


### PR DESCRIPTION
Not much to say.
`Pending` is often used as a dummy, and it unfortunately can't be passed to functions that require `Unpin`.