### PR TITLE
Elide lifetimes in `Pin<&mut Self>`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
     # This is the minimum Rust version supported by `async-await` feature.
     # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
     - name: cargo +nightly build (minimum required version)
-      rust: nightly-2019-05-09
+      rust: nightly-2019-07-29
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         - cargo build --all --all-features

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ prevent it from compiling. To use futures-rs with async/await, use:
 futures-preview = { version = "=0.3.0-alpha.17", features = ["async-await", "nightly"] }
 ```
 
-The current `async-await` feature requires Rust nightly 2019-05-09 or later.
+The current `async-await` feature requires Rust nightly 2019-07-29 or later.
 
 # License
 

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -319,8 +319,8 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_fill_buf<'a>(self: Pin<&'a mut Self>, cx: &mut Context<'_>)
-            -> Poll<Result<&'a [u8]>>;
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
+            -> Poll<Result<&[u8]>>;
 
         /// Tells this buffer that `amt` bytes have been consumed from the buffer,
         /// so they should no longer be returned in calls to [`poll_read`].
@@ -597,8 +597,8 @@ mod if_std {
 
     macro_rules! deref_async_buf_read {
         () => {
-            fn poll_fill_buf<'a>(self: Pin<&'a mut Self>, cx: &mut Context<'_>)
-                -> Poll<Result<&'a [u8]>>
+            fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
+                -> Poll<Result<&[u8]>>
             {
                 Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
             }
@@ -622,8 +622,8 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncBufRead,
     {
-        fn poll_fill_buf<'a>(self: Pin<&'a mut Self>, cx: &mut Context<'_>)
-            -> Poll<Result<&'a [u8]>>
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
+            -> Poll<Result<&[u8]>>
         {
             self.get_mut().as_mut().poll_fill_buf(cx)
         }
@@ -635,8 +635,8 @@ mod if_std {
 
     macro_rules! delegate_async_buf_read_to_stdio {
         () => {
-            fn poll_fill_buf<'a>(self: Pin<&'a mut Self>, _: &mut Context<'_>)
-                -> Poll<Result<&'a [u8]>>
+            fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>)
+                -> Poll<Result<&[u8]>>
             {
                 Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
             }

--- a/futures-test/src/interleave_pending.rs
+++ b/futures-test/src/interleave_pending.rs
@@ -47,7 +47,7 @@ impl<T> InterleavePending<T> {
 
     /// Acquires a pinned mutable reference to the underlying I/O object that
     /// this adaptor is wrapping.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut T> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
         self.project().0
     }
 
@@ -56,7 +56,7 @@ impl<T> InterleavePending<T> {
         self.inner
     }
 
-    fn project<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut T>, &'a mut bool) {
+    fn project(self: Pin<&mut Self>) -> (Pin<&mut T>, &mut bool) {
         unsafe {
             let this = self.get_unchecked_mut();
             (Pin::new_unchecked(&mut this.inner), &mut this.pended)
@@ -185,10 +185,10 @@ impl<R: AsyncRead> AsyncRead for InterleavePending<R> {
 }
 
 impl<R: AsyncBufRead> AsyncBufRead for InterleavePending<R> {
-    fn poll_fill_buf<'a>(
-        self: Pin<&'a mut Self>,
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&'a [u8]>> {
+    ) -> Poll<io::Result<&[u8]>> {
         let (reader, pended) = self.project();
         if *pended {
             let next = reader.poll_fill_buf(cx);

--- a/futures-test/src/io/limited.rs
+++ b/futures-test/src/io/limited.rs
@@ -42,7 +42,7 @@ impl<Io> Limited<Io> {
 
     /// Acquires a pinned mutable reference to the underlying I/O object that
     /// this adaptor is wrapping.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Io> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Io> {
         self.io()
     }
 
@@ -89,10 +89,10 @@ impl<R: AsyncRead> AsyncRead for Limited<R> {
 }
 
 impl<R: AsyncBufRead> AsyncBufRead for Limited<R> {
-    fn poll_fill_buf<'a>(
-        self: Pin<&'a mut Self>,
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&'a [u8]>> {
+    ) -> Poll<io::Result<&[u8]>> {
         self.io().poll_fill_buf(cx)
     }
 

--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -278,10 +278,10 @@ mod if_std {
         A: AsyncBufRead,
         B: AsyncBufRead,
     {
-        fn poll_fill_buf<'a>(
-            self: Pin<&'a mut Self>,
+        fn poll_fill_buf(
+            self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-        ) -> Poll<Result<&'a [u8]>> {
+        ) -> Poll<Result<&[u8]>> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Either::Left(x) => Pin::new_unchecked(x).poll_fill_buf(cx),

--- a/futures-util/src/future/flatten_stream.rs
+++ b/futures-util/src/future/flatten_stream.rs
@@ -41,7 +41,7 @@ enum State<Fut, St> {
 }
 
 impl<Fut, St> State<Fut, St> {
-    fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> State<Pin<&'a mut Fut>, Pin<&'a mut St>> {
+    fn get_pin_mut(self: Pin<&mut Self>) -> State<Pin<&mut Fut>, Pin<&mut St>> {
         // safety: data is never moved via the resulting &mut reference
         match unsafe { self.get_unchecked_mut() } {
             // safety: the future we're re-pinning here will never be moved;

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -23,7 +23,7 @@ impl<F> ElemState<F>
 where
     F: Future,
 {
-    fn pending_pin_mut<'a>(self: Pin<&'a mut Self>) -> Option<Pin<&'a mut F>> {
+    fn pending_pin_mut(self: Pin<&mut Self>) -> Option<Pin<&mut F>> {
         // Safety: Basic enum pin projection, no drop + optionally Unpin based
         // on the type of this variant
         match unsafe { self.get_unchecked_mut() } {

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -50,7 +50,7 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// future has been completed and [`take_output`](MaybeDone::take_output)
     /// has not yet been called.
     #[inline]
-    pub fn output_mut<'a>(self: Pin<&'a mut Self>) -> Option<&'a mut Fut::Output> {
+    pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
         unsafe {
             let this = self.get_unchecked_mut();
             match this {

--- a/futures-util/src/io/allow_std.rs
+++ b/futures-util/src/io/allow_std.rs
@@ -157,8 +157,8 @@ impl<T> io::BufRead for AllowStdIo<T> where T: io::BufRead {
 }
 
 impl<T> AsyncBufRead for AllowStdIo<T> where T: io::BufRead {
-    fn poll_fill_buf<'a>(mut self: Pin<&'a mut Self>, _: &mut Context<'_>)
-        -> Poll<io::Result<&'a [u8]>>
+    fn poll_fill_buf(mut self: Pin<&mut Self>, _: &mut Context<'_>)
+        -> Poll<io::Result<&[u8]>>
     {
         let this: *mut Self = &mut *self as *mut _;
         Poll::Ready(Ok(try_with_interrupt!(unsafe { &mut *this }.0.fill_buf())))

--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -75,7 +75,7 @@ impl<R: AsyncRead> BufReader<R> {
     /// Gets a pinned mutable reference to the underlying reader.
     ///
     /// It is inadvisable to directly read from the underlying reader.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut R> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut R> {
         self.inner()
     }
 
@@ -172,10 +172,10 @@ impl<R: AsyncRead> AsyncRead for BufReader<R> {
 }
 
 impl<R: AsyncRead> AsyncBufRead for BufReader<R> {
-    fn poll_fill_buf<'a>(
-        self: Pin<&'a mut Self>,
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&'a [u8]>> {
+    ) -> Poll<io::Result<&[u8]>> {
         let Self { inner, buf, cap, pos } = unsafe { self.get_unchecked_mut() };
         let mut inner = unsafe { Pin::new_unchecked(inner) };
 

--- a/futures-util/src/io/buf_writer.rs
+++ b/futures-util/src/io/buf_writer.rs
@@ -96,7 +96,7 @@ impl<W: AsyncWrite> BufWriter<W> {
     /// Gets a pinned mutable reference to the underlying writer.
     ///
     /// It is inadvisable to directly write to the underlying writer.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut W> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
         self.inner()
     }
 

--- a/futures-util/src/io/copy_buf_into.rs
+++ b/futures-util/src/io/copy_buf_into.rs
@@ -26,7 +26,7 @@ impl<R, W: ?Sized> CopyBufInto<'_, R, W> {
 }
 
 impl<R, W: Unpin + ?Sized> CopyBufInto<'_, R, W> {
-    fn project<'b>(self: Pin<&'b mut Self>) -> (Pin<&'b mut R>, Pin<&'b mut W>, &'b mut u64) {
+    fn project(self: Pin<&mut Self>) -> (Pin<&mut R>, Pin<&mut W>, &mut u64) {
         unsafe {
             let this = self.get_unchecked_mut();
             (Pin::new_unchecked(&mut this.reader), Pin::new(&mut *this.writer), &mut this.amt)

--- a/futures-util/src/io/into_sink.rs
+++ b/futures-util/src/io/into_sink.rs
@@ -32,7 +32,7 @@ impl<W: AsyncWrite, Item: AsRef<[u8]>> IntoSink<W, Item> {
         IntoSink { writer, buffer: None }
     }
 
-    fn project<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut W>, &'a mut Option<Block<Item>>) {
+    fn project(self: Pin<&mut Self>) -> (Pin<&mut W>, &mut Option<Block<Item>>) {
         unsafe {
             let this = self.get_unchecked_mut();
             (Pin::new_unchecked(&mut this.writer), &mut this.buffer)

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -42,7 +42,7 @@ impl<Si: Sink<Item>, Item> Buffer<Si, Item> {
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Si> {
         self.sink()
     }
 

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -35,7 +35,7 @@ impl<Si, E, Item> SinkErrInto<Si, Item, E>
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Si> {
         self.sink().get_pin_mut()
     }
 

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -33,7 +33,7 @@ impl<Si1, Si2> Fanout<Si1, Si2> {
     }
 
     /// Get a pinned mutable reference to the inner sinks.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut Si1>, Pin<&'a mut Si2>)
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut Si1>, Pin<&mut Si2>)
         where Si1: Unpin, Si2: Unpin,
     {
         let Self { sink1, sink2 } = self.get_mut();

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -33,7 +33,7 @@ impl<Si, F> SinkMapErr<Si, F> {
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Si> {
         self.sink()
     }
 

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -69,9 +69,7 @@ enum State<Fut, T> {
 
 impl<Fut, T> State<Fut, T> {
     #[allow(clippy::wrong_self_convention)]
-    fn as_pin_mut<'a>(
-        self: Pin<&'a mut Self>,
-    ) -> State<Pin<&'a mut Fut>, Pin<&'a mut T>> {
+    fn as_pin_mut(self: Pin<&mut Self>) -> State<Pin<&mut Fut>, Pin<&mut T>> {
         unsafe {
             match self.get_unchecked_mut() {
                 State::Empty =>
@@ -118,7 +116,7 @@ impl<Si, Item, U, Fut, F, E> With<Si, Item, U, Fut, F>
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Si> {
         self.sink()
     }
 

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -71,7 +71,7 @@ where
     }
 
     /// Get a pinned mutable reference to the inner sink.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut Si> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut Si> {
         self.sink()
     }
 

--- a/futures-util/src/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/buffer_unordered.rs
@@ -81,7 +81,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream().get_pin_mut()
     }
 

--- a/futures-util/src/stream/buffered.rs
+++ b/futures-util/src/stream/buffered.rs
@@ -76,7 +76,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream().get_pin_mut()
     }
 

--- a/futures-util/src/stream/chunks.rs
+++ b/futures-util/src/stream/chunks.rs
@@ -58,7 +58,7 @@ impl<St: Stream> Chunks<St> where St: Stream {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream().get_pin_mut()
     }
 

--- a/futures-util/src/stream/enumerate.rs
+++ b/futures-util/src/stream/enumerate.rs
@@ -46,7 +46,7 @@ impl<St: Stream> Enumerate<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/filter.rs
+++ b/futures-util/src/stream/filter.rs
@@ -78,7 +78,7 @@ where St: Stream,
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/filter_map.rs
+++ b/futures-util/src/stream/filter_map.rs
@@ -67,7 +67,7 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -60,7 +60,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -52,7 +52,7 @@ impl<St> Fuse<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -200,7 +200,7 @@ impl<Fut> FuturesUnordered<Fut> {
     }
 
     /// Returns an iterator that allows modifying each future in the set.
-    pub fn iter_pin_mut<'a>(self: Pin<&'a mut Self>) -> IterPinMut<'a, Fut> {
+    pub fn iter_pin_mut(self: Pin<&mut Self>) -> IterPinMut<'_, Fut> {
         IterPinMut {
             task: self.head_all,
             len: self.len(),

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -57,7 +57,7 @@ impl<St, F> Inspect<St, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/into_future.rs
+++ b/futures-util/src/stream/into_future.rs
@@ -53,7 +53,7 @@ impl<St: Stream + Unpin> StreamFuture<St> {
     /// implementation of `Future::poll` consumes the underlying stream during polling
     /// in order to return it to the caller of `Future::poll` if the stream yielded
     /// an element.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Option<Pin<&'a mut St>> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Option<Pin<&mut St>> {
         Pin::new(&mut self.get_mut().stream).as_pin_mut()
     }
 

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -57,7 +57,7 @@ impl<St, T, F> Map<St, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -51,7 +51,7 @@ impl<St: Stream> Peekable<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream().get_pin_mut()
     }
 
@@ -67,10 +67,10 @@ impl<St: Stream> Peekable<St> {
     ///
     /// This method polls the underlying stream and return either a reference
     /// to the next item if the stream is ready or passes through any errors.
-    pub fn peek<'a>(
-        mut self: Pin<&'a mut Self>,
+    pub fn peek(
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<&'a St::Item>> {
+    ) -> Poll<Option<&St::Item>> {
         if self.peeked.is_some() {
             let this: &Self = self.into_ref().get_ref();
             return Poll::Ready(this.peeked.as_ref())

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -56,7 +56,7 @@ impl<St1, St2> Select<St1, St2> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut St1>, Pin<&'a mut St2>)
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut St1>, Pin<&mut St2>)
         where St1: Unpin, St2: Unpin,
     {
         let Self { stream1, stream2, .. } = self.get_mut();

--- a/futures-util/src/stream/skip.rs
+++ b/futures-util/src/stream/skip.rs
@@ -46,7 +46,7 @@ impl<St: Stream> Skip<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -76,7 +76,7 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/take.rs
+++ b/futures-util/src/stream/take.rs
@@ -46,7 +46,7 @@ impl<St: Stream> Take<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/take_while.rs
+++ b/futures-util/src/stream/take_while.rs
@@ -78,7 +78,7 @@ impl<St, Fut, F> TakeWhile<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -68,7 +68,7 @@ impl<St, Fut, F> Then<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -58,7 +58,7 @@ impl<St1: Stream, St2: Stream> Zip<St1, St2> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> (Pin<&'a mut St1>, Pin<&'a mut St2>)
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut St1>, Pin<&mut St2>)
         where St1: Unpin, St2: Unpin,
     {
         let Self { stream1, stream2, .. } = self.get_mut();

--- a/futures-util/src/try_future/flatten_stream_sink.rs
+++ b/futures-util/src/try_future/flatten_stream_sink.rs
@@ -58,7 +58,7 @@ enum State<Fut, S> {
 }
 
 impl<Fut, S> State<Fut, S> {
-    fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> State<Pin<&'a mut Fut>, Pin<&'a mut S>> {
+    fn get_pin_mut(self: Pin<&mut Self>) -> State<Pin<&mut Fut>, Pin<&mut S>> {
         // safety: data is never moved via the resulting &mut reference
         match unsafe { self.get_unchecked_mut() } {
             // safety: the future we're re-pinning here will never be moved;

--- a/futures-util/src/try_future/try_join_all.rs
+++ b/futures-util/src/try_future/try_join_all.rs
@@ -25,7 +25,7 @@ impl<F> ElemState<F>
 where
     F: TryFuture,
 {
-    fn pending_pin_mut<'a>(self: Pin<&'a mut Self>) -> Option<Pin<&'a mut F>> {
+    fn pending_pin_mut(self: Pin<&mut Self>) -> Option<Pin<&mut F>> {
         // Safety: Basic enum pin projection, no drop + optionally Unpin based
         // on the type of this variant
         match unsafe { self.get_unchecked_mut() } {

--- a/futures-util/src/try_stream/and_then.rs
+++ b/futures-util/src/try_stream/and_then.rs
@@ -65,7 +65,7 @@ impl<St, Fut, F> AndThen<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/err_into.rs
+++ b/futures-util/src/try_stream/err_into.rs
@@ -43,7 +43,7 @@ impl<St, E> ErrInto<St, E> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/inspect_err.rs
+++ b/futures-util/src/try_stream/inspect_err.rs
@@ -61,7 +61,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/inspect_ok.rs
+++ b/futures-util/src/try_stream/inspect_ok.rs
@@ -61,7 +61,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/into_async_read.rs
+++ b/futures-util/src/try_stream/into_async_read.rs
@@ -133,10 +133,10 @@ where
     St: TryStream<Error = Error> + Unpin,
     St::Ok: AsRef<[u8]>,
 {
-    fn poll_fill_buf<'a>(
-        mut self: Pin<&'a mut Self>,
+    fn poll_fill_buf(
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<&'a [u8]>> {
+    ) -> Poll<Result<&[u8]>> {
         while let ReadState::PendingChunk = self.state {
             match ready!(self.stream.try_poll_next_unpin(cx)) {
                 Some(Ok(chunk)) => {

--- a/futures-util/src/try_stream/into_stream.rs
+++ b/futures-util/src/try_stream/into_stream.rs
@@ -40,7 +40,7 @@ impl<St> IntoStream<St> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -55,7 +55,7 @@ impl<St, F> MapErr<St, F> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -55,7 +55,7 @@ impl<St, F> MapOk<St, F> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/or_else.rs
+++ b/futures-util/src/try_stream/or_else.rs
@@ -65,7 +65,7 @@ impl<St, Fut, F> OrElse<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/try_stream/try_buffer_unordered.rs
@@ -60,7 +60,7 @@ impl<St> TryBufferUnordered<St>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream().get_pin_mut().get_pin_mut()
     }
 

--- a/futures-util/src/try_stream/try_filter.rs
+++ b/futures-util/src/try_stream/try_filter.rs
@@ -75,7 +75,7 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/try_filter_map.rs
+++ b/futures-util/src/try_stream/try_filter_map.rs
@@ -62,7 +62,7 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/try_flatten.rs
+++ b/futures-util/src/try_stream/try_flatten.rs
@@ -61,7 +61,7 @@ where
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures-util/src/try_stream/try_skip_while.rs
+++ b/futures-util/src/try_stream/try_skip_while.rs
@@ -82,7 +82,7 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    pub fn get_pin_mut<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut St> {
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut St> {
         self.stream()
     }
 

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -237,8 +237,8 @@ impl AsyncRead for MaybePending<'_> {
 }
 
 impl AsyncBufRead for MaybePending<'_> {
-    fn poll_fill_buf<'a>(mut self: Pin<&'a mut Self>, _: &mut Context<'_>)
-        -> Poll<io::Result<&'a [u8]>>
+    fn poll_fill_buf(mut self: Pin<&mut Self>, _: &mut Context<'_>)
+        -> Poll<io::Result<&[u8]>>
     {
         if self.ready_fill_buf {
             self.ready_fill_buf = false;
@@ -340,8 +340,8 @@ impl AsyncRead for MaybePendingSeek<'_> {
 }
 
 impl AsyncBufRead for MaybePendingSeek<'_> {
-    fn poll_fill_buf<'a>(mut self: Pin<&'a mut Self>, cx: &mut Context<'_>)
-        -> Poll<io::Result<&'a [u8]>>
+    fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<io::Result<&[u8]>>
     {
         let this: *mut Self = &mut *self as *mut _;
         Pin::new(&mut unsafe { &mut *this }.inner).poll_fill_buf(cx)


### PR DESCRIPTION
~~Blocked on beta-backport of https://github.com/rust-lang/rust/pull/61207.~~

`cargo +stable build` should be successful because of https://github.com/rust-lang/rust/pull/62209.