### PR TITLE
Optimize future::select_all by not preserving order

### DIFF
--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -21,6 +21,9 @@ impl<Fut: Unpin> Unpin for SelectAll<Fut> {}
 /// completion the item resolved will be returned, along with the index of the
 /// future that was ready and the list of all the remaining futures.
 ///
+/// There are no guarantees provided on the order of the list with the remaining
+/// futures. They might be swapped around, reversed, or completely random.
+///
 /// This function is only available when the `std` or `alloc` feature of this
 /// library is activated, and it is activated by default.
 ///
@@ -50,7 +53,7 @@ impl<Fut: Future + Unpin> Future for SelectAll<Fut> {
         });
         match item {
             Some((idx, res)) => {
-                self.inner.remove(idx);
+                let _ = self.inner.swap_remove(idx);
                 let rest = mem::replace(&mut self.inner, Vec::new());
                 Poll::Ready((res, idx, rest))
             }

--- a/futures/tests/select_all.rs
+++ b/futures/tests/select_all.rs
@@ -1,5 +1,6 @@
 use futures::executor::block_on;
 use futures::future::{ready, select_all};
+use std::collections::HashSet;
 
 #[test]
 fn smoke() {
@@ -9,17 +10,20 @@ fn smoke() {
         ready(3),
     ];
 
+    let mut c = vec![1, 2, 3].into_iter().collect::<HashSet<_>>();
+
     let (i, idx, v) = block_on(select_all(v));
-    assert_eq!(i, 1);
+    assert!(c.remove(&i));
     assert_eq!(idx, 0);
 
     let (i, idx, v) = block_on(select_all(v));
-    assert_eq!(i, 2);
+    assert!(c.remove(&i));
     assert_eq!(idx, 0);
 
     let (i, idx, v) = block_on(select_all(v));
-    assert_eq!(i, 3);
+    assert!(c.remove(&i));
     assert_eq!(idx, 0);
 
+    assert!(c.is_empty());
     assert!(v.is_empty());
 }


### PR DESCRIPTION
This change makes use of `Vec::swap_remove` to shuffle less elements around in the backing `Vec` for `SelectAll`.

Related: #969 - which seems to have been missed when porting