### PR TITLE
Remove #[allow(clippy::cast_ptr_alignment)]

### DIFF
--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -180,7 +180,6 @@ impl Current {
 
     fn as_waker(&self) -> WakerRef<'_> {
         unsafe fn ptr_to_current<'a>(ptr: *const ()) -> &'a Current {
-            #[allow(clippy::cast_ptr_alignment)]
             &*(ptr as *const Current)
         }
         fn current_to_ptr(current: &Current) -> *const () {

--- a/futures-util/src/task/waker_ref.rs
+++ b/futures-util/src/task/waker_ref.rs
@@ -63,7 +63,6 @@ where
 {
     // This uses the same mechanism as Arc::into_raw, without needing a reference.
     // This is potentially not stable
-    #![allow(clippy::cast_ptr_alignment)]
     let ptr = &*wake as &W as *const W as *const ();
 
     // Similar to `waker_vtable`, but with a no-op `drop` function.


### PR DESCRIPTION
The issue has been fixed in https://github.com/rust-lang/rust-clippy/pull/4257.