### PR TITLE
Fix warnings on the latest nightly

### DIFF
--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -384,6 +384,7 @@ mod io {
         ///
         /// ```
         /// #![feature(async_await, impl_trait_in_bindings)]
+        /// # #![allow(incomplete_features)]
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncReadExt;
         /// use futures_util::compat::AsyncRead01CompatExt;
@@ -412,7 +413,7 @@ mod io {
         /// [`AsyncWrite`](futures_io::AsyncWrite).
         ///
         /// ```
-        /// #![feature(async_await, impl_trait_in_bindings)]
+        /// #![feature(async_await)]
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncWriteExt;
         /// use futures_util::compat::AsyncWrite01CompatExt;

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -66,8 +66,8 @@ pub struct Executor01As03<Ex> {
 }
 
 impl<Ex> Spawn03 for Executor01As03<Ex>
-where Ex: Executor01<Executor01Future>,
-      Ex: Clone + Send + 'static,
+where
+    Ex: Executor01<Executor01Future> + Clone + Send + 'static,
 {
     fn spawn_obj(
         &mut self,

--- a/futures-util/src/stream/zip.rs
+++ b/futures-util/src/stream/zip.rs
@@ -14,6 +14,7 @@ pub struct Zip<St1: Stream, St2: Stream> {
     queued2: Option<St2::Item>,
 }
 
+#[allow(clippy::type_repetition_in_bounds)] // https://github.com/rust-lang/rust-clippy/issues/4323
 impl<St1, St2> Unpin for Zip<St1, St2>
 where
     St1: Stream,


### PR DESCRIPTION
This fixes warnings due to new clippy lints added by https://github.com/rust-lang/rust-clippy/pull/3766.