### PR TITLE
Don't require a full flush before pushing next item in SendAll

### DIFF
--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -87,7 +87,7 @@ where
                     return Poll::Ready(Ok(()))
                 }
                 Poll::Pending => {
-                    ready!(Pin::new(&mut this.sink).poll_flush(cx))?;
+                    ready!(Pin::new(&mut this.sink).poll_ready(cx))?;
                     return Poll::Pending
                 }
             }


### PR DESCRIPTION
Fixes #1760 