### PR TITLE
ci: Use the latest toolchain with clippy available if clippy is unavailable on the latest nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,14 @@ matrix:
     - name: cargo clippy
       rust: nightly
       script:
-        - if rustup component add clippy-preview;
-          then
-            cargo clippy --all --all-features;
-          else
-            echo 'Skipping clippy';
+        - if ! rustup component add clippy; then
+            target=`curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/clippy`;
+            echo "'clippy' is unavailable on the toolchain 'nightly', use the toolchain 'nightly-$target' instead";
+            rustup toolchain install nightly-$target;
+            rustup default nightly-$target;
+            rustup component add clippy;
           fi
+        - cargo clippy --all --all-features
 
     - name: cargo bench
       rust: nightly


### PR DESCRIPTION
Currently, the check is done only if there is clippy in the latest nighty. This PR change it to use the latest clippy available at that time.

Refs: https://github.com/rust-lang/rustup-components-history#the-web-part