### PR TITLE
Add Future/Stream bounds to FusedFuture/FusedStream

### DIFF
--- a/futures-core/src/stream.rs
+++ b/futures-core/src/stream.rs
@@ -83,7 +83,7 @@ where
     }
 }
 
-/// A `Stream` or `TryStream` which tracks whether or not the underlying stream
+/// A stream which tracks whether or not the underlying stream
 /// should no longer be polled.
 ///
 /// `is_terminated` will return `true` if a future should no longer be polled.
@@ -91,12 +91,12 @@ where
 /// `Poll::Ready(None)`. However, `is_terminated` may also return `true` if a
 /// stream has become inactive and can no longer make progress and should be
 /// ignored or dropped rather than being polled again.
-pub trait FusedStream {
+pub trait FusedStream: Stream {
     /// Returns `true` if the stream should no longer be polled.
     fn is_terminated(&self) -> bool;
 }
 
-impl<F: ?Sized + FusedStream> FusedStream for &mut F {
+impl<F: ?Sized + FusedStream + Unpin> FusedStream for &mut F {
     fn is_terminated(&self) -> bool {
         <F as FusedStream>::is_terminated(&**self)
     }
@@ -190,7 +190,7 @@ mod if_alloc {
         }
     }
 
-    impl<S: ?Sized + FusedStream> FusedStream for Box<S> {
+    impl<S: ?Sized + FusedStream + Unpin> FusedStream for Box<S> {
         fn is_terminated(&self) -> bool {
             <S as FusedStream>::is_terminated(&**self)
         }

--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -69,7 +69,7 @@ where
 impl<A, B> FusedFuture for Either<A, B>
 where
     A: FusedFuture,
-    B: FusedFuture,
+    B: FusedFuture<Output = A::Output>,
 {
     fn is_terminated(&self) -> bool {
         match self {
@@ -99,7 +99,7 @@ where
 impl<A, B> FusedStream for Either<A, B>
 where
     A: FusedStream,
-    B: FusedStream,
+    B: FusedStream<Item = A::Item>,
 {
     fn is_terminated(&self) -> bool {
         match self {

--- a/futures-util/src/future/inspect.rs
+++ b/futures-util/src/future/inspect.rs
@@ -25,7 +25,10 @@ impl<Fut: Future, F: FnOnce(&Fut::Output)> Inspect<Fut, F> {
 
 impl<Fut: Future + Unpin, F> Unpin for Inspect<Fut, F> {}
 
-impl<Fut: Future + FusedFuture, F> FusedFuture for Inspect<Fut, F> {
+impl<Fut, F> FusedFuture for Inspect<Fut, F>
+    where Fut: FusedFuture,
+          F: FnOnce(&Fut::Output),
+{
     fn is_terminated(&self) -> bool { self.future.is_terminated() }
 }
 

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -38,11 +38,13 @@ pub fn lazy<F, R>(f: F) -> Lazy<F>
     Lazy { f: Some(f) }
 }
 
-impl<F> FusedFuture for Lazy<F> {
+impl<F, R> FusedFuture for Lazy<F>
+    where F: FnOnce(&mut Context<'_>) -> R,
+{
     fn is_terminated(&self) -> bool { self.f.is_none() }
 }
 
-impl<R, F> Future for Lazy<F>
+impl<F, R> Future for Lazy<F>
     where F: FnOnce(&mut Context<'_>) -> R,
 {
     type Output = R;

--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -23,7 +23,10 @@ impl<Fut, F> Map<Fut, F> {
 
 impl<Fut: Unpin, F> Unpin for Map<Fut, F> {}
 
-impl<Fut, F> FusedFuture for Map<Fut, F> {
+impl<Fut, F, T> FusedFuture for Map<Fut, F>
+    where Fut: Future,
+          F: FnOnce(Fut::Output) -> T,
+{
     fn is_terminated(&self) -> bool { self.f.is_none() }
 }
 

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -173,14 +173,19 @@ where
     }
 }
 
-impl<Fut: Future> FusedFuture for Shared<Fut> {
+impl<Fut> FusedFuture for Shared<Fut>
+where
+    Fut: Future,
+    Fut::Output: Clone,
+{
     fn is_terminated(&self) -> bool {
         self.inner.is_none()
     }
 }
 
-impl<Fut: Future> Future for Shared<Fut>
+impl<Fut> Future for Shared<Fut>
 where
+    Fut: Future,
     Fut::Output: Clone,
 {
     type Output = Fut::Output;

--- a/futures-util/src/future/then.rs
+++ b/futures-util/src/future/then.rs
@@ -25,7 +25,11 @@ impl<Fut1, Fut2, F> Then<Fut1, Fut2, F>
     }
 }
 
-impl<Fut1, Fut2, F> FusedFuture for Then<Fut1, Fut2, F> {
+impl<Fut1, Fut2, F> FusedFuture for Then<Fut1, Fut2, F>
+    where Fut1: Future,
+          Fut2: Future,
+          F: FnOnce(Fut1::Output) -> Fut2,
+{
     fn is_terminated(&self) -> bool { self.chain.is_terminated() }
 }
 

--- a/futures-util/src/stream/chain.rs
+++ b/futures-util/src/stream/chain.rs
@@ -27,7 +27,10 @@ where St1: Stream,
     }
 }
 
-impl<St1, St2: FusedStream> FusedStream for Chain<St1, St2> {
+impl<St1, St2> FusedStream for Chain<St1, St2>
+where St1: Stream,
+      St2: FusedStream<Item=St1::Item>,
+{
     fn is_terminated(&self) -> bool {
         self.first.is_none() && self.second.is_terminated()
     }

--- a/futures-util/src/stream/collect.rs
+++ b/futures-util/src/stream/collect.rs
@@ -31,7 +31,10 @@ impl<St: Stream, C: Default> Collect<St, C> {
     }
 }
 
-impl<St: FusedStream, C> FusedFuture for Collect<St, C> {
+impl<St, C> FusedFuture for Collect<St, C>
+where St: FusedStream,
+      C: Default + Extend<St:: Item>
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/stream/flatten.rs
+++ b/futures-util/src/stream/flatten.rs
@@ -75,7 +75,8 @@ where
 
 impl<St> FusedStream for Flatten<St>
 where
-    St: Stream + FusedStream,
+    St: FusedStream,
+    St::Item: Stream,
 {
     fn is_terminated(&self) -> bool {
         self.next.is_none() && self.stream.is_terminated()

--- a/futures-util/src/stream/fold.rs
+++ b/futures-util/src/stream/fold.rs
@@ -51,7 +51,11 @@ where St: Stream,
     }
 }
 
-impl<St, Fut, T, F> FusedFuture for Fold<St, Fut, T, F> {
+impl<St, Fut, T, F> FusedFuture for Fold<St, Fut, T, F>
+    where St: Stream,
+          F: FnMut(T, St::Item) -> Fut,
+          Fut: Future<Output = T>,
+{
     fn is_terminated(&self) -> bool {
         self.accum.is_none() && self.future.is_none()
     }

--- a/futures-util/src/stream/for_each.rs
+++ b/futures-util/src/stream/for_each.rs
@@ -50,7 +50,11 @@ where St: Stream,
     }
 }
 
-impl<St: FusedStream, Fut, F> FusedFuture for ForEach<St, Fut, F> {
+impl<St, Fut, F> FusedFuture for ForEach<St, Fut, F>
+    where St: FusedStream,
+          F: FnMut(St::Item) -> Fut,
+          Fut: Future<Output = ()>,
+{
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()
     }

--- a/futures-util/src/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/for_each_concurrent.rs
@@ -57,7 +57,11 @@ where St: Stream,
     }
 }
 
-impl<St, Fut, F> FusedFuture for ForEachConcurrent<St, Fut, F> {
+impl<St, Fut, F> FusedFuture for ForEachConcurrent<St, Fut, F>
+    where St: Stream,
+          F: FnMut(St::Item) -> Fut,
+          Fut: Future<Output = ()>,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_none() && self.futures.is_empty()
     }

--- a/futures-util/src/stream/forward.rs
+++ b/futures-util/src/stream/forward.rs
@@ -53,7 +53,11 @@ where
     }
 }
 
-impl<St: TryStream, Si: Sink<St::Ok> + Unpin> FusedFuture for Forward<St, Si> {
+impl<St, Si, Item, E> FusedFuture for Forward<St, Si>
+where
+    Si: Sink<Item, Error = E>,
+    St: Stream<Item = Result<Item, E>>,
+{
     fn is_terminated(&self) -> bool {
         self.sink.is_none()
     }

--- a/futures-util/src/stream/fuse.rs
+++ b/futures-util/src/stream/fuse.rs
@@ -65,7 +65,7 @@ impl<St> Fuse<St> {
     }
 }
 
-impl<S> FusedStream for Fuse<S> {
+impl<S: Stream> FusedStream for Fuse<S> {
     fn is_terminated(&self) -> bool {
         self.done
     }

--- a/futures-util/src/stream/inspect.rs
+++ b/futures-util/src/stream/inspect.rs
@@ -70,7 +70,10 @@ impl<St, F> Inspect<St, F>
     }
 }
 
-impl<St: Stream + FusedStream, F> FusedStream for Inspect<St, F> {
+impl<St, F> FusedStream for Inspect<St, F>
+    where St: FusedStream,
+          F: FnMut(&St::Item),
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/stream/into_future.rs
+++ b/futures-util/src/stream/into_future.rs
@@ -71,7 +71,7 @@ impl<St: Stream + Unpin> StreamFuture<St> {
     }
 }
 
-impl<St> FusedFuture for StreamFuture<St> {
+impl<St: Stream + Unpin> FusedFuture for StreamFuture<St> {
     fn is_terminated(&self) -> bool {
         self.stream.is_none()
     }

--- a/futures-util/src/stream/map.rs
+++ b/futures-util/src/stream/map.rs
@@ -70,7 +70,10 @@ impl<St, T, F> Map<St, F>
     }
 }
 
-impl<St: FusedStream, F> FusedStream for Map<St, F> {
+impl<St, F, T> FusedStream for Map<St, F>
+    where St: FusedStream,
+          F: FnMut(St::Item) -> T,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/stream/next.rs
+++ b/futures-util/src/stream/next.rs
@@ -19,7 +19,7 @@ impl<'a, St: ?Sized + Stream + Unpin> Next<'a, St> {
     }
 }
 
-impl<St: ?Sized + FusedStream> FusedFuture for Next<'_, St> {
+impl<St: ?Sized + FusedStream + Unpin> FusedFuture for Next<'_, St> {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -72,7 +72,10 @@ impl<St1, St2> Select<St1, St2> {
     }
 }
 
-impl<St1, St2> FusedStream for Select<St1, St2> {
+impl<St1, St2> FusedStream for Select<St1, St2>
+    where St1: Stream,
+          St2: Stream<Item = St1::Item>
+{
     fn is_terminated(&self) -> bool {
         self.stream1.is_terminated() && self.stream2.is_terminated()
     }

--- a/futures-util/src/stream/select_next_some.rs
+++ b/futures-util/src/stream/select_next_some.rs
@@ -1,5 +1,5 @@
 use core::pin::Pin;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::FusedStream;
 use futures_core::future::{Future, FusedFuture};
 use futures_core::task::{Context, Poll};
 use crate::stream::StreamExt;
@@ -18,13 +18,13 @@ impl<'a, St: ?Sized> SelectNextSome<'a, St> {
     }
 }
 
-impl<St: ?Sized + FusedStream> FusedFuture for SelectNextSome<'_, St> {
+impl<St: ?Sized + FusedStream + Unpin> FusedFuture for SelectNextSome<'_, St> {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }
 }
 
-impl<St: ?Sized + Stream + FusedStream + Unpin> Future for SelectNextSome<'_, St> {
+impl<St: ?Sized + FusedStream + Unpin> Future for SelectNextSome<'_, St> {
     type Output = St::Item;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/futures-util/src/stream/skip_while.rs
+++ b/futures-util/src/stream/skip_while.rs
@@ -89,7 +89,11 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     }
 }
 
-impl<St: Stream + FusedStream, Fut, F> FusedStream for SkipWhile<St, Fut, F> {
+impl<St, Fut, F> FusedStream for SkipWhile<St, Fut, F>
+    where St: FusedStream,
+          F: FnMut(&St::Item) -> Fut,
+          Fut: Future<Output = bool>,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/stream/then.rs
+++ b/futures-util/src/stream/then.rs
@@ -81,7 +81,11 @@ impl<St, Fut, F> Then<St, Fut, F>
     }
 }
 
-impl<St: FusedStream, Fut, F> FusedStream for Then<St, Fut, F> {
+impl<St, Fut, F> FusedStream for Then<St, Fut, F>
+    where St: FusedStream,
+          F: FnMut(St::Item) -> Fut,
+          Fut: Future,
+{
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()
     }

--- a/futures-util/src/try_future/err_into.rs
+++ b/futures-util/src/try_future/err_into.rs
@@ -25,7 +25,10 @@ impl<Fut, E> ErrInto<Fut, E> {
     }
 }
 
-impl<Fut: FusedFuture, E> FusedFuture for ErrInto<Fut, E> {
+impl<Fut, E> FusedFuture for ErrInto<Fut, E>
+    where Fut: TryFuture + FusedFuture,
+          Fut::Error: Into<E>,
+{
     fn is_terminated(&self) -> bool { self.future.is_terminated() }
 }
 

--- a/futures-util/src/try_future/flatten_sink.rs
+++ b/futures-util/src/try_future/flatten_sink.rs
@@ -32,7 +32,7 @@ where
 impl<Fut, S> FusedStream for FlattenSink<Fut, S>
 where
     Fut: TryFuture<Ok = S>,
-    S: FusedStream,
+    S: TryStream<Error = Fut::Error> + FusedStream,
 {
     fn is_terminated(&self) -> bool {
         self.inner.is_terminated()

--- a/futures-util/src/try_future/flatten_stream_sink.rs
+++ b/futures-util/src/try_future/flatten_stream_sink.rs
@@ -100,7 +100,7 @@ where
 impl<Fut> FusedStream for FlattenStreamSink<Fut>
 where
     Fut: TryFuture,
-    Fut::Ok: FusedStream,
+    Fut::Ok: TryStream<Error = Fut::Error> + FusedStream,
 {
     fn is_terminated(&self) -> bool {
         match &self.state {

--- a/futures-util/src/try_future/inspect_err.rs
+++ b/futures-util/src/try_future/inspect_err.rs
@@ -26,7 +26,11 @@ where
     }
 }
 
-impl<Fut: FusedFuture, F> FusedFuture for InspectErr<Fut, F> {
+impl<Fut, F> FusedFuture for InspectErr<Fut, F>
+where
+    Fut: TryFuture + FusedFuture,
+    F: FnOnce(&Fut::Error),
+{
     fn is_terminated(&self) -> bool {
         self.future.is_terminated()
     }

--- a/futures-util/src/try_future/inspect_ok.rs
+++ b/futures-util/src/try_future/inspect_ok.rs
@@ -26,7 +26,11 @@ where
     }
 }
 
-impl<Fut: FusedFuture, F> FusedFuture for InspectOk<Fut, F> {
+impl<Fut, F> FusedFuture for InspectOk<Fut, F>
+where
+    Fut: TryFuture + FusedFuture,
+    F: FnOnce(&Fut::Ok),
+{
     fn is_terminated(&self) -> bool {
         self.future.is_terminated()
     }

--- a/futures-util/src/try_future/into_future.rs
+++ b/futures-util/src/try_future/into_future.rs
@@ -19,7 +19,7 @@ impl<Fut> IntoFuture<Fut> {
     }
 }
 
-impl<Fut: FusedFuture> FusedFuture for IntoFuture<Fut> {
+impl<Fut: TryFuture + FusedFuture> FusedFuture for IntoFuture<Fut> {
     fn is_terminated(&self) -> bool { self.future.is_terminated() }
 }
 

--- a/futures-util/src/try_future/map_err.rs
+++ b/futures-util/src/try_future/map_err.rs
@@ -23,7 +23,10 @@ impl<Fut, F> MapErr<Fut, F> {
 
 impl<Fut: Unpin, F> Unpin for MapErr<Fut, F> {}
 
-impl<Fut, F> FusedFuture for MapErr<Fut, F> {
+impl<Fut, F, E> FusedFuture for MapErr<Fut, F>
+    where Fut: TryFuture,
+          F: FnOnce(Fut::Error) -> E,
+{
     fn is_terminated(&self) -> bool { self.f.is_none() }
 }
 

--- a/futures-util/src/try_future/map_ok.rs
+++ b/futures-util/src/try_future/map_ok.rs
@@ -23,7 +23,10 @@ impl<Fut, F> MapOk<Fut, F> {
 
 impl<Fut: Unpin, F> Unpin for MapOk<Fut, F> {}
 
-impl<Fut, F> FusedFuture for MapOk<Fut, F> {
+impl<Fut, F, T> FusedFuture for MapOk<Fut, F>
+    where Fut: TryFuture,
+          F: FnOnce(Fut::Ok) -> T,
+{
     fn is_terminated(&self) -> bool {
         self.f.is_none()
     }

--- a/futures-util/src/try_future/unwrap_or_else.rs
+++ b/futures-util/src/try_future/unwrap_or_else.rs
@@ -24,7 +24,10 @@ impl<Fut, F> UnwrapOrElse<Fut, F> {
 
 impl<Fut: Unpin, F> Unpin for UnwrapOrElse<Fut, F> {}
 
-impl<Fut, F> FusedFuture for UnwrapOrElse<Fut, F> {
+impl<Fut, F> FusedFuture for UnwrapOrElse<Fut, F>
+    where Fut: TryFuture,
+          F: FnOnce(Fut::Error) -> Fut::Ok,
+{
     fn is_terminated(&self) -> bool {
         self.f.is_none()
     }

--- a/futures-util/src/try_stream/err_into.rs
+++ b/futures-util/src/try_stream/err_into.rs
@@ -56,7 +56,11 @@ impl<St, E> ErrInto<St, E> {
     }
 }
 
-impl<St: FusedStream, E> FusedStream for ErrInto<St, E> {
+impl<St, E> FusedStream for ErrInto<St, E>
+where
+    St: TryStream + FusedStream,
+    St::Error: Into<E>,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/try_stream/inspect_err.rs
+++ b/futures-util/src/try_stream/inspect_err.rs
@@ -74,7 +74,11 @@ where
     }
 }
 
-impl<St: TryStream + FusedStream, F> FusedStream for InspectErr<St, F> {
+impl<St, F> FusedStream for InspectErr<St, F>
+where
+    St: TryStream + FusedStream,
+    F: FnMut(&St::Error),
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/try_stream/inspect_ok.rs
+++ b/futures-util/src/try_stream/inspect_ok.rs
@@ -74,7 +74,11 @@ where
     }
 }
 
-impl<St: TryStream + FusedStream, F> FusedStream for InspectOk<St, F> {
+impl<St, F> FusedStream for InspectOk<St, F>
+where
+    St: TryStream + FusedStream,
+    F: FnMut(&St::Ok),
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/try_stream/into_stream.rs
+++ b/futures-util/src/try_stream/into_stream.rs
@@ -53,7 +53,7 @@ impl<St> IntoStream<St> {
     }
 }
 
-impl<St: FusedStream> FusedStream for IntoStream<St> {
+impl<St: TryStream + FusedStream> FusedStream for IntoStream<St> {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/try_stream/map_err.rs
+++ b/futures-util/src/try_stream/map_err.rs
@@ -68,7 +68,11 @@ impl<St, F> MapErr<St, F> {
     }
 }
 
-impl<St: FusedStream, F> FusedStream for MapErr<St, F> {
+impl<St, F, E> FusedStream for MapErr<St, F>
+where
+    St: TryStream + FusedStream,
+    F: FnMut(St::Error) -> E,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/try_stream/map_ok.rs
+++ b/futures-util/src/try_stream/map_ok.rs
@@ -68,7 +68,11 @@ impl<St, F> MapOk<St, F> {
     }
 }
 
-impl<St: FusedStream, F> FusedStream for MapOk<St, F> {
+impl<St, F, T> FusedStream for MapOk<St, F>
+where
+    St: TryStream + FusedStream,
+    F: FnMut(St::Ok) -> T,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/try_stream/try_collect.rs
+++ b/futures-util/src/try_stream/try_collect.rs
@@ -31,14 +31,20 @@ impl<St: TryStream, C: Default> TryCollect<St, C> {
 
 impl<St: Unpin + TryStream, C> Unpin for TryCollect<St, C> {}
 
-impl<St: FusedStream, C> FusedFuture for TryCollect<St, C> {
+impl<St, C> FusedFuture for TryCollect<St, C>
+where
+    St: TryStream + FusedStream,
+    C: Default + Extend<St::Ok>,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }
 }
 
 impl<St, C> Future for TryCollect<St, C>
-    where St: TryStream, C: Default + Extend<St::Ok>
+where
+    St: TryStream,
+    C: Default + Extend<St::Ok>,
 {
     type Output = Result<C, St::Error>;
 

--- a/futures-util/src/try_stream/try_flatten.rs
+++ b/futures-util/src/try_stream/try_flatten.rs
@@ -77,6 +77,8 @@ where
 impl<St> FusedStream for TryFlatten<St>
 where
     St: TryStream + FusedStream,
+    St::Ok: TryStream,
+    <St::Ok as TryStream>::Error: From<St::Error>,
 {
     fn is_terminated(&self) -> bool {
         self.next.is_none() && self.stream.is_terminated()

--- a/futures-util/src/try_stream/try_fold.rs
+++ b/futures-util/src/try_stream/try_fold.rs
@@ -51,7 +51,11 @@ where St: TryStream,
     }
 }
 
-impl<St, Fut, T, F> FusedFuture for TryFold<St, Fut, T, F> {
+impl<St, Fut, T, F> FusedFuture for TryFold<St, Fut, T, F>
+    where St: TryStream,
+          F: FnMut(T, St::Ok) -> Fut,
+          Fut: TryFuture<Ok = T, Error = St::Error>,
+{
     fn is_terminated(&self) -> bool {
         self.accum.is_none() && self.future.is_none()
     }

--- a/futures-util/src/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/try_stream/try_for_each_concurrent.rs
@@ -38,7 +38,11 @@ where
     }
 }
 
-impl<St, Fut, F> FusedFuture for TryForEachConcurrent<St, Fut, F> {
+impl<St, Fut, F> FusedFuture for TryForEachConcurrent<St, Fut, F>
+    where St: TryStream,
+          F: FnMut(St::Ok) -> Fut,
+          Fut: Future<Output = Result<(), St::Error>>,
+{
     fn is_terminated(&self) -> bool {
         self.stream.is_none() && self.futures.is_empty()
     }

--- a/futures-util/src/try_stream/try_next.rs
+++ b/futures-util/src/try_stream/try_next.rs
@@ -19,7 +19,7 @@ impl<'a, St: ?Sized + TryStream + Unpin> TryNext<'a, St> {
     }
 }
 
-impl<St: ?Sized + Unpin + FusedStream> FusedFuture for TryNext<'_, St> {
+impl<St: ?Sized + TryStream + Unpin + FusedStream> FusedFuture for TryNext<'_, St> {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures/tests/object_safety.rs
+++ b/futures/tests/object_safety.rs
@@ -6,18 +6,18 @@ fn future() {
     use futures::future::{FusedFuture, Future, TryFuture};
 
     assert_is_object_safe::<&dyn Future<Output = ()>>();
+    assert_is_object_safe::<&dyn FusedFuture<Output = ()>>();
     assert_is_object_safe::<&dyn TryFuture<Ok = (), Error = ()>>();
-    assert_is_object_safe::<&dyn FusedFuture>();
 }
 
 #[test]
 fn stream() {
-    // `StreamExt` and `StreamExt` are not object safe.
+    // `StreamExt` and `TryStreamExt` are not object safe.
     use futures::stream::{FusedStream, Stream, TryStream};
 
     assert_is_object_safe::<&dyn Stream<Item = ()>>();
+    assert_is_object_safe::<&dyn FusedStream<Item = ()>>();
     assert_is_object_safe::<&dyn TryStream<Ok = (), Error = ()>>();
-    assert_is_object_safe::<&dyn FusedStream>();
 }
 
 #[test]


### PR DESCRIPTION
Just as `ExactSizeIterator` and `FusedIterator` have `Iterator` bounds, I think it's preferable for consistency to add `Future`/`Stream` bounds to `FusedFuture`/`FusedStream` as well.