### PR TITLE
Rename ArcWake to Wake

### DIFF
--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -2,7 +2,7 @@ use crate::enter;
 use futures_core::future::{Future, FutureObj, LocalFutureObj};
 use futures_core::stream::{Stream};
 use futures_core::task::{Context, Poll, Spawn, LocalSpawn, SpawnError};
-use futures_util::task::{waker_ref, ArcWake};
+use futures_util::task::{waker_ref, Wake};
 use futures_util::stream::FuturesUnordered;
 use futures_util::stream::StreamExt;
 use futures_util::pin_mut;
@@ -48,7 +48,7 @@ thread_local! {
     });
 }
 
-impl ArcWake for ThreadNotify {
+impl Wake for ThreadNotify {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         arc_self.thread.unpark();
     }

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -3,7 +3,7 @@ use crate::unpark_mutex::UnparkMutex;
 use futures_core::future::{Future, FutureObj};
 use futures_core::task::{Context, Poll, Spawn, SpawnError};
 use futures_util::future::FutureExt;
-use futures_util::task::{ArcWake, waker_ref};
+use futures_util::task::{Wake, waker_ref};
 use std::io;
 use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -367,7 +367,7 @@ impl fmt::Debug for Task {
     }
 }
 
-impl ArcWake for WakeHandle {
+impl Wake for WakeHandle {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         match arc_self.mutex.notify() {
             Ok(task) => arc_self.exec.state.send(Message::Run(task)),

--- a/futures-test/src/task/wake_counter.rs
+++ b/futures-test/src/task/wake_counter.rs
@@ -1,5 +1,5 @@
 use futures_core::task::Waker;
-use futures_util::task::{self, ArcWake};
+use futures_util::task::{self, Wake};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -29,7 +29,7 @@ struct WakerInner {
     count: AtomicUsize,
 }
 
-impl ArcWake for WakerInner {
+impl Wake for WakerInner {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         let _ = arc_self.count.fetch_add(1, Ordering::SeqCst);
     }

--- a/futures-util/benches_disabled/bilock.rs
+++ b/futures-util/benches_disabled/bilock.rs
@@ -7,7 +7,7 @@ use futures::executor::LocalPool;
 use futures_util::lock::BiLock;
 use futures_util::lock::BiLockAcquire;
 use futures_util::lock::BiLockAcquired;
-use futures_util::task::ArcWake;
+use futures_util::task::Wake;
 
 use std::sync::Arc;
 use test::Bencher;
@@ -15,11 +15,11 @@ use test::Bencher;
 fn notify_noop() -> Waker {
     struct Noop;
 
-    impl ArcWake for Noop {
+    impl Wake for Noop {
         fn wake(_: &Arc<Self>) {}
     }
 
-    ArcWake::into_waker(Arc::new(Noop))
+    Wake::into_waker(Arc::new(Noop))
 }
 
 

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -15,7 +15,7 @@ use futures_core::{
 use futures_sink::Sink as Sink03;
 use crate::task::{
     self as task03,
-    ArcWake as ArcWake03,
+    Wake as Wake03,
     WakerRef,
 };
 #[cfg(feature = "sink")]
@@ -207,7 +207,7 @@ impl Current {
     }
 }
 
-impl ArcWake03 for Current {
+impl Wake03 for Current {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         arc_self.0.notify();
     }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -1,4 +1,4 @@
-use crate::task::{ArcWake, waker_ref};
+use crate::task::{Wake, waker_ref};
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll, Waker};
 use slab::Slab;
@@ -319,7 +319,7 @@ where
     }
 }
 
-impl ArcWake for Notifier {
+impl Wake for Notifier {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         arc_self.state.compare_and_swap(POLLING, REPOLL, SeqCst);
 

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicPtr, AtomicBool};
 use core::sync::atomic::Ordering::SeqCst;
 use alloc::sync::{Arc, Weak};
 
-use crate::task::{ArcWake, WakerRef, waker_ref};
+use crate::task::{Wake, WakerRef, waker_ref};
 use super::ReadyToRunQueue;
 use super::abort::abort;
 
@@ -35,7 +35,7 @@ pub(super) struct Task<Fut> {
 unsafe impl<Fut> Send for Task<Fut> {}
 unsafe impl<Fut> Sync for Task<Fut> {}
 
-impl<Fut> ArcWake for Task<Fut> {
+impl<Fut> Wake for Task<Fut> {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         let inner = match arc_self.ready_to_run_queue.upgrade() {
             Some(inner) => inner,

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -2,7 +2,7 @@
 
 cfg_target_has_atomic! {
     /// A macro for creating a `RawWaker` vtable for a type that implements
-    /// the `ArcWake` trait.
+    /// the `Wake` trait.
     #[cfg(feature = "alloc")]
     macro_rules! waker_vtable {
         ($ty:ident) => {
@@ -16,9 +16,9 @@ cfg_target_has_atomic! {
     }
 
     #[cfg(feature = "alloc")]
-    mod arc_wake;
+    mod wake;
     #[cfg(feature = "alloc")]
-    pub use self::arc_wake::ArcWake;
+    pub use self::wake::Wake;
 
     #[cfg(feature = "alloc")]
     mod waker;

--- a/futures-util/src/task/wake.rs
+++ b/futures-util/src/task/wake.rs
@@ -7,22 +7,22 @@ use alloc::sync::Arc;
 /// Those Wakers can be used to signal executors that a task it owns
 /// is ready to be `poll`ed again.
 ///
-/// Currently, there are two ways to convert `ArcWake` into [`Waker`]:
+/// Currently, there are two ways to convert `Wake` into [`Waker`]:
 ///
-/// * [`waker`](crate::task::waker()) converts `Arc<impl ArcWake>` into [`Waker`].
-/// * [`waker_ref`](crate::task::waker_ref()) converts `&Arc<impl ArcWake>` into [`WakerRef`] that
+/// * [`waker`](crate::task::waker()) converts `Arc<impl Wake>` into [`Waker`].
+/// * [`waker_ref`](crate::task::waker_ref()) converts `&Arc<impl Wake>` into [`WakerRef`] that
 ///   provides access to a [`&Waker`][`Waker`].
 ///
 /// [`Waker`]: std::task::Waker
 /// [`WakerRef`]: crate::task::WakerRef
 // Note: Send + Sync required because `Arc<T>` doesn't automatically imply
 // those bounds, but `Waker` implements them.
-pub trait ArcWake: Send + Sync {
+pub trait Wake: Send + Sync {
     /// Indicates that the associated task is ready to make progress and should
     /// be `poll`ed.
     ///
     /// This function can be called from an arbitrary thread, including threads which
-    /// did not create the `ArcWake` based [`Waker`].
+    /// did not create the `Wake` based [`Waker`].
     ///
     /// Executors generally maintain a queue of "ready" tasks; `wake` should place
     /// the associated task onto this queue.
@@ -36,12 +36,12 @@ pub trait ArcWake: Send + Sync {
     /// be `poll`ed.
     ///
     /// This function can be called from an arbitrary thread, including threads which
-    /// did not create the `ArcWake` based [`Waker`].
+    /// did not create the `Wake` based [`Waker`].
     ///
     /// Executors generally maintain a queue of "ready" tasks; `wake_by_ref` should place
     /// the associated task onto this queue.
     ///
-    /// This function is similar to [`wake`](ArcWake::wake), but must not consume the provided data
+    /// This function is similar to [`wake`](Wake::wake), but must not consume the provided data
     /// pointer.
     ///
     /// [`Waker`]: std::task::Waker

--- a/futures-util/src/task/waker_ref.rs
+++ b/futures-util/src/task/waker_ref.rs
@@ -1,4 +1,4 @@
-use super::arc_wake::ArcWake;
+use super::wake::Wake;
 use super::waker::{clone_arc_raw, wake_by_ref_arc_raw};
 use alloc::sync::Arc;
 use core::marker::PhantomData;
@@ -42,7 +42,7 @@ unsafe fn noop(_data: *const ()) {}
 
 unsafe fn wake_unreachable(_data: *const ()) {
     // With only a reference, calling `wake_arc_raw()` would be unsound,
-    // since the `WakerRef` didn't increment the refcount of the `ArcWake`,
+    // since the `WakerRef` didn't increment the refcount of the `Wake`,
     // and `wake_arc_raw` would *decrement* it.
     //
     // This should never be reachable, since `WakerRef` only provides a `Deref`
@@ -52,14 +52,14 @@ unsafe fn wake_unreachable(_data: *const ()) {
     unreachable!("WakerRef::wake");
 }
 
-/// Creates a reference to a [`Waker`] from a reference to `Arc<impl ArcWake>`.
+/// Creates a reference to a [`Waker`] from a reference to `Arc<impl Wake>`.
 ///
 /// The resulting [`Waker`] will call
-/// [`ArcWake.wake()`](ArcWake::wake) if awoken.
+/// [`Wake.wake()`](Wake::wake) if awoken.
 #[inline]
 pub fn waker_ref<W>(wake: &Arc<W>) -> WakerRef<'_>
 where
-    W: ArcWake
+    W: Wake
 {
     // This uses the same mechanism as Arc::into_raw, without needing a reference.
     // This is potentially not stable

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -499,7 +499,7 @@ pub mod task {
         cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
     )]
     #[cfg(feature = "alloc")]
-    pub use futures_util::task::{waker, waker_ref, WakerRef, ArcWake};
+    pub use futures_util::task::{waker, waker_ref, WakerRef, Wake};
 
     #[cfg_attr(
         feature = "cfg-target-has-atomic",

--- a/futures/tests/object_safety.rs
+++ b/futures/tests/object_safety.rs
@@ -41,7 +41,7 @@ fn io() {
 
 #[test]
 fn task() {
-    // `ArcWake`, `SpawnExt` and `LocalSpawnExt` are not object safe.
+    // `Wake`, `SpawnExt` and `LocalSpawnExt` are not object safe.
     use futures::task::{LocalSpawn, Spawn};
 
     assert_is_object_safe::<&dyn Spawn>();

--- a/futures/tests/wake.rs
+++ b/futures/tests/wake.rs
@@ -1,4 +1,4 @@
-use futures::task::{self, ArcWake, Waker};
+use futures::task::{self, Wake, Waker};
 use std::sync::{Arc, Mutex};
 
 struct CountingWaker {
@@ -17,7 +17,7 @@ impl CountingWaker {
     }
 }
 
-impl ArcWake for CountingWaker {
+impl Wake for CountingWaker {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         let mut lock = arc_self.nr_wake.lock().unwrap();
         *lock += 1;


### PR DESCRIPTION
Since both methods take Arc as an argument, it should not be difficult to understand that this trait is based on Arc. Also, I think this should be near to [the API we want to add to std/alloc in the future](https://github.com/rust-lang/rust/issues/59725#issuecomment-480594110).