### PR TITLE
Add an AsyncReadExt::take adapter.

### DIFF
--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -78,6 +78,84 @@ impl<R: AsyncRead + Unpin> Take<R> {
     pub fn set_limit(&mut self, limit: u64) {
         self.limit = limit
     }
+
+    /// Consumes the `Take`, returning the wrapped reader.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(async_await)]
+    /// # futures::executor::block_on(async {
+    /// use futures::io::AsyncReadExt;
+    /// use std::io::Cursor;
+    ///
+    /// let reader = Cursor::new(&b"12345678"[..]);
+    /// let mut buffer = [0; 4];
+    ///
+    /// let mut take = reader.take(4);
+    /// let n = take.read(&mut buffer).await?;
+    ///
+    /// let cursor = take.into_inner();
+    /// assert_eq!(cursor.position(), 4);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
+    /// ```
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+
+    /// Gets a reference to the underlying reader.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(async_await)]
+    /// # futures::executor::block_on(async {
+    /// use futures::io::AsyncReadExt;
+    /// use std::io::Cursor;
+    ///
+    /// let reader = Cursor::new(&b"12345678"[..]);
+    /// let mut buffer = [0; 4];
+    ///
+    /// let mut take = reader.take(4);
+    /// let n = take.read(&mut buffer).await?;
+    ///
+    /// let cursor_ref = take.get_ref();
+    /// assert_eq!(cursor_ref.position(), 4);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
+    /// ```
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying reader.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying reader as doing so may corrupt the internal limit of this
+    /// `Take`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(async_await)]
+    /// # futures::executor::block_on(async {
+    /// use futures::io::AsyncReadExt;
+    /// use std::io::Cursor;
+    ///
+    /// let reader = Cursor::new(&b"12345678"[..]);
+    /// let mut buffer = [0; 4];
+    ///
+    /// let mut take = reader.take(4);
+    /// let n = take.read(&mut buffer).await?;
+    ///
+    /// let cursor_mut = take.get_mut();
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
+    /// ```
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
 }
 
 impl<R: AsyncRead + Unpin> AsyncRead for Take<R> {

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -18,10 +18,63 @@ impl<R: AsyncRead + Unpin> Take<R> {
         Take { inner, limit }
     }
 
+    /// Returns the remaining number of bytes that can be
+    /// read before this instance will return EOF.
+    ///
+    /// # Note
+    ///
+    /// This instance may reach `EOF` after reading fewer bytes than indicated by
+    /// this method if the underlying [`AsyncRead`] instance reaches EOF.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(async_await)]
+    /// # futures::executor::block_on(async {
+    /// use futures::io::AsyncReadExt;
+    /// use std::io::Cursor;
+    ///
+    /// let reader = Cursor::new(&b"12345678"[..]);
+    /// let mut buffer = [0; 2];
+    ///
+    /// let mut take = reader.take(4);
+    /// let n = take.read(&mut buffer).await?;
+    ///
+    /// assert_eq!(take.limit(), 2);
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
+    /// ```
     pub fn limit(&self) -> u64 {
         self.limit
     }
 
+    /// Sets the number of bytes that can be read before this instance will
+    /// return EOF. This is the same as constructing a new `Take` instance, so
+    /// the amount of bytes read and the previous limit value don't matter when
+    /// calling this method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(async_await)]
+    /// # futures::executor::block_on(async {
+    /// use futures::io::AsyncReadExt;
+    /// use std::io::Cursor;
+    ///
+    /// let reader = Cursor::new(&b"12345678"[..]);
+    /// let mut buffer = [0; 4];
+    ///
+    /// let mut take = reader.take(4);
+    /// let n = take.read(&mut buffer).await?;
+    ///
+    /// assert_eq!(n, 4);
+    /// assert_eq!(take.limit(), 0);
+    ///
+    /// take.set_limit(10);
+    /// let n = take.read(&mut buffer).await?;
+    /// assert_eq!(n, 4);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
+    /// ```
     pub fn set_limit(&mut self, limit: u64) {
         self.limit = limit
     }

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -1,0 +1,35 @@
+use futures_core::task::{Context, Poll};
+use futures_io::AsyncRead;
+use std::io;
+use std::pin::Pin;
+
+/// Future for the [`take`](super::AsyncReadExt::take) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Take<R: Unpin> {
+    inner: R,
+    limit: u64,
+}
+
+impl<R: AsyncRead + Unpin> Take<R> {
+    pub(super) fn new(inner: R, limit: u64) -> Self {
+        Take { inner, limit }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for Take<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        if self.limit == 0 {
+            return Poll::Ready(Ok(0));
+        }
+
+        let max = std::cmp::min(buf.len() as u64, self.limit) as usize;
+        let n = ready!(Pin::new(&mut self.inner).poll_read(cx, &mut buf[..max]))?;
+        self.limit -= n as u64;
+        Poll::Ready(Ok(n))
+    }
+}

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -11,9 +11,19 @@ pub struct Take<R: Unpin> {
     limit: u64,
 }
 
+impl<R: Unpin> Unpin for Take<R> { }
+
 impl<R: AsyncRead + Unpin> Take<R> {
     pub(super) fn new(inner: R, limit: u64) -> Self {
         Take { inner, limit }
+    }
+
+    pub fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    pub fn set_limit(&mut self, limit: u64) {
+        self.limit = limit
     }
 }
 


### PR DESCRIPTION
I wrote this adapter because it is used relatively frequently in `rocket_contrib`, examples, and tests, but I think it deserves a place in `futures-rs`.

Code is based on the synchronous equivalent in std - how/where should I attribute this?

Not ready:
* [x] docs
* [x] tests
* [x] manual `impl Unpin`?
* [ ] attribution to std if necessary