### PR TITLE
Temporarily ignore buffer_unordered::works test on macOS

### DIFF
--- a/futures/tests/buffer_unordered.rs
+++ b/futures/tests/buffer_unordered.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc as std_mpsc;
 use std::thread;
 
 #[test]
+#[cfg_attr(target_os = "macos", ignore)] // FIXME: https://github.com/rust-lang-nursery/futures-rs/issues/1790
 fn works() {
     const N: usize = 4;
 


### PR DESCRIPTION
Prevent other PRs from being blocked by #1790 until #1790 is resolved.

cc @cramertj