### PR TITLE
Fix use-after-free on panic during ArcWake::wake_by_ref

### DIFF
--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -44,3 +44,22 @@ fn create_waker_from_arc() {
     drop(w1);
     assert_eq!(1, Arc::strong_count(&some_w));
 }
+
+struct PanicWaker;
+
+impl ArcWake for PanicWaker {
+    fn wake_by_ref(_arc_self: &Arc<Self>) {
+        panic!("WAKE UP");
+    }
+}
+
+#[test]
+fn proper_refcount_on_wake_panic() {
+    let some_w = Arc::new(PanicWaker);
+
+    let w1: Waker = task::waker(some_w.clone());
+    assert_eq!("WAKE UP", *std::panic::catch_unwind(|| w1.wake_by_ref()).unwrap_err().downcast::<&str>().unwrap());
+    assert_eq!(2, Arc::strong_count(&some_w)); // some_w + w1
+    drop(w1);
+    assert_eq!(1, Arc::strong_count(&some_w)); // some_w
+}


### PR DESCRIPTION
Wrap temporary `Arc<>`s in `ManuallyDrop` early instead of calling `forget()` later: that way even during unwinding for panics it doesn't drop the refcount it doesn't actually own.

Also it means `wake_by_ref` doesn't need an unwind section anymore.

Same thing in `increase_refcount` (although `Arc::clone` should only abort, not unwind).