### PR TITLE
Use ManuallyDrop for WakerRef to use same vtable as normal Waker

### DIFF
--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -201,9 +201,9 @@ impl Current {
 
         let ptr = current_to_ptr(self);
         let vtable = &RawWakerVTable::new(clone, wake, wake, drop);
-        unsafe {
-            WakerRef::new(task03::Waker::from_raw(RawWaker::new(ptr, vtable)))
-        }
+        WakerRef::new_unowned(std::mem::ManuallyDrop::new(unsafe {
+            task03::Waker::from_raw(RawWaker::new(ptr, vtable))
+        }))
     }
 }
 

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -1,20 +1,6 @@
 //! Task notification
 
 cfg_target_has_atomic! {
-    /// A macro for creating a `RawWaker` vtable for a type that implements
-    /// the `ArcWake` trait.
-    #[cfg(feature = "alloc")]
-    macro_rules! waker_vtable {
-        ($ty:ident) => {
-            &RawWakerVTable::new(
-                clone_arc_raw::<$ty>,
-                wake_arc_raw::<$ty>,
-                wake_by_ref_arc_raw::<$ty>,
-                drop_arc_raw::<$ty>,
-            )
-        };
-    }
-
     #[cfg(feature = "alloc")]
     mod arc_wake;
     #[cfg(feature = "alloc")]

--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -63,3 +63,15 @@ fn proper_refcount_on_wake_panic() {
     drop(w1);
     assert_eq!(1, Arc::strong_count(&some_w)); // some_w
 }
+
+#[test]
+fn waker_ref_wake_same() {
+    let some_w = Arc::new(CountingWaker::new());
+
+    let w1: Waker = task::waker(some_w.clone());
+    let w2 = task::waker_ref(&some_w);
+    let w3 = w2.clone();
+
+    assert!(w1.will_wake(&w2));
+    assert!(w2.will_wake(&w3));
+}


### PR DESCRIPTION
This makes `Waker::will_wake` work between `task::waker_ref` and `Wakers` cloned from it (or created by `task::waker`).

As `WakerRef` no longer stores an actual waker (as in owning a refcount), `WakerRef::new` takes now a reference instead of ownership. (Theoretically we could have an inner flag/enum to track ownership vs no ownership, but the struct name clearly suggests it shouldn't own anything.)

Replaces `waker_vtable!` with a `waker_vtable<W>()` function, hopefully making the returned vtable pointer (more) stable.

This also removes the safety guard "wake_unreachable" - but after all it should have been unreachable in the first place.