### PR TITLE
futures-util: Re-export some traits/types

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -4,17 +4,14 @@
 //! including the `FutureExt` trait which adds methods to `Future` types.
 
 use core::pin::Pin;
-use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-#[cfg(feature = "alloc")]
-use futures_core::future::{BoxFuture, LocalBoxFuture};
 
-// re-export for `select!`
-#[doc(hidden)]
-pub use futures_core::future::FusedFuture;
+pub use futures_core::future::{FusedFuture, Future};
+#[cfg(feature = "alloc")]
+pub use futures_core::future::{BoxFuture, LocalBoxFuture};
 
 // Primitive futures
 mod lazy;

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -10,7 +10,8 @@
 //! library is activated, and it is activated by default.
 
 pub use futures_io::{
-    AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, IoSlice, IoSliceMut, SeekFrom,
+    AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, Error, ErrorKind,
+    IoSlice, IoSliceMut, Result, SeekFrom,
 };
 
 #[cfg(feature = "io-compat")] use crate::compat::Compat;

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -8,11 +8,12 @@
 
 use futures_core::future::Future;
 use futures_core::stream::Stream;
-use futures_sink::Sink;
 use crate::future::Either;
 
 #[cfg(feature = "compat")]
 use crate::compat::CompatSink;
+
+pub use futures_sink::Sink;
 
 mod close;
 pub use self::close::Close;

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -6,7 +6,6 @@
 use crate::future::Either;
 use core::pin::Pin;
 use futures_core::future::Future;
-use futures_core::stream::{FusedStream, Stream};
 #[cfg(feature = "sink")]
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
@@ -14,8 +13,10 @@ use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
+
+pub use futures_core::stream::{FusedStream, Stream};
 #[cfg(feature = "alloc")]
-use futures_core::stream::{BoxStream, LocalBoxStream};
+pub use futures_core::stream::{BoxStream, LocalBoxStream};
 
 mod iter;
 pub use self::iter::{iter, Iter};

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -41,6 +41,4 @@ pub use self::noop_waker::noop_waker_ref;
 mod spawn;
 pub use self::spawn::{SpawnExt, LocalSpawnExt};
 
-// re-export for `select!`
-#[doc(hidden)]
-pub use futures_core::task::{Context, Poll, Waker};
+pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};

--- a/futures-util/src/try_future/mod.rs
+++ b/futures-util/src/try_future/mod.rs
@@ -4,13 +4,14 @@
 //! including the `FutureExt` trait which adds methods to `Future` types.
 
 use core::pin::Pin;
-use futures_core::future::TryFuture;
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 
 #[cfg(feature = "compat")] use crate::compat::Compat;
+
+pub use futures_core::future::TryFuture;
 
 mod try_join;
 pub use self::try_join::{

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -5,11 +5,12 @@
 
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
-use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 
 #[cfg(feature = "compat")]
 use crate::compat::Compat;
+
+pub use futures_core::stream::TryStream;
 
 mod and_then;
 pub use self::and_then::AndThen;


### PR DESCRIPTION
This is useful if we are using `futures-util` without depending directly on `futures` (`io` module has already done this).