### PR TITLE
Add Mutex::{get_mut, into_inner}

### DIFF
--- a/futures-util/src/lock/mutex.rs
+++ b/futures-util/src/lock/mutex.rs
@@ -61,9 +61,23 @@ impl<T> Mutex<T> {
     pub fn new(t: T) -> Mutex<T> {
         Mutex {
             state: AtomicUsize::new(0),
-            value: UnsafeCell::new(t),
             waiters: StdMutex::new(Slab::new()),
+            value: UnsafeCell::new(t),
         }
+    }
+
+    /// Consumes this mutex, returning the underlying data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::lock::Mutex;
+    ///
+    /// let mutex = Mutex::new(0);
+    /// assert_eq!(mutex.into_inner(), 0);
+    /// ```
+    pub fn into_inner(self) -> T {
+        self.value.into_inner()
     }
 }
 
@@ -89,6 +103,28 @@ impl<T: ?Sized> Mutex<T> {
             mutex: Some(self),
             wait_key: WAIT_KEY_NONE,
         }
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `Mutex` mutably, no actual locking needs to
+    /// take place -- the mutable borrow statically guarantees no locks exist.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::lock::Mutex;
+    ///
+    /// let mut mutex = Mutex::new(0);
+    /// *mutex.get_mut() = 10;
+    /// assert_eq!(*mutex.lock().await, 10);
+    /// # });
+    /// ```
+    pub fn get_mut(&mut self) -> &mut T {
+        // We know statically that there are no other references to `self`, so
+        // there's no need to lock the inner mutex.
+        unsafe { &mut *self.value.get() }
     }
 
     fn remove_waker(&self, wait_key: usize, wake_another: bool) {


### PR DESCRIPTION
Refs: 
* https://doc.rust-lang.org/nightly/std/sync/struct.Mutex.html#method.into_inner
* https://doc.rust-lang.org/nightly/std/sync/struct.Mutex.html#method.get_mut

Closes #1838 