### PR TITLE
invert return type of split for consistency

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -1090,7 +1090,7 @@ pub trait StreamExt: Stream {
         cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
     )]
     #[cfg(feature = "alloc")]
-    fn split<Item>(self) -> (SplitSink<Self, Item>, SplitStream<Self>)
+    fn split<Item>(self) -> (SplitStream<Self>, SplitSink<Self, Item>)
         where Self: Sink<Item> + Sized
     {
         split::split(self)

--- a/futures-util/src/stream/split.rs
+++ b/futures-util/src/stream/split.rs
@@ -99,11 +99,11 @@ impl<S: Sink<Item>, Item> Sink<Item> for SplitSink<S, Item> {
     }
 }
 
-pub(super) fn split<S: Stream + Sink<Item>, Item>(s: S) -> (SplitSink<S, Item>, SplitStream<S>) {
+pub(super) fn split<S: Stream + Sink<Item>, Item>(s: S) -> (SplitStream<S>, SplitSink<S, Item>) {
     let (a, b) = BiLock::new(s);
     let read = SplitStream(a);
     let write = SplitSink(b);
-    (write, read)
+    (read, write)
 }
 
 /// Error indicating a `SplitSink<S>` and `SplitStream<S>` were not two halves

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -67,9 +67,9 @@ fn test_split() {
             sink: &mut dest
         };
 
-        let (sink, stream) = join.split();
+        let (stream, sink) = join.split();
         let join = sink.reunite(stream).expect("test_split: reunite error");
-        let (mut sink, mut stream) = join.split();
+        let (mut stream, mut sink) = join.split();
         block_on(sink.send_all(&mut stream)).unwrap();
     }
     assert_eq!(dest, vec![10, 20, 30]);


### PR DESCRIPTION
`futures::io::AsyncReadExt::split` defines return as:
```
 (ReadHalf<Self>, WriteHalf<Self>)
```

This commit fix inconsistency of `futures::stream::StreamExt::split`