### PR TITLE
Don't bypass stream fuse in Forward

### DIFF
--- a/src/stream/forward.rs
+++ b/src/stream/forward.rs
@@ -91,7 +91,7 @@ impl<T, U> Future for Forward<T, U>
         }
 
         loop {
-            match self.stream_mut()
+            match self.stream.as_mut()
                 .expect("Attempted to poll Forward after completion")
                 .poll()?
             {


### PR DESCRIPTION
The poll implementation for `Forward` used method `stream_mut` to get at the stream. This bypasses the `Fuse` that was meant to prevent the underlying stream from being polled more than once in case `.close()` on the sink initially returns `NotReady`.