### PR TITLE
Remove .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,0 @@
-max_width = 80
-comment_width = 80


### PR DESCRIPTION
As mentioned in #1867, the current setting of rustfmt.toml is different from what we actually use.
(Also, currently, we are not using rustfmt, but the presence of rustfmt.toml may mislead.)