### PR TITLE
Support std::io::{Empty, Sink}

### DIFF
--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -42,6 +42,8 @@ mod if_std {
         IoSlice as IoSlice,
         IoSliceMut as IoSliceMut,
         SeekFrom as SeekFrom,
+        Sink as Sink,
+        Empty as Empty,
     };
 
     #[cfg(feature = "read_initializer")]
@@ -390,6 +392,10 @@ mod if_std {
         delegate_async_read_to_stdio!();
     }
 
+    impl AsyncRead for Empty {
+        delegate_async_read_to_stdio!();
+    }
+
     macro_rules! deref_async_write {
         () => {
             fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
@@ -506,6 +512,10 @@ mod if_std {
     }
 
     impl AsyncWrite for Vec<u8> {
+        delegate_async_write_to_stdio!();
+    }
+
+    impl AsyncWrite for Sink {
         delegate_async_write_to_stdio!();
     }
 


### PR DESCRIPTION
Add async support for the „stub“ helpers of std::io.

Some motivation can be found here: https://vorner.github.io/2019/09/15/play-with-new-async.html#switching-to-tokio ‒ I find these helpers quite useful sometimes.