### PR TITLE
Improve support for mutable borrows in select! blocks

### DIFF
--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -173,21 +173,28 @@ pub fn select(input: TokenStream) -> TokenStream {
                     // This prevents creating redundant stack space
                     // for them.
                     // Passing Futures by path requires those Futures to implement Unpin.
+                    // We check for this condition here in order to be able to
+                    // safely use Pin::new_unchecked(&mut #path) later on.
+                    future_let_bindings.push(quote! {
+                        #futures_crate::async_await::assert_fused_future(&mut #path);
+                        #futures_crate::async_await::assert_unpin(&mut #path);
+                    });
                     path
                 },
                 _ => {
                     // Bind and pin the resulting Future on the stack. This is
                     // necessary to support direct select! calls on !Unpin
-                    // Futures.
+                    // Futures. The Future is not explicitly pinned here with
+                    // a Pin call, but assumed as pinned. The actual Pin is
+                    // created inside the poll() function below to defer the
+                    // creation of the temporary pointer, which would otherwise
+                    // increase the size of the generated Future.
                     // Safety: This is safe since the lifetime of the Future
                     // is totally constraint to the lifetime of the select!
                     // expression, and the Future can't get moved inside it
                     // (it is shadowed).
                     future_let_bindings.push(quote! {
                         let mut #variant_name = #expr;
-                        let mut #variant_name = unsafe {
-                            ::core::pin::Pin::new_unchecked(&mut #variant_name)
-                        };
                     });
                     parse_quote! { #variant_name }
                 }
@@ -199,8 +206,19 @@ pub fn select(input: TokenStream) -> TokenStream {
     // to use for polling that individual future. These will then be put in an array.
     let poll_functions = bound_future_names.iter().zip(variant_names.iter())
         .map(|(bound_future_name, variant_name)| {
+            // Below we lazily create the Pin on the Future below.
+            // This is done in order to avoid allocating memory in the generator
+            // for the Pin variable.
+            // Safety: This is safe because one of the following condition applies:
+            // 1. The Future is passed by the caller by name, and we assert that
+            //    it implements Unpin.
+            // 2. The Future is created in scope of the select! function and will
+            //    not be moved for the duration of it. It is thereby stack-pinned
             quote! {
                 let mut #variant_name = |__cx: &mut #futures_crate::task::Context<'_>| {
+                    let mut #bound_future_name = unsafe {
+                        ::core::pin::Pin::new_unchecked(&mut #bound_future_name)
+                    };
                     if #futures_crate::future::FusedFuture::is_terminated(&#bound_future_name) {
                         None
                     } else {

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -172,6 +172,7 @@ pub fn select(input: TokenStream) -> TokenStream {
                     // Don't bind futures that are already a path.
                     // This prevents creating redundant stack space
                     // for them.
+                    // Passing Futures by path requires those Futures to implement Unpin.
                     path
                 },
                 _ => {

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -246,21 +246,32 @@ pub fn select(input: TokenStream) -> TokenStream {
         #complete_branch
     };
 
-    let await_and_select = if let Some(default_expr) = parsed.default {
+    let await_select_fut = if parsed.default.is_some() {
+        // For select! with default this returns the Poll result
         quote! {
-            if let #futures_crate::task::Poll::Ready(x) =
-                __poll_fn(&mut #futures_crate::task::Context::from_waker(
-                    #futures_crate::task::noop_waker_ref()
-                ))
-            {
-                match x { #branches }
-            } else {
-                #default_expr
-            };
+            __poll_fn(&mut #futures_crate::task::Context::from_waker(
+                #futures_crate::task::noop_waker_ref()
+            ))
         }
     } else {
         quote! {
-            match #futures_crate::future::poll_fn(__poll_fn).await {
+            #futures_crate::future::poll_fn(__poll_fn).await
+        }
+    };
+
+    let execute_result_expr = if let Some(default_expr) = &parsed.default {
+        // For select! with default __select_result is a Poll, otherwise not
+        quote! {
+            match __select_result {
+                #futures_crate::task::Poll::Ready(result) => match result {
+                    #branches
+                },
+                _ => #default_expr
+            }
+        }
+    } else {
+        quote! {
+            match __select_result {
                 #branches
             }
         }
@@ -268,36 +279,41 @@ pub fn select(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! { {
         #enum_item
-        #( #future_let_bindings )*
 
-        let mut __poll_fn = |__cx: &mut #futures_crate::task::Context<'_>| {
-            let mut __any_polled = false;
+        let __select_result = {
+            #( #future_let_bindings )*
 
-            #( #poll_functions )*
+            let mut __poll_fn = |__cx: &mut #futures_crate::task::Context<'_>| {
+                let mut __any_polled = false;
 
-            let mut __select_arr = [#( #variant_names ),*];
-            #futures_crate::async_await::shuffle(&mut __select_arr);
-            for poller in &mut __select_arr {
-                let poller: &mut &mut dyn FnMut(
-                    &mut #futures_crate::task::Context<'_>
-                ) -> Option<#futures_crate::task::Poll<_>> = poller;
-                match poller(__cx) {
-                    Some(x @ #futures_crate::task::Poll::Ready(_)) =>
-                        return x,
-                    Some(#futures_crate::task::Poll::Pending) => {
-                        __any_polled = true;
+                #( #poll_functions )*
+
+                let mut __select_arr = [#( #variant_names ),*];
+                #futures_crate::async_await::shuffle(&mut __select_arr);
+                for poller in &mut __select_arr {
+                    let poller: &mut &mut dyn FnMut(
+                        &mut #futures_crate::task::Context<'_>
+                    ) -> Option<#futures_crate::task::Poll<_>> = poller;
+                    match poller(__cx) {
+                        Some(x @ #futures_crate::task::Poll::Ready(_)) =>
+                            return x,
+                        Some(#futures_crate::task::Poll::Pending) => {
+                            __any_polled = true;
+                        }
+                        None => {}
                     }
-                    None => {}
                 }
-            }
 
-            if !__any_polled {
-                #none_polled
-            } else {
-                #futures_crate::task::Poll::Pending
-            }
+                if !__any_polled {
+                    #none_polled
+                } else {
+                    #futures_crate::task::Poll::Pending
+                }
+            };
+
+            #await_select_fut
         };
 
-        #await_and_select
+        #execute_result_expr
     } })
 }

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -168,13 +168,25 @@ pub fn select(input: TokenStream) -> TokenStream {
         .zip(variant_names.iter())
         .map(|(expr, variant_name)| {
             match expr {
-                // Don't bind futures that are already a path.
-                // This prevents creating redundant stack space
-                // for them.
-                syn::Expr::Path(path) => path,
+                syn::Expr::Path(path) => {
+                    // Don't bind futures that are already a path.
+                    // This prevents creating redundant stack space
+                    // for them.
+                    path
+                },
                 _ => {
+                    // Bind and pin the resulting Future on the stack. This is
+                    // necessary to support direct select! calls on !Unpin
+                    // Futures.
+                    // Safety: This is safe since the lifetime of the Future
+                    // is totally constraint to the lifetime of the select!
+                    // expression, and the Future can't get moved inside it
+                    // (it is shadowed).
                     future_let_bindings.push(quote! {
                         let mut #variant_name = #expr;
+                        let mut #variant_name = unsafe {
+                            ::core::pin::Pin::new_unchecked(&mut #variant_name)
+                        };
                     });
                     parse_quote! { #variant_name }
                 }

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -12,10 +12,10 @@ macro_rules! document_select_macro {
         /// passed to `select!` must be `Unpin` and implement `FusedFuture`.
         ///
         /// If an expression which yields a `Future` is passed to `select!`
-        /// (e.g. an `async fn` call) instead of a `Future` directly the `Unpin`
+        /// (e.g. an `async fn` call) instead of a `Future` by name the `Unpin`
         /// requirement is relaxed, since the macro will pin the resulting `Future`
         /// on the stack. However the `Future` returned by the expression must
-        /// still implement `FusedFuture`.
+        /// still implement `FusedFuture`. This difference is presented
         ///
         /// Futures and streams which are not already fused can be fused using the
         /// `.fuse()` method. Note, though, that fusing a future or stream directly
@@ -24,8 +24,9 @@ macro_rules! document_select_macro {
         /// `select!`ing in a loop, users should take care to `fuse()` outside of
         /// the loop.
         ///
-        /// `select!` can select over futures with different output types, but each
-        /// branch has to have the same return type.
+        /// `select!` can be used as an expression and will return the return
+        /// value of the selected branch. For this reason the return type of every
+        /// branch in a `select!` must be the same.
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
         /// It is also gated behind the `async-await` feature of this library, which is
@@ -63,11 +64,67 @@ macro_rules! document_select_macro {
         /// # });
         /// ```
         ///
+        /// As described earlier, `select` can directly select on expressions
+        /// which return `Future`s - even if those do not implement `Unpin`:
+        ///
+        /// ```
+        /// # futures::executor::block_on(async {
+        /// use futures::future::FutureExt;
+        /// use futures::select;
+        ///
+        /// // Calling the following async fn returns a Future which does not
+        /// // implement Unpin
+        /// async fn async_identity_fn(arg: usize) -> usize {
+        ///     arg
+        /// }
+        ///
+        /// let res = select! {
+        ///     a_res = async_identity_fn(62).fuse() => a_res + 1,
+        ///     b_res = async_identity_fn(13).fuse() => b_res,
+        /// };
+        /// assert!(res == 63 || res == 12);
+        /// # });
+        /// ```
+        ///
+        /// If a similar async function is called outside of `select` to produce
+        /// a `Future`, the `Future` must be pinned in order to be able to pass
+        /// it to `select`. This can be achieved via `Box::pin` for pinning a
+        /// `Future` on the heap or the `pin_mut!` macro for pinning a `Future`
+        /// on the stack.
+        ///
+        /// ```
+        /// # futures::executor::block_on(async {
+        /// use futures::future::FutureExt;
+        /// use futures::select;
+        /// use pin_utils::pin_mut;
+        ///
+        /// // Calling the following async fn returns a Future which does not
+        /// // implement Unpin
+        /// async fn async_identity_fn(arg: usize) -> usize {
+        ///     arg
+        /// }
+        ///
+        /// let fut_1 = async_identity_fn(1).fuse();
+        /// let fut_2 = async_identity_fn(2).fuse();
+        /// let mut fut_1 = Box::pin(fut_1); // Pins the Future on the heap
+        /// pin_mut!(fut_2); // Pins the Future on the stack
+        ///
+        /// let res = select! {
+        ///     a_res = fut_1 => a_res,
+        ///     b_res = fut_2 => b_res,
+        /// };
+        /// assert!(res == 1 || res == 2);
+        /// # });
+        /// ```
+        ///
         /// `select` also accepts a `complete` branch and a `default` branch.
         /// `complete` will run if all futures and streams have already been
         /// exhausted. `default` will run if no futures or streams are
         /// immediately ready. `complete` takes priority over `default` in
         /// the case where all futures have completed.
+        /// A motivating use-case for passing `Future`s by name as well as for
+        /// `complete` blocks is to call `select!` in a loop, which is
+        /// demonstrated in the following example:
         ///
         /// ```
         /// # futures::executor::block_on(async {

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -8,8 +8,15 @@ macro_rules! document_select_macro {
     ($item:item) => {
         /// Polls multiple futures and streams simultaneously, executing the branch
         /// for the future that finishes first. If multiple futures are ready,
-        /// one will be pseudo-randomly selected at runtime. Futures passed to
-        /// `select!` must be `Unpin` and implement `FusedFuture`.
+        /// one will be pseudo-randomly selected at runtime. Futures directly
+        /// passed to `select!` must be `Unpin` and implement `FusedFuture`.
+        ///
+        /// If an expression which yields a `Future` is passed to `select!`
+        /// (e.g. an `async fn` call) instead of a `Future` directly the `Unpin`
+        /// requirement is relaxed, since the macro will pin the resulting `Future`
+        /// on the stack. However the `Future` returned by the expression must
+        /// still implement `FusedFuture`.
+        ///
         /// Futures and streams which are not already fused can be fused using the
         /// `.fuse()` method. Note, though, that fusing a future or stream directly
         /// in the call to `select!` will not be enough to prevent it from being

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -162,6 +162,25 @@ fn select_size() {
 }
 
 #[test]
+fn select_on_non_unpin_expressions() {
+    // The returned Future is !Unpin
+    let make_non_unpin_fut = || { async {
+        5
+    }};
+
+    let res = block_on(async {
+        let select_res;
+        select! {
+            value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
+            value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
+            default => { select_res = 7 },
+        };
+        select_res
+    });
+    assert_eq!(res, 5);
+}
+
+#[test]
 fn join_size() {
     let fut = async {
         let ready = future::ready(0i32);

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -3,9 +3,10 @@
 use futures::{Poll, pending, pin_mut, poll, join, try_join, select};
 use futures::channel::{mpsc, oneshot};
 use futures::executor::block_on;
-use futures::future::{self, FutureExt};
+use futures::future::{self, FutureExt, poll_fn};
 use futures::stream::StreamExt;
 use futures::sink::SinkExt;
+use futures::task::Context;
 
 #[test]
 fn poll_and_pending() {
@@ -178,6 +179,78 @@ fn select_on_non_unpin_expressions() {
         select_res
     });
     assert_eq!(res, 5);
+}
+
+#[test]
+fn select_can_be_used_as_expression() {
+    block_on(async {
+        let res = select! {
+            x = future::ready(7) => { x },
+            y = future::ready(3) => { y + 1 },
+        };
+        assert!(res == 7 || res == 4);
+    });
+}
+
+#[test]
+fn select_with_default_can_be_used_as_expression() {
+    fn poll_always_pending<T>(_cx: &mut Context<'_>) -> Poll<T> {
+        Poll::Pending
+    }
+
+    block_on(async {
+        let res = select! {
+            x = poll_fn(poll_always_pending::<i32>).fuse() => x,
+            y = poll_fn(poll_always_pending::<i32>).fuse() => { y + 1 },
+            default => 99,
+        };
+        assert_eq!(res, 99);
+    });
+}
+
+#[test]
+fn select_with_complete_can_be_used_as_expression() {
+    block_on(async {
+        let res = select! {
+            x = future::pending::<i32>() => { x },
+            y = future::pending::<i32>() => { y + 1 },
+            default => 99,
+            complete => 237,
+        };
+        assert_eq!(res, 237);
+    });
+}
+
+async fn require_mutable(_: &mut i32) {}
+async fn async_noop() {}
+
+#[test]
+fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
+    block_on(async {
+        let mut foo = 234;
+        select! {
+            x = require_mutable(&mut foo).fuse() => { },
+            y = async_noop().fuse() => {
+                foo += 5;
+            },
+        }
+    });
+}
+
+#[test]
+fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
+    block_on(async {
+        let mut foo = 234;
+        select! {
+            x = require_mutable(&mut foo).fuse() => { },
+            y = async_noop().fuse() => {
+                foo += 5;
+            },
+            default => {
+                foo += 27;
+            },
+        }
+    });
 }
 
 #[test]

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -174,11 +174,48 @@ fn select_on_non_unpin_expressions() {
         select! {
             value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
             value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
+        };
+        select_res
+    });
+    assert_eq!(res, 5);
+}
+
+#[test]
+fn select_on_non_unpin_expressions_with_default() {
+    // The returned Future is !Unpin
+    let make_non_unpin_fut = || { async {
+        5
+    }};
+
+    let res = block_on(async {
+        let select_res;
+        select! {
+            value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
+            value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
             default => { select_res = 7 },
         };
         select_res
     });
     assert_eq!(res, 5);
+}
+
+#[test]
+fn select_on_non_unpin_size() {
+    // The returned Future is !Unpin
+    let make_non_unpin_fut = || { async {
+        5
+    }};
+
+    let fut = async {
+        let select_res;
+        select! {
+            value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
+            value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
+        };
+        select_res
+    };
+
+    assert_eq!(48, std::mem::size_of_val(&fut));
 }
 
 #[test]


### PR DESCRIPTION
Improve support for mutable borrows in select! blocks  …
As reported in #1811 mutable accesses were not allowed inside select!
blocks if a Future inside the same expression borrowed it. This is not
necessarily required, since the actual polling of the Futures occurs
before the result blocks are evaluated.

This change allows borrowing a variable inside a Future and referring to
the same variable inside other select branches. The change introduces
additional scoping into the select macro which separates the future poll
phase from executing the result blocks phase.

Fixes #1811