### PR TITLE
Use docs.rs as default documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures/">
+  <a href="https://docs.rs/futures-preview/">
     Documentation
   </a> | <a href="https://rust-lang-nursery.github.io/futures-rs/">
     Website

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_channel"
+documentation = "https://docs.rs/futures-channel-preview/0.3.0-alpha.19"
 description = """
 Channels for asynchronous communication using futures-rs.
 """

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -17,7 +17,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_channel")]
+#![doc(html_root_url = "https://docs.rs/futures-channel-preview/0.3.0-alpha.19")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_core"
+documentation = "https://docs.rs/futures-core-preview/0.3.0-alpha.19"
 description = """
 The core traits and types in for the `futures` library.
 """

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_core")]
+#![doc(html_root_url = "https://docs.rs/futures-core-preview/0.3.0-alpha.19")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_executor"
+documentation = "https://docs.rs/futures-executor-preview/0.3.0-alpha.19"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_executor")]
+#![doc(html_root_url = "https://docs.rs/futures-executor-preview/0.3.0-alpha.19")]
 
 #[cfg(feature = "std")]
 mod local_pool;

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_io"
+documentation = "https://docs.rs/futures-io-preview/0.3.0-alpha.19"
 description = """
 The `AsyncRead` and `AsyncWrite` traits for the futures-rs library.
 """

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -19,7 +19,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_io")]
+#![doc(html_root_url = "https://docs.rs/futures-io-preview/0.3.0-alpha.19")]
 
 #[cfg(all(feature = "read_initializer", not(feature = "unstable")))]
 compile_error!("The `read_initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures-join-macro/Cargo.toml
+++ b/futures-join-macro/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_join_macro"
+documentation = "https://docs.rs/futures-join-macro-preview/0.3.0-alpha.19"
 description = """
 Definition of the `join!` macro and the `try_join!` macro.
 """

--- a/futures-join-macro/src/lib.rs
+++ b/futures-join-macro/src/lib.rs
@@ -6,6 +6,10 @@
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
+#![doc(html_root_url = "https://docs.rs/futures-join-macro-preview/0.3.0-alpha.19")]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/futures-select-macro/Cargo.toml
+++ b/futures-select-macro/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Taylor Cramer <cramertj@google.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_select_macro"
+documentation = "https://docs.rs/futures-select-macro-preview/0.3.0-alpha.19"
 description = """
 The `select!` macro for waiting on multiple different `Future`s at once and handling the first one to complete.
 """

--- a/futures-select-macro/src/lib.rs
+++ b/futures-select-macro/src/lib.rs
@@ -6,6 +6,10 @@
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 
+#![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
+
+#![doc(html_root_url = "https://docs.rs/futures-select-macro-preview/0.3.0-alpha.19")]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_sink"
+documentation = "https://docs.rs/futures-sink-preview/0.3.0-alpha.19"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -11,7 +11,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_sink")]
+#![doc(html_root_url = "https://docs.rs/futures-sink-preview/0.3.0-alpha.19")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-doc/0.3.0-alpha.12/futures_test"
+documentation = "https://docs.rs/futures-test-preview/0.3.0-alpha.19"
 description = """
 Common utilities for testing components built off futures-rs.
 """

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_test")]
+#![doc(html_root_url = "https://docs.rs/futures-test-preview/0.3.0-alpha.19")]
 
 #[cfg(not(feature = "std"))]
 compile_error!("`futures-test` must have the `std` feature activated, this is a default-active feature");

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_util"
+documentation = "https://docs.rs/futures-util-preview/0.3.0-alpha.19"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures_util")]
+#![doc(html_root_url = "https://docs.rs/futures-util-preview/0.3.0-alpha.19")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang-nursery/futures-rs"
 homepage = "https://rust-lang-nursery.github.io/futures-rs"
-documentation = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures"
+documentation = "https://docs.rs/futures-preview/0.3.0-alpha.19"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -33,7 +33,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.19/futures")]
+#![doc(html_root_url = "https://docs.rs/futures-preview/0.3.0-alpha.19")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");


### PR DESCRIPTION
[docs-rs uses the latest nightly since September 30th](https://blog.rust-lang.org/2019/09/18/upcoming-docsrs-changes.html), so I think the problem has been resolved.

cc #1637

Closes #1105

cc @cramertj @Nemo157 
