### PR TITLE
Remove publishing of docs on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,34 +183,12 @@ matrix:
       script:
         - RUSTDOCFLAGS=-Dwarnings cargo doc --all --no-deps --all-features
 
-    - name: publish docs
-      stage: release
-      rust: nightly
-      before_script:
-        - echo "machine github.com login $GH_TOKEN password x-oauth-basic" >> ~/.netrc
-        - chmod 0600 ~/.netrc
-        - git clone https://github.com/rust-lang-nursery/futures-api-docs
-      script:
-        - cargo doc --all --no-deps --all-features
-        - mv target/doc "futures-api-docs/$TRAVIS_TAG"
-        - cd futures-api-docs
-        - |
-          sed -i'' -e '/<main id="doc-links">/a\
-          \        <a href="https://rust-lang-nursery.github.io/futures-api-docs/'"$TRAVIS_TAG"'/futures/">\
-          \          <span>'"$TRAVIS_TAG"'</span>\
-          \        </a>\
-          ' index.html
-        - git add "$TRAVIS_TAG" index.html
-        - git commit -m "Add API docs for $TRAVIS_TAG"
-        - git push origin master
-
 script:
   - cargo test --all --all-features
   - cargo test --all --all-features --release
 
 env:
   global:
-    - secure: "iwVcMVIF7ZSY82fK5UyyUvVvJxMSYrbZawh1+4Oi8pvOdYq1gptcDoOC8jxWwCwrNF1b+/85n+jlEUngEqqSmV5PjAbWPjoc+u4Zn7CRi1AlxoUlvHPiQm4vM4Mkkd6GsqoIZttCeedU9m/w0nQ18uUtK8uD6vr2FVdcMnUnkYQAxuGOowGLrwidukzfBXMCu/JrwKMIbt61knAFiI/KJknu0h1mRrhpeF/sQ3tJFzRRcQeFJkbfwDzltMpPo1hq5D3HI4ONjYi/qO2pwUhDk4umfp9cLW9MS8rQvptxJTQmWemHi+f2/U4ld6a0URL6kEuMkt/EbH0A74eFtlicfRs44dX9MlWoqbLypnC3ymqmHcpwcwNA3HmZyg800MTuU+BPK41HIPdO9tPpxjHEiqvNDknH7qs+YBnis0eH7DHJgEjXq651PjW7pm+rnHPwsj+OzKE1YBNxBQZZDkS3VnZJz+O4tVsOzc3IOz0e+lf7VVuI17C9haj117nKp3umC4MVBA0S8RfreFgqpyDeY2zwcqOr0YOlEGGRl0vyWP8Qcxx12kQ7+doLolt6Kxda4uO0hKRmIF6+qki1T+L7v8BOGOtCncz4f7IX48eQ7+Wu0OtglRn45qAa3CxjUuW6xX3KSNH66PCXV0Jtp8Ga2SSevX2wtbbFu9f+9R+PQY4="
     - RUSTFLAGS=-Dwarnings
 
 notifications:


### PR DESCRIPTION
As mentioned in #1898 this is currently broken because the auth token is no longer valid, with the changes in #1895 there's no need to really publish these docs here so instead of fixing the token just remove the job.