### PR TITLE
Add panic message to select_ok

### DIFF
--- a/futures-util/src/try_future/select_ok.rs
+++ b/futures-util/src/try_future/select_ok.rs
@@ -35,7 +35,7 @@ pub fn select_ok<I>(iter: I) -> SelectOk<I::Item>
     let ret = SelectOk {
         inner: iter.into_iter().collect()
     };
-    assert!(!ret.inner.is_empty());
+    assert!(!ret.inner.is_empty(), "iterator provided to select_ok was empty");
     ret
 }
 


### PR DESCRIPTION
Came across this panic in a runtime situation. Would have found it more useful if it contained a message. That's what I've added. Rather simple.