### PR TITLE
Rename oneshot:Sender::poll_cancel to poll_canceled

### DIFF
--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -12,11 +12,11 @@ fn smoke_poll() {
     let (mut tx, rx) = oneshot::channel::<u32>();
     let mut rx = Some(rx);
     let f = poll_fn(|cx| {
-        assert!(tx.poll_cancel(cx).is_pending());
-        assert!(tx.poll_cancel(cx).is_pending());
+        assert!(tx.poll_canceled(cx).is_pending());
+        assert!(tx.poll_canceled(cx).is_pending());
         drop(rx.take());
-        assert!(tx.poll_cancel(cx).is_ready());
-        assert!(tx.poll_cancel(cx).is_ready());
+        assert!(tx.poll_canceled(cx).is_ready());
+        assert!(tx.poll_canceled(cx).is_ready());
         Poll::Ready(())
     });
 
@@ -42,7 +42,7 @@ impl Future for WaitForCancel {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.tx.poll_cancel(cx)
+        self.tx.poll_canceled(cx)
     }
 }
 
@@ -72,7 +72,7 @@ fn cancel_lots() {
 fn cancel_after_sender_drop_doesnt_notify() {
     let (mut tx, rx) = oneshot::channel::<u32>();
     let mut cx = Context::from_waker(panic_waker_ref());
-    assert_eq!(tx.poll_cancel(&mut cx), Poll::Pending);
+    assert_eq!(tx.poll_canceled(&mut cx), Poll::Pending);
     drop(tx);
     drop(rx);
 }
@@ -86,7 +86,7 @@ fn close() {
             Poll::Ready(Err(_)) => {},
             _ => panic!(),
         };
-        assert!(tx.poll_cancel(cx).is_ready());
+        assert!(tx.poll_canceled(cx).is_ready());
         Poll::Ready(())
     }));
 }

--- a/futures-util/src/future/remote_handle.rs
+++ b/futures-util/src/future/remote_handle.rs
@@ -80,7 +80,7 @@ impl<Fut: Future> Future for Remote<Fut> {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        if let Poll::Ready(_) = self.as_mut().tx().as_mut().unwrap().poll_cancel(cx) {
+        if let Poll::Ready(_) = self.as_mut().tx().as_mut().unwrap().poll_canceled(cx) {
             if !self.keep_running.load(Ordering::SeqCst) {
                 // Cancelled, bail out
                 return Poll::Ready(())

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -81,15 +81,15 @@ fn dropping_ready_queue() {
 
         {
             let cx = &mut noop_context();
-            assert!(!tx1.poll_cancel(cx).is_ready());
-            assert!(!tx2.poll_cancel(cx).is_ready());
-            assert!(!tx3.poll_cancel(cx).is_ready());
+            assert!(!tx1.poll_canceled(cx).is_ready());
+            assert!(!tx2.poll_canceled(cx).is_ready());
+            assert!(!tx3.poll_canceled(cx).is_ready());
 
             drop(queue);
 
-            assert!(tx1.poll_cancel(cx).is_ready());
-            assert!(tx2.poll_cancel(cx).is_ready());
-            assert!(tx3.poll_cancel(cx).is_ready());
+            assert!(tx1.poll_canceled(cx).is_ready());
+            assert!(tx2.poll_canceled(cx).is_ready());
+            assert!(tx3.poll_canceled(cx).is_ready());
         }
     }));
 }


### PR DESCRIPTION
In most other places, `poll_action` means that 'action' is happening
asynchronously. The name `poll_cancel` implies that the call will cancel
the oneshot, but really we just wish to poll if it *has been* canceled.