### PR TITLE
Make ThreadPool optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ matrix:
     - name: cargo build (minimum required version)
       rust: 1.36.0
       script:
-        # default features & compat feature
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
+        # Check default-features
         - cargo build --all
+        # Check compat & threadpool features
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
+        - cargo build --manifest-path futures/Cargo.toml --features threadpool
 
     # This is the minimum Rust version supported by `async-await` feature.
     # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
@@ -31,18 +33,22 @@ matrix:
     - name: cargo +stable build
       rust: stable
       script:
-        # default features & compat feature
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
+        # Check default-features
         - cargo build --all
+        # Check compat & threadpool features
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
+        - cargo build --manifest-path futures/Cargo.toml --features threadpool
 
     - name: cargo +beta build
       rust: beta
       script:
-        # default features & compat feature & async-await feature
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
+        # Check default-features
         - cargo build --all
+        # Check compat & threadpool & async-await features
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
+        - cargo build --manifest-path futures/Cargo.toml --features threadpool
         - cargo build --manifest-path futures/Cargo.toml --features async-await
 
     - name: cargo test
@@ -169,7 +175,7 @@ matrix:
         - cargo check --manifest-path futures-util/Cargo.toml --features io,bilock,unstable
         - cargo check --manifest-path futures-util/Cargo.toml --features sink,io
         - cargo check --manifest-path futures-util/Cargo.toml --features read_initializer,unstable
-
+        # Check each features with --no-default-features
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features --features sink
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features --features alloc,sink
@@ -177,6 +183,13 @@ matrix:
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features --features bilock,unstable
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features --features sink,bilock,unstable
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features --features io,bilock,unstable
+
+        # futures-executor
+        # Check default-features, all-features
+        - cargo check --manifest-path futures-executor/Cargo.toml
+        - cargo check --manifest-path futures-executor/Cargo.toml --all-features
+        # Check each features
+        - cargo check --manifest-path futures-executor/Cargo.toml --features threadpool
 
     - name: cargo doc
       rust: nightly

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -16,7 +16,8 @@ name = "futures_executor"
 
 [features]
 default = ["std"]
-std = ["futures-core-preview/std", "futures-util-preview/std", "num_cpus"]
+std = ["futures-core-preview/std", "futures-util-preview/std"]
+threadpool = ["num_cpus"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.19", default-features = false }

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -19,10 +19,13 @@ mod local_pool;
 #[cfg(feature = "std")]
 pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
 
+#[cfg(feature = "threadpool")]
 #[cfg(feature = "std")]
 mod unpark_mutex;
+#[cfg(feature = "threadpool")]
 #[cfg(feature = "std")]
 mod thread_pool;
+#[cfg(feature = "threadpool")]
 #[cfg(feature = "std")]
 pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -20,11 +20,17 @@ use std::thread;
 ///
 /// This type is a clonable handle to the threadpool itself.
 /// Cloning it will only create a new reference, not a new threadpool.
+///
+/// This type is only available when the `threadpool` feature of this
+/// library is activated.
 pub struct ThreadPool {
     state: Arc<PoolState>,
 }
 
 /// Thread pool configuration object.
+///
+/// This type is only available when the `threadpool` feature of this
+/// library is activated.
 pub struct ThreadPoolBuilder {
     pool_size: usize,
     stack_size: usize,

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -42,6 +42,7 @@ alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-ch
 async-await = ["futures-util-preview/async-await", "futures-util-preview/join-macro", "futures-util-preview/select-macro"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
+threadpool = ["futures-executor-preview/threadpool"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -191,9 +191,11 @@ pub mod executor {
         BlockingStream,
         Enter, EnterError,
         LocalSpawner, LocalPool,
-        ThreadPool, ThreadPoolBuilder,
         block_on, block_on_stream, enter,
     };
+
+    #[cfg(feature = "threadpool")]
+    pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
 }
 
 pub mod future {


### PR DESCRIPTION
This makes `ThreadPool` optional (disabled by default). 
cc #1893 

Closes #1724

r? @cramertj 
cc @seanmonstar