### PR TITLE
Avoid infinite recursion in Debug of MutexGuard

### DIFF
--- a/futures-util/src/lock/mutex.rs
+++ b/futures-util/src/lock/mutex.rs
@@ -246,7 +246,7 @@ pub struct MutexGuard<'a, T: ?Sized> {
 impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MutexGuard")
-            .field("value", &*self)
+            .field("value", &&**self)
             .field("mutex", &self.mutex)
             .finish()
     }
@@ -292,3 +292,10 @@ unsafe impl<T: ?Sized> Sync for MutexLockFuture<'_, T> {}
 // lock is essentially spinlock-equivalent (attempt to flip an atomic bool)
 unsafe impl<T: ?Sized + Send> Send for MutexGuard<'_, T> {}
 unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
+
+#[test]
+fn test_mutex_guard_debug_not_recurse() {
+    let mutex = Mutex::new(42);
+    let guard = mutex.try_lock().unwrap();
+    let _ = format!("{:?}", guard);
+}


### PR DESCRIPTION
```rust
use futures::lock::Mutex;

fn main() {
    let m = Mutex::new(1);
    let g = m.try_lock().unwrap();
    dbg!(&g);
}
```

Current output:
```
[testt/src/main.rs:6] &g = MutexGuard {
    value: MutexGuard {
        value: MutexGuard {
            value: MutexGuard {
                value: MutexGuard {
                    value: MutexGuard {
                        value: MutexGuard {
                            value: MutexGuard {
                                value: MutexGuard {
                                    value: MutexGuard {
                                        value: MutexGuard {
...
```
