### PR TITLE
Fix breakage with cfg-target-has-atomic feature

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -24,10 +24,7 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feat
 
 macro_rules! cfg_target_has_atomic {
     ($($item:item)*) => {$(
-        #[cfg_attr(
-            feature = "cfg-target-has-atomic",
-            cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-        )]
+        #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
         $item
     )*};
 }

--- a/futures-core/src/task/__internal/mod.rs
+++ b/futures-core/src/task/__internal/mod.rs
@@ -1,10 +1,4 @@
-#[cfg_attr(
-    feature = "cfg-target-has-atomic",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 mod atomic_waker;
-#[cfg_attr(
-    feature = "cfg-target-has-atomic",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 pub use self::atomic_waker::AtomicWaker;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -48,10 +48,7 @@ pub use futures_core::core_reexport;
 
 macro_rules! cfg_target_has_atomic {
     ($($item:item)*) => {$(
-        #[cfg_attr(
-            feature = "cfg-target-has-atomic",
-            cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-        )]
+        #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
         $item
     )*};
 }

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -685,10 +685,7 @@ pub trait StreamExt: Stream {
     /// fut.await;
     /// # })
     /// ```
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn for_each_concurrent<Fut, F>(
         self,
@@ -904,10 +901,7 @@ pub trait StreamExt: Stream {
     ///
     /// This method is only available when the `std` or `alloc` feature of this
     /// library is activated, and it is activated by default.
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn buffered(self, n: usize) -> Buffered<Self>
         where Self::Item: Future,
@@ -951,10 +945,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(buffered.next().await, None);
     /// # Ok::<(), i32>(()) }).unwrap();
     /// ```
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn buffer_unordered(self, n: usize) -> BufferUnordered<Self>
         where Self::Item: Future,
@@ -1085,10 +1076,7 @@ pub trait StreamExt: Stream {
     /// This method is only available when the `std` or `alloc` feature of this
     /// library is activated, and it is activated by default.
     #[cfg(feature = "sink")]
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn split<Item>(self) -> (SplitSink<Self, Item>, SplitStream<Self>)
         where Self: Sink<Item> + Sized

--- a/futures-util/src/try_stream/mod.rs
+++ b/futures-util/src/try_stream/mod.rs
@@ -420,10 +420,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(Err(oneshot::Canceled), fut.await);
     /// # })
     /// ```
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn try_for_each_concurrent<Fut, F>(
         self,
@@ -732,10 +729,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(buffered.next().await, Some(Err("error in the stream")));
     /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn try_buffer_unordered(self, n: usize) -> TryBufferUnordered<Self>
         where Self::Ok: TryFuture<Error = Self::Error>,

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -75,10 +75,7 @@ pub use futures_util::pin_mut;
 #[cfg(feature = "async-await")]
 pub use futures_util::{pending, poll}; // Async-await
 
-#[cfg_attr(
-    feature = "cfg-target-has-atomic",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]
 pub mod channel {
     //! Cross-task communication.
@@ -243,10 +240,7 @@ pub mod future {
         select_all, SelectAll,
     };
 
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     pub use futures_util::future::{
         abortable, Abortable, AbortHandle, AbortRegistration, Aborted,
@@ -319,10 +313,7 @@ pub mod io {
     };
 }
 
-#[cfg_attr(
-    feature = "cfg-target-has-atomic",
-    cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-)]
+#[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]
 pub mod lock {
     //! Futures-powered synchronization primitives.
@@ -438,10 +429,7 @@ pub mod stream {
         Chunks,
     };
 
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     pub use futures_util::stream::{
         FuturesOrdered,
@@ -469,10 +457,7 @@ pub mod stream {
         IntoStream,
     };
 
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     pub use futures_util::try_stream::{
         // For TryStreamExt:
@@ -509,17 +494,11 @@ pub mod task {
     #[cfg(feature = "alloc")]
     pub use futures_util::task::{SpawnExt, LocalSpawnExt};
 
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     pub use futures_util::task::{waker, waker_ref, WakerRef, ArcWake};
 
-    #[cfg_attr(
-        feature = "cfg-target-has-atomic",
-        cfg(all(target_has_atomic = "cas", target_has_atomic = "ptr"))
-    )]
+    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     pub use futures_util::task::AtomicWaker;
 }
 


### PR DESCRIPTION
`target_has_atomic = "cas"` was removed in https://github.com/rust-lang/rust/pull/65214.