### PR TITLE
Derive Clone on SinkMapErr

### DIFF
--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -5,7 +5,7 @@ use futures_sink::{Sink};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Sink for the [`sink_map_err`](super::SinkExt::sink_map_err) method.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct SinkMapErr<Si, F> {
     sink: Si,


### PR DESCRIPTION
Using a channel, one could consider:

```rust
let (sink, stream) = mpsc::unbounded();
let mut sink = sink.clone().sink_map_err(|_| {
    io::Error::new(io::ErrorKind::BrokenPipe, "Message aggregate stopped")
})
```

... and try to use the `sink` in multiple producers. However, SinkMapErr does not implement `Clone`, even if both the closure and the `Sink` do.

This commit adds `derive(Clone)` to SinkMapErr.