### PR TITLE
#[derive(Clone)] for Pending.

### DIFF
--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -4,7 +4,7 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 
 /// Future for the [`pending()`] function.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Pending<T> {
     _data: marker::PhantomData<T>,

--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -4,7 +4,7 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 
 /// Future for the [`pending()`] function.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Pending<T> {
     _data: marker::PhantomData<T>,
@@ -47,4 +47,10 @@ impl<T> Future for Pending<T> {
 }
 
 impl<T> Unpin for Pending<T> {
+}
+
+impl<T> Clone for Pending<T> {
+    fn clone(&self) -> Self {
+        pending()
+    }
 }


### PR DESCRIPTION
## Description
Make `futures::future::Pending<T>` implement `Clone`.

## Motivation
I am writing a program that uses tokio-timer's `Delay` in a loop to asynchronously sleep for a long time, e.g. 5 minutes. If my program receives a shutdown signal I want to interrupt the sleep early and exit the loop. My plan for doing so was to use the `Abortable` future support from this crate to propagate the shutdown signal.

My loop would basically look like this:
```rust
let (shutdown_future, shutdown_handle) = abortable(pending::<()>());
while let Either::Right(_) = select(shutdown_future, tokio::timer::delay_for(FIVE_MINUTES)).await {
    // Do work
}
// Then in some signal handler I could trigger graceful shutdown.
when_shutdown_signal_received(move || {
    shutdown_handle.abort();
});
```

The only problem is that I am running this loop on multiple threads, so `Abortable<Pending<()>>` needs to be Send, Sync, and Clone. `Abortable` is all three already and `Pending` is Send + Sync, but not Clone. I worked around this by writing my own `Pending` struct that is Clone, but I'd prefer to use the one from futures-util.

## Alternatives
An alternative to this PR would be if there is a simpler preexisting way of accomplishing my goal above that I don't know about. I tried to use the `oneshot` channel, but the `Receiver` is not Clone, which I think makes sense given that its a single-consumer channel.