### PR TITLE
Rename Peekable::peek to poll_peek

### DIFF
--- a/futures-util/src/stream/peek.rs
+++ b/futures-util/src/stream/peek.rs
@@ -67,7 +67,7 @@ impl<St: Stream> Peekable<St> {
     ///
     /// This method polls the underlying stream and return either a reference
     /// to the next item if the stream is ready or passes through any errors.
-    pub fn peek(
+    pub fn poll_peek(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<&St::Item>> {


### PR DESCRIPTION
I'm not sure if #1871 can be done in the period up to 0.3 release. but I don't want #1871 to be a breaking change. 