### PR TITLE
Since LocalFutureObj implements Unpin, this code can be simplified.

### DIFF
--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -19,6 +19,9 @@ pub struct LocalFutureObj<'a, T> {
     _marker: PhantomData<&'a ()>,
 }
 
+// As LocalFutureObj only holds pointers, even if we move it, the pointed to values won't move,
+// so this is safe as long as we don't provide any way for a user to directly access the pointers
+// and move their values.
 impl<T> Unpin for LocalFutureObj<'_, T> {}
 
 #[allow(single_use_lifetimes)]

--- a/futures-core/src/future/future_obj.rs
+++ b/futures-core/src/future/future_obj.rs
@@ -127,11 +127,8 @@ impl<T> Future for FutureObj<'_, T> {
     type Output = T;
 
     #[inline]
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        let pinned_field: Pin<&mut LocalFutureObj<'_, T>> = unsafe {
-            self.map_unchecked_mut(|x| &mut x.0)
-        };
-        LocalFutureObj::poll(pinned_field, cx)
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        Pin::new( &mut self.0 ).poll(cx)
     }
 }
 


### PR DESCRIPTION
Removes some code and an unsafe block.

Follow up from: https://users.rust-lang.org/t/question-about-some-pinning-code-in-futures-rs/34104