### PR TITLE
Replace u64 with usize

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -719,7 +719,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(vec![1, 2, 3], stream.collect::<Vec<_>>().await);
     /// # });
     /// ```
-    fn take(self, n: u64) -> Take<Self>
+    fn take(self, n: usize) -> Take<Self>
     where
         Self: Sized,
     {
@@ -742,7 +742,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(vec![6, 7, 8, 9, 10], stream.collect::<Vec<_>>().await);
     /// # });
     /// ```
-    fn skip(self, n: u64) -> Skip<Self>
+    fn skip(self, n: usize) -> Skip<Self>
     where
         Self: Sized,
     {

--- a/futures-util/src/stream/stream/skip.rs
+++ b/futures-util/src/stream/stream/skip.rs
@@ -10,16 +10,16 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 #[must_use = "streams do nothing unless polled"]
 pub struct Skip<St> {
     stream: St,
-    remaining: u64,
+    remaining: usize,
 }
 
 impl<St: Unpin> Unpin for Skip<St> {}
 
 impl<St: Stream> Skip<St> {
     unsafe_pinned!(stream: St);
-    unsafe_unpinned!(remaining: u64);
+    unsafe_unpinned!(remaining: usize);
 
-    pub(super) fn new(stream: St, n: u64) -> Skip<St> {
+    pub(super) fn new(stream: St, n: usize) -> Skip<St> {
         Skip {
             stream,
             remaining: n,

--- a/futures-util/src/stream/stream/take.rs
+++ b/futures-util/src/stream/stream/take.rs
@@ -11,16 +11,16 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 #[must_use = "streams do nothing unless polled"]
 pub struct Take<St> {
     stream: St,
-    remaining: u64,
+    remaining: usize,
 }
 
 impl<St: Unpin> Unpin for Take<St> {}
 
 impl<St: Stream> Take<St> {
     unsafe_pinned!(stream: St);
-    unsafe_unpinned!(remaining: u64);
+    unsafe_unpinned!(remaining: usize);
 
-    pub(super) fn new(stream: St, n: u64) -> Take<St> {
+    pub(super) fn new(stream: St, n: usize) -> Take<St> {
         Take {
             stream,
             remaining: n,


### PR DESCRIPTION
I find that `take` and `skip` in std's iterator are using usize rather than u64.
```rust
fn skip(self, n: usize) -> Skip<Self>
where
    Self: Sized, 
```
Is there needed to alter them?