### PR TITLE
improve comments and relax one cmpxch in AtomicWaker

### DIFF
--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -268,15 +268,18 @@ impl AtomicWaker {
                     // Release the lock. If the state transitioned to include
                     // the `WAKING` bit, this means that at least one wake has
                     // been called concurrently.
-                    //
+                    // 
                     // Start by assuming that the state is `REGISTERING` as this
-                    // is what we jut set it to.
+                    // is what we just set it to. If this holds, we know that no
+                    // other writes were performed in the meantime, so there is
+                    // nothing to acquire, but release the update. In case of
+                    // concurrent wakers, we need to acquire their releases.
                     let res = self.state.compare_exchange(
-                        REGISTERING, WAITING, AcqRel, Acquire);
+                        REGISTERING, WAITING, Release, Acquire);
 
                     match res {
                         Ok(_) => {
-                            // memory ordering: acquired self.state
+                            // memory ordering: acquired self.state during CAS
                             // - if previous wakes went through it syncs with
                             //   their final release (`fetch_and`)
                             // - if there was no previous wake the next wake
@@ -293,7 +296,10 @@ impl AtomicWaker {
                             // completed.
                             let waker = (*self.waker.get()).take().unwrap();
 
-                            // Just swap, because no one could change state while state == `REGISTERING` | `WAKING`.
+                            // We need to return to WAITING state (clear our lock and
+                            // concurrent WAKING flag). This needs to acquire all
+                            // WAKING fetch_or releases and it needs to release our
+                            // update to self.waker, so we need a `swap` operation.
                             self.state.swap(WAITING, AcqRel);
 
                             // memory ordering: we acquired the state for all

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -268,14 +268,15 @@ impl AtomicWaker {
                     // Release the lock. If the state transitioned to include
                     // the `WAKING` bit, this means that at least one wake has
                     // been called concurrently.
-                    // 
+                    //
                     // Start by assuming that the state is `REGISTERING` as this
                     // is what we just set it to. If this holds, we know that no
                     // other writes were performed in the meantime, so there is
-                    // nothing to acquire, but release the update. In case of
-                    // concurrent wakers, we need to acquire their releases.
+                    // nothing to acquire, only release. In case of concurrent
+                    // wakers, we need to acquire their releases, so success needs
+                    // to do both.
                     let res = self.state.compare_exchange(
-                        REGISTERING, WAITING, Release, Acquire);
+                        REGISTERING, WAITING, AcqRel, Acquire);
 
                     match res {
                         Ok(_) => {


### PR DESCRIPTION
While reading AtomicWaker I stumbled over some comments that were pointing slightly off path, so I’m offering potential improvements in case my understanding of the code is correct.

Caveat emptor: I have only reasoned about the code, not tested it. If such code-based discussion is not common in the Rust community then please let me know where I should raise this point instead. I’m looking forward to learning from your responses!