### PR TITLE
Unify case convention for feature names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         # Check default-features
         - cargo build --all
-        # Check compat & threadpool features
+        # Check compat & thread-pool features
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
-        - cargo build --manifest-path futures/Cargo.toml --features threadpool
+        - cargo build --manifest-path futures/Cargo.toml --features thread-pool
 
     # This is the minimum Rust version supported by `async-await` feature.
     # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
@@ -36,9 +36,9 @@ matrix:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         # Check default-features
         - cargo build --all
-        # Check compat & threadpool features
+        # Check compat & thread-pool features
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
-        - cargo build --manifest-path futures/Cargo.toml --features threadpool
+        - cargo build --manifest-path futures/Cargo.toml --features thread-pool
 
     - name: cargo +beta build
       rust: beta
@@ -46,9 +46,9 @@ matrix:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         # Check default-features
         - cargo build --all
-        # Check compat & threadpool & async-await features
+        # Check compat & thread-pool & async-await features
         - cargo build --manifest-path futures/Cargo.toml --features io-compat
-        - cargo build --manifest-path futures/Cargo.toml --features threadpool
+        - cargo build --manifest-path futures/Cargo.toml --features thread-pool
         - cargo build --manifest-path futures/Cargo.toml --features async-await
 
     - name: cargo test
@@ -153,7 +153,7 @@ matrix:
         - cargo check --manifest-path futures-io/Cargo.toml
         - cargo check --manifest-path futures-io/Cargo.toml --all-features
         # Check each features
-        - cargo check --manifest-path futures-io/Cargo.toml --features read_initializer,unstable
+        - cargo check --manifest-path futures-io/Cargo.toml --features read-initializer,unstable
 
         # futures-util
         # Check default-features, all-features
@@ -173,7 +173,7 @@ matrix:
         - cargo check --manifest-path futures-util/Cargo.toml --features sink,bilock,unstable
         - cargo check --manifest-path futures-util/Cargo.toml --features io,bilock,unstable
         - cargo check --manifest-path futures-util/Cargo.toml --features sink,io
-        - cargo check --manifest-path futures-util/Cargo.toml --features read_initializer,unstable
+        - cargo check --manifest-path futures-util/Cargo.toml --features read-initializer,unstable
         # Check each features with --no-default-features
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features
         - cargo check --manifest-path futures-util/Cargo.toml --no-default-features --features sink
@@ -188,7 +188,7 @@ matrix:
         - cargo check --manifest-path futures-executor/Cargo.toml
         - cargo check --manifest-path futures-executor/Cargo.toml --all-features
         # Check each features
-        - cargo check --manifest-path futures-executor/Cargo.toml --features threadpool
+        - cargo check --manifest-path futures-executor/Cargo.toml --features thread-pool
 
     - name: cargo doc
       rust: nightly

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -17,7 +17,7 @@ name = "futures_executor"
 [features]
 default = ["std"]
 std = ["futures-core-preview/std", "futures-util-preview/std"]
-threadpool = ["num_cpus"]
+thread-pool = ["num_cpus"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.19", default-features = false }

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -19,13 +19,13 @@ mod local_pool;
 #[cfg(feature = "std")]
 pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
 
-#[cfg(feature = "threadpool")]
+#[cfg(feature = "thread-pool")]
 #[cfg(feature = "std")]
 mod unpark_mutex;
-#[cfg(feature = "threadpool")]
+#[cfg(feature = "thread-pool")]
 #[cfg(feature = "std")]
 mod thread_pool;
-#[cfg(feature = "threadpool")]
+#[cfg(feature = "thread-pool")]
 #[cfg(feature = "std")]
 pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -21,7 +21,7 @@ use std::thread;
 /// This type is a clonable handle to the threadpool itself.
 /// Cloning it will only create a new reference, not a new threadpool.
 ///
-/// This type is only available when the `threadpool` feature of this
+/// This type is only available when the `thread-pool` feature of this
 /// library is activated.
 pub struct ThreadPool {
     state: Arc<PoolState>,
@@ -29,7 +29,7 @@ pub struct ThreadPool {
 
 /// Thread pool configuration object.
 ///
-/// This type is only available when the `threadpool` feature of this
+/// This type is only available when the `thread-pool` feature of this
 /// library is activated.
 pub struct ThreadPoolBuilder {
     pool_size: usize,

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -22,6 +22,6 @@ std = []
 # These features are outside of the normal semver guarantees and require the
 # `unstable` feature as an explicit opt-in to unstable API.
 unstable = []
-read_initializer = []
+read-initializer = []
 
 [dependencies]

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -8,7 +8,7 @@
 //! All items of this library are only available when the `std` feature of this
 //! library is activated, and it is activated by default.
 
-#![cfg_attr(feature = "read_initializer", feature(read_initializer))]
+#![cfg_attr(feature = "read-initializer", feature(read_initializer))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -21,8 +21,8 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-io-preview/0.3.0-alpha.19")]
 
-#[cfg(all(feature = "read_initializer", not(feature = "unstable")))]
-compile_error!("The `read_initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
+#[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
+compile_error!("The `read-initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
 #[cfg(feature = "std")]
 mod if_std {
@@ -44,7 +44,7 @@ mod if_std {
         SeekFrom as SeekFrom,
     };
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
     pub use io::Initializer as Initializer;
 
@@ -67,7 +67,7 @@ mod if_std {
         /// This method is `unsafe` because and `AsyncRead`er could otherwise
         /// return a non-zeroing `Initializer` from another `AsyncRead` type
         /// without an `unsafe` block.
-        #[cfg(feature = "read_initializer")]
+        #[cfg(feature = "read-initializer")]
         #[inline]
         unsafe fn initializer(&self) -> Initializer {
             Initializer::zeroing()
@@ -311,7 +311,7 @@ mod if_std {
 
     macro_rules! deref_async_read {
         () => {
-            #[cfg(feature = "read_initializer")]
+            #[cfg(feature = "read-initializer")]
             unsafe fn initializer(&self) -> Initializer {
                 (**self).initializer()
             }
@@ -343,7 +343,7 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncRead,
     {
-        #[cfg(feature = "read_initializer")]
+        #[cfg(feature = "read-initializer")]
         unsafe fn initializer(&self) -> Initializer {
             (**self).initializer()
         }
@@ -363,7 +363,7 @@ mod if_std {
 
     macro_rules! delegate_async_read_to_stdio {
         () => {
-            #[cfg(feature = "read_initializer")]
+            #[cfg(feature = "read-initializer")]
             unsafe fn initializer(&self) -> Initializer {
                 io::Read::initializer(self)
             }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -32,7 +32,7 @@ channel = ["std", "futures-channel-preview"]
 unstable = ["futures-core-preview/unstable"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic"]
 bilock = []
-read_initializer = ["io", "futures-io-preview/read_initializer", "futures-io-preview/unstable"]
+read-initializer = ["io", "futures-io-preview/read-initializer", "futures-io-preview/unstable"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.19", default-features = false }

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -368,7 +368,7 @@ unsafe impl UnsafeNotify01 for NotifyWaker {
 #[cfg(feature = "io-compat")]
 mod io {
     use super::*;
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     use futures_io::Initializer;
     use futures_io::{AsyncRead as AsyncRead03, AsyncWrite as AsyncWrite03};
     use std::io::Error;
@@ -433,7 +433,7 @@ mod io {
     impl<W: AsyncWrite01> AsyncWrite01CompatExt for W {}
 
     impl<R: AsyncRead01> AsyncRead03 for Compat01As03<R> {
-        #[cfg(feature = "read_initializer")]
+        #[cfg(feature = "read-initializer")]
         unsafe fn initializer(&self) -> Initializer {
             // check if `prepare_uninitialized_buffer` needs zeroing
             if self.inner.get_ref().prepare_uninitialized_buffer(&mut [1]) {

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -262,7 +262,7 @@ mod io {
     }
 
     impl<R: AsyncRead03 + Unpin> AsyncRead01 for Compat<R> {
-        #[cfg(feature = "read_initializer")]
+        #[cfg(feature = "read-initializer")]
         unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
             let initializer = self.inner.initializer();
             let does_init = initializer.should_initialize();

--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -160,7 +160,7 @@ mod if_std {
     use super::Either;
     use core::pin::Pin;
     use core::task::{Context, Poll};
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     use futures_io::Initializer;
     use futures_io::{
         AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSlice, IoSliceMut, Result, SeekFrom,
@@ -171,7 +171,7 @@ mod if_std {
         A: AsyncRead,
         B: AsyncRead,
     {
-        #[cfg(feature = "read_initializer")]
+        #[cfg(feature = "read-initializer")]
         unsafe fn initializer(&self) -> Initializer {
             match self {
                 Either::Left(x) => x.initializer(),

--- a/futures-util/src/io/allow_std.rs
+++ b/futures-util/src/io/allow_std.rs
@@ -1,5 +1,5 @@
 use futures_core::task::{Context, Poll};
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, IoSlice, IoSliceMut, SeekFrom};
 use std::{fmt, io};
@@ -108,7 +108,7 @@ impl<T> io::Read for AllowStdIo<T> where T: io::Read {
     fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
         self.0.read_vectored(bufs)
     }
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     unsafe fn initializer(&self) -> Initializer {
         self.0.initializer()
     }
@@ -136,7 +136,7 @@ impl<T> AsyncRead for AllowStdIo<T> where T: io::Read {
         Poll::Ready(Ok(try_with_interrupt!(self.0.read_vectored(bufs))))
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     unsafe fn initializer(&self) -> Initializer {
         self.0.initializer()
     }

--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -1,5 +1,5 @@
 use futures_core::task::{Context, Poll};
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, IoSliceMut, SeekFrom};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -168,7 +168,7 @@ impl<R: AsyncRead> AsyncRead for BufReader<R> {
     }
 
     // we can't skip unconditionally because of the large buffer case in read.
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()
     }

--- a/futures-util/src/io/chain.rs
+++ b/futures-util/src/io/chain.rs
@@ -1,5 +1,5 @@
 use futures_core::task::{Context, Poll};
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncBufRead, AsyncRead, IoSliceMut};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -119,7 +119,7 @@ where
         self.second().poll_read_vectored(cx, bufs)
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     unsafe fn initializer(&self) -> Initializer {
         let initializer = self.first.initializer();
         if initializer.should_initialize() {

--- a/futures-util/src/io/empty.rs
+++ b/futures-util/src/io/empty.rs
@@ -1,5 +1,5 @@
 use futures_core::task::{Context, Poll};
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncBufRead, AsyncRead};
 use std::fmt;
@@ -44,7 +44,7 @@ impl AsyncRead for Empty {
         Poll::Ready(Ok(0))
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -17,7 +17,7 @@ pub use futures_io::{
     AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, Error, ErrorKind,
     IoSlice, IoSliceMut, Result, SeekFrom,
 };
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 pub use futures_io::Initializer;
 
 // used by `BufReader` and `BufWriter`
@@ -26,10 +26,10 @@ const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
 /// Initializes a buffer if necessary.
 ///
-/// A buffer is always initialized if `read_initializer` feature is disabled.
+/// A buffer is always initialized if `read-initializer` feature is disabled.
 #[inline]
 unsafe fn initialize<R: AsyncRead>(_reader: &R, buf: &mut [u8]) {
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     {
         if !_reader.initializer().should_initialize() {
             return;

--- a/futures-util/src/io/repeat.rs
+++ b/futures-util/src/io/repeat.rs
@@ -1,5 +1,5 @@
 use futures_core::task::{Context, Poll};
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncRead, IoSliceMut};
 use std::fmt;
@@ -59,7 +59,7 @@ impl AsyncRead for Repeat {
         Poll::Ready(Ok(nwritten))
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     #[inline]
     unsafe fn initializer(&self) -> Initializer {
         Initializer::nop()

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -1,5 +1,5 @@
 use futures_core::task::{Context, Poll};
-#[cfg(feature = "read_initializer")]
+#[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncRead, AsyncBufRead};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -185,7 +185,7 @@ impl<R: AsyncRead> AsyncRead for Take<R> {
         Poll::Ready(Ok(n))
     }
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     unsafe fn initializer(&self) -> Initializer {
         self.inner.initializer()
     }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -2,7 +2,7 @@
 //! and the `AsyncRead` and `AsyncWrite` traits.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(feature = "read_initializer", feature(read_initializer))]
+#![cfg_attr(feature = "read-initializer", feature(read_initializer))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
@@ -20,8 +20,8 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feat
 #[cfg(all(feature = "bilock", not(feature = "unstable")))]
 compile_error!("The `bilock` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
-#[cfg(all(feature = "read_initializer", not(feature = "unstable")))]
-compile_error!("The `read_initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
+#[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
+compile_error!("The `read-initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -42,7 +42,7 @@ alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-ch
 async-await = ["futures-util-preview/async-await", "futures-util-preview/async-await-macro"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
-threadpool = ["futures-executor-preview/threadpool"]
+thread-pool = ["futures-executor-preview/thread-pool"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the
@@ -50,7 +50,7 @@ threadpool = ["futures-executor-preview/threadpool"]
 unstable = ["futures-core-preview/unstable", "futures-channel-preview/unstable", "futures-io-preview/unstable", "futures-util-preview/unstable"]
 cfg-target-has-atomic = ["futures-core-preview/cfg-target-has-atomic", "futures-channel-preview/cfg-target-has-atomic", "futures-util-preview/cfg-target-has-atomic"]
 bilock = ["futures-util-preview/bilock"]
-read_initializer = ["futures-io-preview/read_initializer", "futures-util-preview/read_initializer"]
+read-initializer = ["futures-io-preview/read-initializer", "futures-util-preview/read-initializer"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -22,7 +22,7 @@
 //! completion, but *do not block* the thread running them.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-#![cfg_attr(feature = "read_initializer", feature(read_initializer))]
+#![cfg_attr(feature = "read-initializer", feature(read_initializer))]
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -41,8 +41,8 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feat
 #[cfg(all(feature = "bilock", not(feature = "unstable")))]
 compile_error!("The `bilock` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
-#[cfg(all(feature = "read_initializer", not(feature = "unstable")))]
-compile_error!("The `read_initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
+#[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
+compile_error!("The `read-initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
 #[doc(hidden)] pub use futures_core::future::{Future, TryFuture};
 #[doc(hidden)] pub use futures_util::future::{FutureExt, TryFutureExt};
@@ -181,7 +181,7 @@ pub mod executor {
         block_on, block_on_stream, enter,
     };
 
-    #[cfg(feature = "threadpool")]
+    #[cfg(feature = "thread-pool")]
     pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
 }
 
@@ -282,7 +282,7 @@ pub mod io {
         IoSlice, IoSliceMut, Result, SeekFrom,
     };
 
-    #[cfg(feature = "read_initializer")]
+    #[cfg(feature = "read-initializer")]
     pub use futures_io::Initializer;
 
     pub use futures_util::io::{


### PR DESCRIPTION
feature names should not have a formal rule yet (https://github.com/rust-lang/api-guidelines/issues/101), but use the same kebab case as the crate name.

Also, thread-pool hasn't been released yet, and read-initializer depends on std's unstable feature, so I think there were few users of these features.