### PR TITLE
fix Future::flatten doc

### DIFF
--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -240,7 +240,7 @@ pub trait FutureExt: Future {
     /// `IntoFuture` trait and the error can be created from this future's error
     /// type.
     ///
-    /// This method is roughly equivalent to `self.and_then(|x| x)`.
+    /// This method is roughly equivalent to `self.then(|x| x)`.
     ///
     /// Note that this function consumes the receiving future and returns a
     /// wrapped version of it.


### PR DESCRIPTION
`and_then(|x| x)` would be equivalent to `try_flatten`.
`then(|x| x)`is the equivalent to `flatten`.