### PR TITLE
Use our own io::Cursor

### DIFF
--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -385,10 +385,6 @@ mod if_std {
         delegate_async_read_to_stdio!();
     }
 
-    impl<T: AsRef<[u8]> + Unpin> AsyncRead for io::Cursor<T> {
-        delegate_async_read_to_stdio!();
-    }
-
     macro_rules! deref_async_write {
         () => {
             fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
@@ -471,22 +467,6 @@ mod if_std {
         }
     }
 
-    impl AsyncWrite for io::Cursor<&mut [u8]> {
-        delegate_async_write_to_stdio!();
-    }
-
-    impl AsyncWrite for io::Cursor<&mut Vec<u8>> {
-        delegate_async_write_to_stdio!();
-    }
-
-    impl AsyncWrite for io::Cursor<Vec<u8>> {
-        delegate_async_write_to_stdio!();
-    }
-
-    impl AsyncWrite for io::Cursor<Box<[u8]>> {
-        delegate_async_write_to_stdio!();
-    }
-
     impl AsyncWrite for Vec<u8> {
         delegate_async_write_to_stdio!();
     }
@@ -519,20 +499,6 @@ mod if_std {
         {
             self.get_mut().as_mut().poll_seek(cx, pos)
         }
-    }
-
-    macro_rules! delegate_async_seek_to_stdio {
-        () => {
-            fn poll_seek(mut self: Pin<&mut Self>, _: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<Result<u64>>
-            {
-                Poll::Ready(io::Seek::seek(&mut *self, pos))
-            }
-        }
-    }
-
-    impl<T: AsRef<[u8]> + Unpin> AsyncSeek for io::Cursor<T> {
-        delegate_async_seek_to_stdio!();
     }
 
     macro_rules! deref_async_buf_read {
@@ -588,10 +554,6 @@ mod if_std {
     }
 
     impl AsyncBufRead for &[u8] {
-        delegate_async_buf_read_to_stdio!();
-    }
-
-    impl<T: AsRef<[u8]> + Unpin> AsyncBufRead for io::Cursor<T> {
         delegate_async_buf_read_to_stdio!();
     }
 }

--- a/futures-test/src/io/read/mod.rs
+++ b/futures-test/src/io/read/mod.rs
@@ -14,12 +14,12 @@ pub trait AsyncReadTestExt: AsyncRead {
     ///
     /// ```
     /// use futures::task::Poll;
-    /// use futures::io::AsyncRead;
+    /// use futures::io::{AsyncRead, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
     /// use futures::pin_mut;
     ///
-    /// let reader = std::io::Cursor::new(&[1, 2, 3]).interleave_pending();
+    /// let reader = Cursor::new(&[1, 2, 3]).interleave_pending();
     /// pin_mut!(reader);
     ///
     /// let mut cx = noop_context();
@@ -44,12 +44,12 @@ pub trait AsyncReadTestExt: AsyncRead {
     ///
     /// ```
     /// use futures::task::Poll;
-    /// use futures::io::AsyncBufRead;
+    /// use futures::io::{AsyncBufRead, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
     /// use futures::pin_mut;
     ///
-    /// let reader = std::io::Cursor::new(&[1, 2, 3]).interleave_pending();
+    /// let reader = Cursor::new(&[1, 2, 3]).interleave_pending();
     /// pin_mut!(reader);
     ///
     /// let mut cx = noop_context();
@@ -78,12 +78,12 @@ pub trait AsyncReadTestExt: AsyncRead {
     ///
     /// ```
     /// use futures::task::Poll;
-    /// use futures::io::AsyncRead;
+    /// use futures::io::{AsyncRead, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
     /// use futures::pin_mut;
     ///
-    /// let reader = std::io::Cursor::new(&[1, 2, 3, 4, 5]).limited(2);
+    /// let reader = Cursor::new(&[1, 2, 3, 4, 5]).limited(2);
     /// pin_mut!(reader);
     ///
     /// let mut cx = noop_context();

--- a/futures-test/src/io/write/mod.rs
+++ b/futures-test/src/io/write/mod.rs
@@ -14,12 +14,12 @@ pub trait AsyncWriteTestExt: AsyncWrite {
     ///
     /// ```
     /// use futures::task::Poll;
-    /// use futures::io::AsyncWrite;
+    /// use futures::io::{AsyncWrite, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncWriteTestExt;
     /// use futures::pin_mut;
     ///
-    /// let writer = std::io::Cursor::new(vec![0u8; 4].into_boxed_slice()).interleave_pending_write();
+    /// let writer = Cursor::new(vec![0u8; 4].into_boxed_slice()).interleave_pending_write();
     /// pin_mut!(writer);
     ///
     /// let mut cx = noop_context();
@@ -54,12 +54,12 @@ pub trait AsyncWriteTestExt: AsyncWrite {
     ///
     /// ```
     /// use futures::task::Poll;
-    /// use futures::io::AsyncWrite;
+    /// use futures::io::{AsyncWrite, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncWriteTestExt;
     /// use futures::pin_mut;
     ///
-    /// let writer = std::io::Cursor::new(vec![0u8; 4].into_boxed_slice()).limited_write(2);
+    /// let writer = Cursor::new(vec![0u8; 4].into_boxed_slice()).limited_write(2);
     /// pin_mut!(writer);
     ///
     /// let mut cx = noop_context();

--- a/futures-util/src/io/cursor.rs
+++ b/futures-util/src/io/cursor.rs
@@ -1,0 +1,238 @@
+use futures_core::task::{Context, Poll};
+#[cfg(feature = "read_initializer")]
+use futures_io::Initializer;
+use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSlice, IoSliceMut, SeekFrom};
+use std::io;
+use std::pin::Pin;
+
+/// A `Cursor` wraps an in-memory buffer and provides it with a
+/// [`AsyncSeek`] implementation.
+///
+/// `Cursor`s are used with in-memory buffers, anything implementing
+/// `AsRef<[u8]>`, to allow them to implement [`AsyncRead`] and/or [`AsyncWrite`],
+/// allowing these buffers to be used anywhere you might use a reader or writer
+/// that does actual I/O.
+///
+/// The standard library implements some I/O traits on various types which
+/// are commonly used as a buffer, like `Cursor<`[`Vec`]`<u8>>` and
+/// `Cursor<`[`&[u8]`][bytes]`>`.
+///
+/// [`AsyncSeek`]: trait.AsyncSeek.html
+/// [`AsyncRead`]: trait.AsyncRead.html
+/// [`AsyncWrite`]: trait.AsyncWrite.html
+/// [bytes]: https://doc.rust-lang.org/std/primitive.slice.html
+#[derive(Clone, Debug, Default)]
+pub struct Cursor<T> {
+    inner: io::Cursor<T>,
+}
+
+impl<T> Cursor<T> {
+    /// Creates a new cursor wrapping the provided underlying in-memory buffer.
+    ///
+    /// Cursor initial position is `0` even if underlying buffer (e.g., `Vec`)
+    /// is not empty. So writing to cursor starts with overwriting `Vec`
+    /// content, not with appending to it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::io::Cursor;
+    ///
+    /// let buff = Cursor::new(Vec::new());
+    /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
+    /// # force_inference(&buff);
+    /// ```
+    pub fn new(inner: T) -> Cursor<T> {
+        Cursor {
+            inner: io::Cursor::new(inner),
+        }
+    }
+
+    /// Consumes this cursor, returning the underlying value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::io::Cursor;
+    ///
+    /// let buff = Cursor::new(Vec::new());
+    /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
+    /// # force_inference(&buff);
+    ///
+    /// let vec = buff.into_inner();
+    /// ```
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner()
+    }
+
+    /// Gets a reference to the underlying value in this cursor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::io::Cursor;
+    ///
+    /// let buff = Cursor::new(Vec::new());
+    /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
+    /// # force_inference(&buff);
+    ///
+    /// let reference = buff.get_ref();
+    /// ```
+    pub fn get_ref(&self) -> &T {
+        self.inner.get_ref()
+    }
+
+    /// Gets a mutable reference to the underlying value in this cursor.
+    ///
+    /// Care should be taken to avoid modifying the internal I/O state of the
+    /// underlying value as it may corrupt this cursor's position.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::io::Cursor;
+    ///
+    /// let mut buff = Cursor::new(Vec::new());
+    /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
+    /// # force_inference(&buff);
+    ///
+    /// let reference = buff.get_mut();
+    /// ```
+    pub fn get_mut(&mut self) -> &mut T {
+        self.inner.get_mut()
+    }
+
+    /// Returns the current position of this cursor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::io::{AsyncSeekExt, Cursor, SeekFrom};
+    ///
+    /// let mut buff = Cursor::new(vec![1, 2, 3, 4, 5]);
+    ///
+    /// assert_eq!(buff.position(), 0);
+    ///
+    /// buff.seek(SeekFrom::Current(2)).await?;
+    /// assert_eq!(buff.position(), 2);
+    ///
+    /// buff.seek(SeekFrom::Current(-1)).await?;
+    /// assert_eq!(buff.position(), 1);
+    /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
+    /// ```
+    pub fn position(&self) -> u64 {
+        self.inner.position()
+    }
+
+    /// Sets the position of this cursor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use futures::io::Cursor;
+    ///
+    /// let mut buff = Cursor::new(vec![1, 2, 3, 4, 5]);
+    ///
+    /// assert_eq!(buff.position(), 0);
+    ///
+    /// buff.set_position(2);
+    /// assert_eq!(buff.position(), 2);
+    ///
+    /// buff.set_position(4);
+    /// assert_eq!(buff.position(), 4);
+    /// ```
+    pub fn set_position(&mut self, pos: u64) {
+        self.inner.set_position(pos)
+    }
+}
+
+impl<T> AsyncSeek for Cursor<T>
+where
+    T: AsRef<[u8]> + Unpin,
+{
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        pos: SeekFrom,
+    ) -> Poll<io::Result<u64>> {
+        Poll::Ready(io::Seek::seek(&mut self.inner, pos))
+    }
+}
+
+impl<T: AsRef<[u8]> + Unpin> AsyncRead for Cursor<T> {
+    #[cfg(feature = "read_initializer")]
+    #[inline]
+    unsafe fn initializer(&self) -> Initializer {
+        io::Read::initializer(&self.inner)
+    }
+
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(io::Read::read(&mut self.inner, buf))
+    }
+
+    fn poll_read_vectored(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(io::Read::read_vectored(&mut self.inner, bufs))
+    }
+}
+
+impl<T> AsyncBufRead for Cursor<T>
+where
+    T: AsRef<[u8]> + Unpin,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        Poll::Ready(io::BufRead::fill_buf(&mut self.get_mut().inner))
+    }
+
+    fn consume(mut self: Pin<&mut Self>, amt: usize) {
+        io::BufRead::consume(&mut self.inner, amt)
+    }
+}
+
+macro_rules! delegate_async_write_to_stdio {
+    () => {
+        fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8])
+            -> Poll<io::Result<usize>>
+        {
+            Poll::Ready(io::Write::write(&mut self.inner, buf))
+        }
+
+        fn poll_write_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &[IoSlice<'_>])
+            -> Poll<io::Result<usize>>
+        {
+            Poll::Ready(io::Write::write_vectored(&mut self.inner, bufs))
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(io::Write::flush(&mut self.inner))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.poll_flush(cx)
+        }
+    }
+}
+
+impl AsyncWrite for Cursor<&mut [u8]> {
+    delegate_async_write_to_stdio!();
+}
+
+impl AsyncWrite for Cursor<&mut Vec<u8>> {
+    delegate_async_write_to_stdio!();
+}
+
+impl AsyncWrite for Cursor<Vec<u8>> {
+    delegate_async_write_to_stdio!();
+}
+
+impl AsyncWrite for Cursor<Box<[u8]>> {
+    delegate_async_write_to_stdio!();
+}

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -59,6 +59,9 @@ pub use self::copy_into::CopyInto;
 mod copy_buf_into;
 pub use self::copy_buf_into::CopyBufInto;
 
+mod cursor;
+pub use self::cursor::Cursor;
+
 mod empty;
 pub use self::empty::{empty, Empty};
 
@@ -133,8 +136,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader1 = Cursor::new([1, 2, 3, 4]);
     /// let reader2 = Cursor::new([5, 6, 7, 8]);
@@ -168,8 +170,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::{AsyncReadExt, AsyncWriteExt};
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, AsyncWriteExt, Cursor};
     ///
     /// let reader = Cursor::new([1, 2, 3, 4]);
     /// let mut writer = Cursor::new(vec![0u8; 5]);
@@ -199,8 +200,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 5];
@@ -243,8 +243,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 4];
@@ -259,8 +258,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::{self, Cursor};
+    /// use futures::io::{self, AsyncReadExt, Cursor};
     ///
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 5];
@@ -287,8 +285,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = Vec::with_capacity(4);
@@ -316,8 +313,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let mut reader = Cursor::new(&b"1234"[..]);
     /// let mut buffer = String::with_capacity(4);
@@ -346,8 +342,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// // Note that for `Cursor` the read and write halves share a single
     /// // seek position. This may or may not be true for other types that
@@ -380,8 +375,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader = Cursor::new(&b"12345678"[..]);
     /// let mut buffer = [0; 5];
@@ -484,8 +478,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncWriteExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncWriteExt, Cursor};
     ///
     /// let mut writer = Cursor::new(vec![0u8; 5]);
     ///
@@ -578,8 +571,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::{AsyncBufReadExt, AsyncWriteExt};
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncBufReadExt, AsyncWriteExt, Cursor};
     ///
     /// let reader = Cursor::new([1, 2, 3, 4]);
     /// let mut writer = Cursor::new(vec![0u8; 5]);
@@ -617,8 +609,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncBufReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncBufReadExt, Cursor};
     ///
     /// let mut cursor = Cursor::new(b"lorem-ipsum");
     /// let mut buf = vec![];
@@ -679,8 +670,7 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncBufReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncBufReadExt, Cursor};
     ///
     /// let mut cursor = Cursor::new(b"foo\nbar");
     /// let mut buf = String::new();
@@ -729,9 +719,8 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncBufReadExt;
+    /// use futures::io::{AsyncBufReadExt, Cursor};
     /// use futures::stream::StreamExt;
-    /// use std::io::Cursor;
     ///
     /// let cursor = Cursor::new(b"lorem\nipsum\r\ndolor");
     ///

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -37,8 +37,7 @@ impl<R: AsyncRead> Take<R> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader = Cursor::new(&b"12345678"[..]);
     /// let mut buffer = [0; 2];
@@ -62,8 +61,7 @@ impl<R: AsyncRead> Take<R> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader = Cursor::new(&b"12345678"[..]);
     /// let mut buffer = [0; 4];
@@ -90,8 +88,7 @@ impl<R: AsyncRead> Take<R> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader = Cursor::new(&b"12345678"[..]);
     /// let mut buffer = [0; 4];
@@ -118,8 +115,7 @@ impl<R: AsyncRead> Take<R> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader = Cursor::new(&b"12345678"[..]);
     /// let mut buffer = [0; 4];
@@ -150,8 +146,7 @@ impl<R: AsyncRead> Take<R> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::io::AsyncReadExt;
-    /// use std::io::Cursor;
+    /// use futures::io::{AsyncReadExt, Cursor};
     ///
     /// let reader = Cursor::new(&b"12345678"[..]);
     /// let mut buffer = [0; 4];

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -287,10 +287,11 @@ pub mod io {
 
     pub use futures_util::io::{
         AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt, AllowStdIo,
-        BufReader, BufWriter, Chain, Close, CopyInto, CopyBufInto, empty, Empty,
-        Flush, IntoSink, Lines, Read, ReadExact, ReadHalf, ReadLine, ReadToEnd,
-        ReadToString, ReadUntil, ReadVectored, repeat, Repeat, Seek, sink, Sink,
-        Take, Window, Write, WriteAll, WriteHalf, WriteVectored,
+        BufReader, BufWriter, Cursor, Chain, Close, CopyInto, CopyBufInto,
+        empty, Empty, Flush, IntoSink, Lines, Read, ReadExact, ReadHalf,
+        ReadLine, ReadToEnd, ReadToString, ReadUntil, ReadVectored, repeat,
+        Repeat, Seek, sink, Sink, Take, Window, Write, WriteAll, WriteHalf,
+        WriteVectored,
     };
 }
 

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -2,12 +2,12 @@ use futures::executor::block_on;
 use futures::future::{Future, FutureExt};
 use futures::io::{
     AsyncSeek, AsyncSeekExt, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt,
-    AllowStdIo, BufReader, SeekFrom,
+    AllowStdIo, BufReader, Cursor, SeekFrom,
 };
 use futures::task::{Context, Poll};
 use futures_test::task::noop_context;
 use std::cmp;
-use std::io::{self, Cursor};
+use std::io;
 use std::pin::Pin;
 
 /// A dummy reader intended at testing short-reads propagation.

--- a/futures/tests/io_buf_writer.rs
+++ b/futures/tests/io_buf_writer.rs
@@ -1,9 +1,9 @@
 use futures::executor::block_on;
 use futures::future::{Future, FutureExt};
-use futures::io::{AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, BufWriter, SeekFrom};
+use futures::io::{AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, BufWriter, Cursor, SeekFrom};
 use futures::task::{Context, Poll};
 use futures_test::task::noop_context;
-use std::io::{self, Cursor};
+use std::io;
 use std::pin::Pin;
 
 #[test]

--- a/futures/tests/io_cursor.rs
+++ b/futures/tests/io_cursor.rs
@@ -1,8 +1,7 @@
 use assert_matches::assert_matches;
 use futures::future::lazy;
-use futures::io::AsyncWrite;
+use futures::io::{AsyncWrite, Cursor};
 use futures::task::Poll;
-use std::io::Cursor;
 use std::pin::Pin;
 
 #[test]

--- a/futures/tests/io_lines.rs
+++ b/futures/tests/io_lines.rs
@@ -1,11 +1,10 @@
 use futures::executor::block_on;
 use futures::future::{Future, FutureExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use futures::io::AsyncBufReadExt;
+use futures::io::{AsyncBufReadExt, Cursor};
 use futures::task::Poll;
 use futures_test::io::AsyncReadTestExt;
 use futures_test::task::noop_context;
-use std::io::Cursor;
 
 macro_rules! block_on_next {
     ($expr:expr) => {

--- a/futures/tests/io_read_line.rs
+++ b/futures/tests/io_read_line.rs
@@ -1,11 +1,10 @@
 use futures::executor::block_on;
 use futures::future::{Future, FutureExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use futures::io::AsyncBufReadExt;
+use futures::io::{AsyncBufReadExt, Cursor};
 use futures::task::Poll;
 use futures_test::io::AsyncReadTestExt;
 use futures_test::task::noop_context;
-use std::io::Cursor;
 
 #[test]
 fn read_line() {

--- a/futures/tests/io_read_to_string.rs
+++ b/futures/tests/io_read_to_string.rs
@@ -1,11 +1,10 @@
 use futures::executor::block_on;
 use futures::future::{Future, FutureExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use futures::io::AsyncReadExt;
+use futures::io::{AsyncReadExt, Cursor};
 use futures::task::Poll;
 use futures_test::io::AsyncReadTestExt;
 use futures_test::task::noop_context;
-use std::io::Cursor;
 
 #[test]
 fn read_to_string() {

--- a/futures/tests/io_read_until.rs
+++ b/futures/tests/io_read_until.rs
@@ -1,11 +1,10 @@
 use futures::executor::block_on;
 use futures::future::{Future, FutureExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use futures::io::AsyncBufReadExt;
+use futures::io::{AsyncBufReadExt, Cursor};
 use futures::task::Poll;
 use futures_test::io::AsyncReadTestExt;
 use futures_test::task::noop_context;
-use std::io::Cursor;
 
 #[test]
 fn read_until() {


### PR DESCRIPTION
Based on #1936

Context: #1829

> If both `futures::io` ext traits and `std::io` traits are imported, method names may conflict, so use our own.

cc @Nemo157 
