### PR TITLE
Add executor feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,10 +143,26 @@ matrix:
             --no-default-features
             --features async-await
 
-    - name: cargo check (sub crates)
+    - name: cargo check (features)
       rust: nightly
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
+
+        # futures
+        # Check default-features, all-features
+        - cargo check --manifest-path futures/Cargo.toml
+        - cargo check --manifest-path futures/Cargo.toml --all-features
+        # Check each features
+        - cargo check --manifest-path futures/Cargo.toml --features async-await
+        - cargo check --manifest-path futures/Cargo.toml --features compat
+        - cargo check --manifest-path futures/Cargo.toml --features io-compat
+        - cargo check --manifest-path futures/Cargo.toml --features read-initializer,unstable
+        - cargo check --manifest-path futures/Cargo.toml --features bilock,unstable
+        # Check each features with --no-default-features
+        - cargo check --manifest-path futures/Cargo.toml --no-default-features --features async-await
+        - cargo check --manifest-path futures/Cargo.toml --no-default-features --features compat
+        - cargo check --manifest-path futures/Cargo.toml --no-default-features --features io-compat
+        - cargo check --manifest-path futures/Cargo.toml --no-default-features --features executor
 
         # futures-io
         # Check default-features, all-features
@@ -189,6 +205,8 @@ matrix:
         - cargo check --manifest-path futures-executor/Cargo.toml --all-features
         # Check each features
         - cargo check --manifest-path futures-executor/Cargo.toml --features thread-pool
+        # Check each features with --no-default-features
+        - cargo check --manifest-path futures-executor/Cargo.toml --no-default-features --features thread-pool
 
     - name: cargo doc
       rust: nightly

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -17,7 +17,7 @@ name = "futures_executor"
 [features]
 default = ["std"]
 std = ["futures-core-preview/std", "futures-util-preview/std"]
-thread-pool = ["num_cpus"]
+thread-pool = ["std", "num_cpus"]
 
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.19", default-features = false }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "rust-lang-nursery/futures-rs" }
 [dependencies]
 futures-core-preview = { path = "../futures-core", version = "=0.3.0-alpha.19", default-features = false }
 futures-channel-preview = { path = "../futures-channel", version = "=0.3.0-alpha.19", default-features = false, features = ["sink"] }
-futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.19", default-features = false }
+futures-executor-preview = { path = "../futures-executor", version = "=0.3.0-alpha.19", default-features = false, optional = true }
 futures-io-preview = { path = "../futures-io", version = "=0.3.0-alpha.19", default-features = false }
 futures-sink-preview = { path = "../futures-sink", version = "=0.3.0-alpha.19", default-features = false }
 futures-util-preview = { path = "../futures-util", version = "=0.3.0-alpha.19", default-features = false, features = ["sink"] }
@@ -36,13 +36,14 @@ tokio = "0.1.11"
 assert_matches = "1.3.0"
 
 [features]
-default = ["std"]
-std = ["alloc", "futures-core-preview/std", "futures-executor-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std", "futures-util-preview/io", "futures-util-preview/channel"]
+default = ["std", "executor"]
+std = ["alloc", "futures-core-preview/std", "futures-io-preview/std", "futures-sink-preview/std", "futures-util-preview/std", "futures-util-preview/io", "futures-util-preview/channel"]
 alloc = ["futures-core-preview/alloc", "futures-sink-preview/alloc", "futures-channel-preview/alloc", "futures-util-preview/alloc"]
 async-await = ["futures-util-preview/async-await", "futures-util-preview/async-await-macro"]
 compat = ["std", "futures-util-preview/compat"]
 io-compat = ["compat", "futures-util-preview/io-compat"]
-thread-pool = ["futures-executor-preview/thread-pool"]
+executor = ["std", "futures-executor-preview/std"]
+thread-pool = ["executor", "futures-executor-preview/thread-pool"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -115,7 +115,7 @@ pub mod compat {
     };
 }
 
-#[cfg(feature = "std")]
+#[cfg(feature = "executor")]
 pub mod executor {
     //! Task execution.
     //!
@@ -123,7 +123,7 @@ pub mod executor {
     //! capable of spawning futures as tasks. This module provides several
     //! built-in executors, as well as tools for building your own.
     //!
-    //! This module is only available when the `std` feature of this
+    //! This module is only available when the `executor` feature of this
     //! library is activated, and it is activated by default.
     //!
     //! # Using a thread pool (M:N task scheduling)
@@ -134,7 +134,7 @@ pub mod executor {
     //! than threads). Tasks spawned onto the pool with the
     //! [`spawn_ok()`](crate::executor::ThreadPool::spawn_ok)
     //! function will run on ambiently on the created threads.
-    //! 
+    //!
     //! # Spawning additional tasks
     //!
     //! Tasks can be spawned onto a spawner by calling its


### PR DESCRIPTION
Part of #1875

This adds `executor` feature (enabled by default) to futures crate.

cc #1893 