### PR TITLE
Make `Spawn::spawn` take `&self` rather than `&mut self`

### DIFF
--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -333,7 +333,7 @@ impl<S: Stream + Unpin> Iterator for BlockingStream<S> {
 
 impl Spawn for LocalSpawner {
     fn spawn_obj(
-        &mut self,
+        &self,
         future: FutureObj<'static, ()>,
     ) -> Result<(), SpawnError> {
         if let Some(incoming) = self.incoming.upgrade() {
@@ -355,7 +355,7 @@ impl Spawn for LocalSpawner {
 
 impl LocalSpawn for LocalSpawner {
     fn spawn_local_obj(
-        &mut self,
+        &self,
         future: LocalFutureObj<'static, ()>,
     ) -> Result<(), SpawnError> {
         if let Some(incoming) = self.incoming.upgrade() {

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -131,17 +131,7 @@ impl ThreadPool {
 
 impl Spawn for ThreadPool {
     fn spawn_obj(
-        &mut self,
-        future: FutureObj<'static, ()>,
-    ) -> Result<(), SpawnError> {
-        self.spawn_obj_ok(future);
-        Ok(())
-    }
-}
-
-impl Spawn for &ThreadPool {
-    fn spawn_obj(
-        &mut self,
+        &self,
         future: FutureObj<'static, ()>,
     ) -> Result<(), SpawnError> {
         self.spawn_obj_ok(future);

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -39,7 +39,7 @@ fn run_until_single_future() {
 #[test]
 fn run_until_ignores_spawned() {
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
     spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
     assert_eq!(pool.run_until(lazy(|_| ())), ());
 }
@@ -48,7 +48,7 @@ fn run_until_ignores_spawned() {
 fn run_until_executes_spawned() {
     let (tx, rx) = oneshot::channel();
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
     spawn.spawn_local_obj(Box::pin(lazy(move |_| {
         tx.send(()).unwrap();
         ()
@@ -69,8 +69,8 @@ fn run_executes_spawned() {
     let cnt2 = cnt.clone();
 
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
-    let mut spawn2 = pool.spawner();
+    let spawn = pool.spawner();
+    let spawn2 = pool.spawner();
 
     spawn.spawn_local_obj(Box::pin(lazy(move |_| {
         spawn2.spawn_local_obj(Box::pin(lazy(move |_| {
@@ -93,7 +93,7 @@ fn run_spawn_many() {
     let cnt = Rc::new(Cell::new(0));
 
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     for _ in 0..ITER {
         let cnt = cnt.clone();
@@ -121,7 +121,7 @@ fn try_run_one_executes_one_ready() {
     let cnt = Rc::new(Cell::new(0));
 
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     for _ in 0..ITER {
         spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
@@ -150,7 +150,7 @@ fn try_run_one_returns_on_no_progress() {
     let cnt = Rc::new(Cell::new(0));
 
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     let waker: Rc<Cell<Option<Waker>>> = Rc::new(Cell::new(None));
     {
@@ -182,10 +182,10 @@ fn try_run_one_returns_on_no_progress() {
 #[test]
 fn try_run_one_runs_sub_futures() {
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
     let cnt = Rc::new(Cell::new(0));
 
-    let mut inner_spawner = spawn.clone();
+    let inner_spawner = spawn.clone();
     let cnt1 = cnt.clone();
     spawn.spawn_local_obj(Box::pin(poll_fn(move |_| {
         cnt1.set(cnt1.get() + 1);
@@ -212,7 +212,7 @@ fn run_until_stalled_returns_if_empty() {
 #[test]
 fn run_until_stalled_returns_multiple_times() {
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
     let cnt = Rc::new(Cell::new(0));
 
     let cnt1 = cnt.clone();
@@ -229,10 +229,10 @@ fn run_until_stalled_returns_multiple_times() {
 #[test]
 fn run_until_stalled_runs_spawned_sub_futures() {
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
     let cnt = Rc::new(Cell::new(0));
 
-    let mut inner_spawner = spawn.clone();
+    let inner_spawner = spawn.clone();
     let cnt1 = cnt.clone();
     spawn.spawn_local_obj(Box::pin(poll_fn(move |_| {
         cnt1.set(cnt1.get() + 1);
@@ -257,7 +257,7 @@ fn run_until_stalled_executes_all_ready() {
     let cnt = Rc::new(Cell::new(0));
 
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     for i in 0..ITER {
         for _ in 0..PER_ITER {
@@ -282,7 +282,7 @@ fn run_until_stalled_executes_all_ready() {
 #[should_panic]
 fn nesting_run() {
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     spawn.spawn_obj(Box::pin(lazy(|_| {
         let mut pool = LocalPool::new();
@@ -296,7 +296,7 @@ fn nesting_run() {
 #[should_panic]
 fn nesting_run_run_until_stalled() {
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     spawn.spawn_obj(Box::pin(lazy(|_| {
         let mut pool = LocalPool::new();
@@ -343,7 +343,7 @@ fn tasks_are_scheduled_fairly() {
     }
 
     let mut pool = LocalPool::new();
-    let mut spawn = pool.spawner();
+    let spawn = pool.spawner();
 
     spawn.spawn_local_obj(Box::pin(Spin {
         state: state.clone(),

--- a/futures-task/src/spawn.rs
+++ b/futures-task/src/spawn.rs
@@ -12,7 +12,7 @@ pub trait Spawn {
     /// represent relatively rare scenarios, such as the executor
     /// having been shut down so that it is no longer able to accept
     /// tasks.
-    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError>;
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError>;
 
     /// Determines whether the executor is able to spawn new tasks.
     ///
@@ -37,7 +37,7 @@ pub trait LocalSpawn {
     /// represent relatively rare scenarios, such as the executor
     /// having been shut down so that it is no longer able to accept
     /// tasks.
-    fn spawn_local_obj(&mut self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError>;
+    fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError>;
 
     /// Determines whether the executor is able to spawn new tasks.
     ///
@@ -84,7 +84,7 @@ impl SpawnError {
 }
 
 impl<Sp: ?Sized + Spawn> Spawn for &mut Sp {
-    fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         Sp::spawn_obj(self, future)
     }
 
@@ -93,8 +93,8 @@ impl<Sp: ?Sized + Spawn> Spawn for &mut Sp {
     }
 }
 
-impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &mut Sp {
-    fn spawn_local_obj(&mut self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &Sp {
+    fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
         Sp::spawn_local_obj(self, future)
     }
 
@@ -109,7 +109,7 @@ mod if_alloc {
     use alloc::boxed::Box;
 
     impl<Sp: ?Sized + Spawn> Spawn for Box<Sp> {
-        fn spawn_obj(&mut self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
             (**self).spawn_obj(future)
         }
 
@@ -119,7 +119,7 @@ mod if_alloc {
     }
 
     impl<Sp: ?Sized + LocalSpawn> LocalSpawn for Box<Sp> {
-        fn spawn_local_obj(&mut self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+        fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
             (**self).spawn_local_obj(future)
         }
 

--- a/futures-test/src/task/noop_spawner.rs
+++ b/futures-test/src/task/noop_spawner.rs
@@ -26,7 +26,7 @@ impl NoopSpawner {
 
 impl Spawn for NoopSpawner {
     fn spawn_obj(
-        &mut self,
+        &self,
         _future: FutureObj<'static, ()>,
     ) -> Result<(), SpawnError> {
         Ok(())

--- a/futures-test/src/task/panic_spawner.rs
+++ b/futures-test/src/task/panic_spawner.rs
@@ -27,7 +27,7 @@ impl PanicSpawner {
 
 impl Spawn for PanicSpawner {
     fn spawn_obj(
-        &mut self,
+        &self,
         _future: FutureObj<'static, ()>,
     ) -> Result<(), SpawnError> {
         panic!("should not spawn")

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -67,7 +67,7 @@ where
     Ex: Executor01<Executor01Future> + Clone + Send + 'static,
 {
     fn spawn_obj(
-        &mut self,
+        &self,
         future: FutureObj<'static, ()>,
     ) -> Result<(), SpawnError03> {
         let future = future.unit_error().compat();

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -70,7 +70,7 @@ fn resolving_errors() {
 #[test]
 fn dropping_ready_queue() {
     block_on(future::lazy(move |_| {
-        let mut queue = FuturesUnordered::new();
+        let queue = FuturesUnordered::new();
         let (mut tx1, rx1) = oneshot::channel::<()>();
         let (mut tx2, rx2) = oneshot::channel::<()>();
         let (mut tx3, rx3) = oneshot::channel::<()>();


### PR DESCRIPTION
Fix #1669

r? @Nemo157 @taiki-e @seanmonstar 