### PR TITLE
fix: [Local]SpawnExt should take &self as their base traits

### DIFF
--- a/futures-task/src/spawn.rs
+++ b/futures-task/src/spawn.rs
@@ -83,6 +83,16 @@ impl SpawnError {
     }
 }
 
+impl<Sp: ?Sized + Spawn> Spawn for &Sp {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        Sp::spawn_obj(self, future)
+    }
+
+    fn status(&self) -> Result<(), SpawnError> {
+        Sp::status(self)
+    }
+}
+
 impl<Sp: ?Sized + Spawn> Spawn for &mut Sp {
     fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         Sp::spawn_obj(self, future)
@@ -94,6 +104,16 @@ impl<Sp: ?Sized + Spawn> Spawn for &mut Sp {
 }
 
 impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &Sp {
+    fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+        Sp::spawn_local_obj(self, future)
+    }
+
+    fn status_local(&self) -> Result<(), SpawnError> {
+        Sp::status_local(self)
+    }
+}
+
+impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &mut Sp {
     fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
         Sp::spawn_local_obj(self, future)
     }

--- a/futures-test/src/task/noop_spawner.rs
+++ b/futures-test/src/task/noop_spawner.rs
@@ -1,4 +1,4 @@
-use futures_task::{Spawn, SpawnError, FutureObj};
+use futures_task::{FutureObj, Spawn, SpawnError};
 
 /// An implementation of [`Spawn`](futures_task::Spawn) that
 /// discards spawned futures when used.
@@ -9,7 +9,7 @@ use futures_task::{Spawn, SpawnError, FutureObj};
 /// use futures::task::SpawnExt;
 /// use futures_test::task::NoopSpawner;
 ///
-/// let mut spawner = NoopSpawner::new();
+/// let spawner = NoopSpawner::new();
 /// spawner.spawn(async { }).unwrap();
 /// ```
 #[derive(Debug)]
@@ -25,10 +25,7 @@ impl NoopSpawner {
 }
 
 impl Spawn for NoopSpawner {
-    fn spawn_obj(
-        &self,
-        _future: FutureObj<'static, ()>,
-    ) -> Result<(), SpawnError> {
+    fn spawn_obj(&self, _future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         Ok(())
     }
 }

--- a/futures-test/src/task/panic_spawner.rs
+++ b/futures-test/src/task/panic_spawner.rs
@@ -1,4 +1,4 @@
-use futures_task::{Spawn, SpawnError, FutureObj};
+use futures_task::{FutureObj, Spawn, SpawnError};
 
 /// An implementation of [`Spawn`](futures_task::Spawn) that panics
 /// when used.
@@ -9,7 +9,7 @@ use futures_task::{Spawn, SpawnError, FutureObj};
 /// use futures::task::SpawnExt;
 /// use futures_test::task::PanicSpawner;
 ///
-/// let mut spawn = PanicSpawner::new();
+/// let spawn = PanicSpawner::new();
 /// spawn.spawn(async { })?; // Will panic
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
@@ -26,10 +26,7 @@ impl PanicSpawner {
 }
 
 impl Spawn for PanicSpawner {
-    fn spawn_obj(
-        &self,
-        _future: FutureObj<'static, ()>,
-    ) -> Result<(), SpawnError> {
+    fn spawn_obj(&self, _future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         panic!("should not spawn")
     }
 }

--- a/futures-test/src/task/record_spawner.rs
+++ b/futures-test/src/task/record_spawner.rs
@@ -1,4 +1,4 @@
-use futures_task::{Spawn, SpawnError, FutureObj};
+use futures_task::{FutureObj, Spawn, SpawnError};
 use std::cell::{Ref, RefCell};
 
 /// An implementation of [`Spawn`](futures_task::Spawn) that records
@@ -10,7 +10,7 @@ use std::cell::{Ref, RefCell};
 /// use futures::task::SpawnExt;
 /// use futures_test::task::RecordSpawner;
 ///
-/// let mut recorder = RecordSpawner::new();
+/// let recorder = RecordSpawner::new();
 /// recorder.spawn(async { }).unwrap();
 /// assert_eq!(recorder.spawned().len(), 1);
 /// ```
@@ -32,10 +32,7 @@ impl RecordSpawner {
 }
 
 impl Spawn for RecordSpawner {
-    fn spawn_obj(
-        &self,
-        future: FutureObj<'static, ()>,
-    ) -> Result<(), SpawnError> {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         self.spawned.borrow_mut().push(future);
         Ok(())
     }

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -1,11 +1,10 @@
-
 use super::{Compat, Future01CompatExt};
 use crate::{
     future::{FutureExt, TryFutureExt, UnitError},
     task::SpawnExt,
 };
+use futures_01::future::{ExecuteError as ExecuteError01, Executor as Executor01};
 use futures_01::Future as Future01;
-use futures_01::future::{Executor as Executor01, ExecuteError as ExecuteError01};
 use futures_task::{FutureObj, Spawn as Spawn03, SpawnError as SpawnError03};
 
 /// A future that can run on a futures 0.1
@@ -13,9 +12,7 @@ use futures_task::{FutureObj, Spawn as Spawn03, SpawnError as SpawnError03};
 pub type Executor01Future = Compat<UnitError<FutureObj<'static, ()>>>;
 
 /// Extension trait for futures 0.1 [`Executor`](futures_01::future::Executor).
-pub trait Executor01CompatExt: Executor01<Executor01Future> +
-                               Clone + Send + 'static
-{
+pub trait Executor01CompatExt: Executor01<Executor01Future> + Clone + Send + 'static {
     /// Converts a futures 0.1 [`Executor`](futures_01::future::Executor) into a
     /// futures 0.3 [`Spawn`](futures_task::Spawn).
     ///
@@ -27,7 +24,7 @@ pub trait Executor01CompatExt: Executor01<Executor01Future> +
     ///
     /// # let (tx, rx) = futures::channel::oneshot::channel();
     ///
-    /// let mut spawner = DefaultExecutor::current().compat();
+    /// let spawner = DefaultExecutor::current().compat();
     /// let future03 = async move {
     ///     println!("Running on the pool");
     ///     spawner.spawn(async {
@@ -42,16 +39,16 @@ pub trait Executor01CompatExt: Executor01<Executor01Future> +
     /// # futures::executor::block_on(rx).unwrap();
     /// ```
     fn compat(self) -> Executor01As03<Self>
-        where Self: Sized;
+    where
+        Self: Sized;
 }
 
 impl<Ex> Executor01CompatExt for Ex
-where Ex: Executor01<Executor01Future> + Clone + Send + 'static
+where
+    Ex: Executor01<Executor01Future> + Clone + Send + 'static,
 {
     fn compat(self) -> Executor01As03<Self> {
-        Executor01As03 {
-            executor01: self,
-        }
+        Executor01As03 { executor01: self }
     }
 }
 
@@ -59,22 +56,19 @@ where Ex: Executor01<Executor01Future> + Clone + Send + 'static
 /// futures 0.3 [`Spawn`](futures_task::Spawn).
 #[derive(Debug, Clone)]
 pub struct Executor01As03<Ex> {
-    executor01: Ex
+    executor01: Ex,
 }
 
 impl<Ex> Spawn03 for Executor01As03<Ex>
 where
     Ex: Executor01<Executor01Future> + Clone + Send + 'static,
 {
-    fn spawn_obj(
-        &self,
-        future: FutureObj<'static, ()>,
-    ) -> Result<(), SpawnError03> {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError03> {
         let future = future.unit_error().compat();
 
-        self.executor01.execute(future).map_err(|_|
-            SpawnError03::shutdown()
-        )
+        self.executor01
+            .execute(future)
+            .map_err(|_| SpawnError03::shutdown())
     }
 }
 
@@ -85,7 +79,8 @@ where
     Fut: Future01<Item = (), Error = ()> + Send + 'static,
 {
     fn execute(&self, future: Fut) -> Result<(), ExecuteError01<Fut>> {
-        (&self.inner).spawn(future.compat().map(|_| ()))
+        (&self.inner)
+            .spawn(future.compat().map(|_| ()))
             .expect("unable to spawn future from Compat executor");
         Ok(())
     }

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -1,16 +1,17 @@
 use futures_task::{LocalSpawn, Spawn};
 
-#[cfg(feature = "compat")] use crate::compat::Compat;
+#[cfg(feature = "compat")]
+use crate::compat::Compat;
 
 #[cfg(feature = "channel")]
 #[cfg(feature = "std")]
 use crate::future::{FutureExt, RemoteHandle};
 #[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 use futures_core::future::Future;
 #[cfg(feature = "alloc")]
-use futures_task::{SpawnError, FutureObj, LocalFutureObj};
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
+use futures_task::{FutureObj, LocalFutureObj, SpawnError};
 
 impl<Sp: ?Sized> SpawnExt for Sp where Sp: Spawn {}
 impl<Sp: ?Sized> LocalSpawnExt for Sp where Sp: LocalSpawn {}
@@ -36,13 +37,13 @@ pub trait SpawnExt: Spawn {
     /// use futures::executor::ThreadPool;
     /// use futures::task::SpawnExt;
     ///
-    /// let mut executor = ThreadPool::new().unwrap();
+    /// let executor = ThreadPool::new().unwrap();
     ///
     /// let future = async { /* ... */ };
     /// executor.spawn(future).unwrap();
     /// ```
     #[cfg(feature = "alloc")]
-    fn spawn<Fut>(&mut self, future: Fut) -> Result<(), SpawnError>
+    fn spawn<Fut>(&self, future: Fut) -> Result<(), SpawnError>
     where
         Fut: Future<Output = ()> + Send + 'static,
     {
@@ -61,7 +62,7 @@ pub trait SpawnExt: Spawn {
     /// use futures::future;
     /// use futures::task::SpawnExt;
     ///
-    /// let mut executor = ThreadPool::new().unwrap();
+    /// let executor = ThreadPool::new().unwrap();
     ///
     /// let future = future::ready(1);
     /// let join_handle_fut = executor.spawn_with_handle(future).unwrap();
@@ -69,10 +70,7 @@ pub trait SpawnExt: Spawn {
     /// ```
     #[cfg(feature = "channel")]
     #[cfg(feature = "std")]
-    fn spawn_with_handle<Fut>(
-        &mut self,
-        future: Fut
-    ) -> Result<RemoteHandle<Fut::Output>, SpawnError>
+    fn spawn_with_handle<Fut>(&self, future: Fut) -> Result<RemoteHandle<Fut::Output>, SpawnError>
     where
         Fut: Future + Send + 'static,
         Fut::Output: Send,
@@ -86,7 +84,8 @@ pub trait SpawnExt: Spawn {
     /// Requires the `compat` feature to enable.
     #[cfg(feature = "compat")]
     fn compat(self) -> Compat<Self>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         Compat::new(self)
     }
@@ -114,13 +113,13 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// use futures::task::LocalSpawnExt;
     ///
     /// let executor = LocalPool::new();
-    /// let mut spawner = executor.spawner();
+    /// let spawner = executor.spawner();
     ///
     /// let future = async { /* ... */ };
     /// spawner.spawn_local(future).unwrap();
     /// ```
     #[cfg(feature = "alloc")]
-    fn spawn_local<Fut>(&mut self, future: Fut) -> Result<(), SpawnError>
+    fn spawn_local<Fut>(&self, future: Fut) -> Result<(), SpawnError>
     where
         Fut: Future<Output = ()> + 'static,
     {
@@ -139,7 +138,7 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// use futures::task::LocalSpawnExt;
     ///
     /// let mut executor = LocalPool::new();
-    /// let mut spawner = executor.spawner();
+    /// let spawner = executor.spawner();
     ///
     /// let future = async { 1 };
     /// let join_handle_fut = spawner.spawn_local_with_handle(future).unwrap();
@@ -148,8 +147,8 @@ pub trait LocalSpawnExt: LocalSpawn {
     #[cfg(feature = "channel")]
     #[cfg(feature = "std")]
     fn spawn_local_with_handle<Fut>(
-        &mut self,
-        future: Fut
+        &self,
+        future: Fut,
     ) -> Result<RemoteHandle<Fut::Output>, SpawnError>
     where
         Fut: Future + 'static,

--- a/futures/tests/eventual.rs
+++ b/futures/tests/eventual.rs
@@ -6,7 +6,7 @@ use std::sync::mpsc;
 use std::thread;
 
 fn run<F: Future + Send + 'static>(future: F) {
-    let mut tp = ThreadPool::new().unwrap();
+    let tp = ThreadPool::new().unwrap();
     tp.spawn(future.map(drop)).unwrap();
 }
 

--- a/futures/tests/mutex.rs
+++ b/futures/tests/mutex.rs
@@ -5,7 +5,7 @@ use futures::lock::Mutex;
 use futures::stream::StreamExt;
 use futures::task::{Context, SpawnExt};
 use futures_test::future::FutureTestExt;
-use futures_test::task::{panic_context, new_count_waker};
+use futures_test::task::{new_count_waker, panic_context};
 use std::sync::Arc;
 
 #[test]
@@ -37,7 +37,7 @@ fn mutex_wakes_waiters() {
 #[test]
 fn mutex_contested() {
     let (tx, mut rx) = mpsc::unbounded();
-    let mut pool = futures::executor::ThreadPool::builder()
+    let pool = futures::executor::ThreadPool::builder()
         .pool_size(16)
         .create()
         .unwrap();
@@ -55,7 +55,8 @@ fn mutex_contested() {
             *lock += 1;
             tx.unbounded_send(()).unwrap();
             drop(lock);
-        }).unwrap();
+        })
+        .unwrap();
     }
 
     block_on(async {


### PR DESCRIPTION
Seems like an oversight in https://github.com/rust-lang-nursery/futures-rs/pull/1950

Technically a

BREAKING CHANGE