### PR TITLE
Enable all stable features on the playground

### DIFF
--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -56,3 +56,6 @@ read-initializer = ["futures-io/read-initializer", "futures-util/read-initialize
 
 [package.metadata.docs.rs]
 all-features = true
+
+[package.metadata.playground]
+features = ["std", "async-await", "compat", "io-compat", "executor", "thread-pool"]


### PR DESCRIPTION
Prompted by [this u.rl.o thread](https://users.rust-lang.org/t/error-unresolved-import-futures-threadpool/34469), based on docs [in the playground source](https://github.com/integer32llc/rust-playground/blob/f68374b402b5dedbcea417086af29deb315e3031/top-crates/src/main.rs#L183-L192).