### PR TITLE
Remove unnecessary mutable references in select!() macro

### DIFF
--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -175,8 +175,8 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                     // We check for this condition here in order to be able to
                     // safely use Pin::new_unchecked(&mut #path) later on.
                     future_let_bindings.push(quote! {
-                        #futures_crate::async_await::assert_fused_future(&mut #path);
-                        #futures_crate::async_await::assert_unpin(&mut #path);
+                        #futures_crate::async_await::assert_fused_future(&#path);
+                        #futures_crate::async_await::assert_unpin(&#path);
                     });
                     path
                 },


### PR DESCRIPTION
Hi there :wave: ,
while using this library in a toy project I noticed that Clippy issues warnings that the assert functions inside the `select!()` macro don't need mutable references. For [this simple example](https://gist.github.com/zacharra/f585eeb31fbbc8d352187a71a0bb59ac) (taken from the futures-rs docs) you get:
```
warning: The function/method `::futures::async_await::assert_fused_future` doesn't need a mutable reference
 --> src/main.rs:15:13
  |
4 | | fn main() {
  | |____________________________________________________^
...
15|           _ = b => 0,
  |  _____________^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_mut_passed

warning: The function/method `::futures::async_await::assert_unpin` doesn't need a mutable reference
 --> src/main.rs:15:13
  |
4 | | fn main() {
  | |____________________________________________________^
...
15|           _ = b => 0,
  |  _____________^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_mut_passed
```
This warning occurs every time you pass futures from outside the macro, as opposed to yielding them from inside, as the particular code branch seems to be triggered then.
Note that the tests will also issue the same warnings when running `cargo clippy --tests` in the `/futures` directory. As such, the CI didn't catch that as it is not running Clippy on the test files.  

The change to immutable references in this PR looks safe to me and the tests look fine, I hope I'm not breaking anything here :see_no_evil: .