### PR TITLE
stream::unfold: Better panic message

### DIFF
--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -108,7 +108,8 @@ impl<T, F, Fut, Item> Stream for Unfold<T, F, Fut>
             self.as_mut().fut().set(Some(fut));
         }
 
-        let step = ready!(self.as_mut().fut().as_pin_mut().unwrap().poll(cx));
+        let step = ready!(self.as_mut().fut().as_pin_mut()
+            .expect("Unfold must not be polled after it returned `Poll::Ready(None)`").poll(cx));
         self.as_mut().fut().set(None);
 
         if let Some((item, next_state)) = step {


### PR DESCRIPTION
The other day, when writing a moderately large pipeline with unfold, I started getting random panics (unwrap() on None).

After debugging for a while, it was clear that `unfold` consistently panics on `poll_next()` 
after `Poll::Ready(None)`.

Having a descriptive error message would be a lot more helpful, especially to beginner users.